### PR TITLE
 Identity null Checks

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/generator/ConstraintLanguageGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/generator/ConstraintLanguageGenerator.xtend
@@ -124,7 +124,7 @@ class ConstraintLanguageGenerator {
 //		val target = constraint.target.context
 //		val feature = constraint.target.feature
 //
-//		'''«eRefGet(importHelper, getJavaExpressionThatReturns(localContext, target, mapping), feature)» != null'''
+//		'''«eRefGet(importHelper, getJavaExpressionThatReturns(localContext, target, mapping), feature)» !== null'''
 //	}
 
 	def dispatch checkSignatureConstraint(ImportHelper importHelper, Map<List<?>, String> localContext,
@@ -241,7 +241,7 @@ class ConstraintLanguageGenerator {
 
 		for (nextMapping : source.requires) {
 			val path = nextMapping.mapping.findMappingPath(target)
-			if (path != null)
+			if (path !== null)
 				return #[#[source], path].flatten.toList
 		}
 
@@ -293,8 +293,8 @@ class ConstraintLanguageGenerator {
 		val sourceMapping = constraint.getContainerOfType(Mapping).requireNonNull
 		val targetJava = getJavaExpressionThatReturns(localContext, target, sourceMapping)
 
-		val createContainmentExpression = if (constraint.source == null) {
-				constraint.relativeResource.claim[it != null]
+		val createContainmentExpression = if (constraint.source === null) {
+				constraint.relativeResource.claim[it !== null]
 
 				val sourceJava = constraint.relativeResourceSource?.apply [
 					getJavaExpressionThatReturns(localContext, it, sourceMapping)
@@ -303,12 +303,12 @@ class ConstraintLanguageGenerator {
 
 				'''
 					final «typeRef(VURI)» resourceVURI = «typeRef(MIRMappingHelper)».resolveIfRelative(«sourceJava», "«constraint.relativeResource»");
-					if ((resourceVURI != null) && (!«typeRef(EMFBridge)».doesResourceExist(resourceVURI.getEMFUri()))) {
+					if ((resourceVURI !== null) && (!«typeRef(EMFBridge)».doesResourceExist(resourceVURI.getEMFUri()))) {
 						state.getTransformationResult().addRootEObjectToSave(«targetJava», resourceVURI);
 					}
 				'''
 			} else {
-				constraint.relativeResource.claim[it == null]
+				constraint.relativeResource.claim[it === null]
 
 				val manipulatedVariable = constraint.source.context
 				val manipulatedVariableAsJavaExpression = getJavaExpressionThatReturns(localContext, manipulatedVariable, sourceMapping)

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/generator/CopyOfMappingLanguageGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/generator/CopyOfMappingLanguageGenerator.xtend
@@ -63,7 +63,7 @@
 //	
 //	def Collection<Reaction> doGenerate(MappingFile mappingFile, IFileSystemAccess fsa) {
 //		
-////		if (mappingFile.pluginName != null) {
+////		if (mappingFile.pluginName !== null) {
 ////			val contributorNames = mappingFile.imports.map[
 ////				EclipseBridge.getNameOfContributorOfExtension(
 ////					"org.eclipse.emf.ecore.generated_package",
@@ -406,7 +406,7 @@
 //					public static void propagateAttributesFrom«imp.toFirstUpperName»(
 //						«typeRef(mapping.correspondenceWrapperClassName)» «mapping.name.toFirstLower»,
 //						«typeRef(MappingExecutionState)» state) {
-//						«IF mapping.constraintsBody != null»
+//						«IF mapping.constraintsBody !== null»
 //							«FOR constraint : mapping.constraintsBody.expressions»
 //								«FOR updateTuidJava : clg.getEObjectsWithPossiblyChangedTuid(ih, #{#['this']->mapping.name.toFirstLower}, constraint, imp.package)»
 //								state.record(«updateTuidJava»);

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/generator/MappingLanguageGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/generator/MappingLanguageGenerator.xtend
@@ -197,7 +197,7 @@ class MappingLanguageGenerator implements IMappingLanguageGenerator {
 						public static void propagateAttributesFrom«imp.toFirstUpperName»(
 							«typeRef(mapping.correspondenceWrapperClassName)» «mapping.name.toFirstLower»,
 							«typeRef(MappingExecutionState)» state) {
-							«IF mapping.constraintsBody != null»
+							«IF mapping.constraintsBody !== null»
 								«FOR constraint : mapping.constraintsBody.expressions»
 									«FOR updateTuidJava : clg.getEObjectsWithPossiblyChangedTuid(ih, #{#['this']->mapping.name.toFirstLower}, constraint, imp.package)»
 									state.record(«updateTuidJava»);
@@ -350,7 +350,7 @@ class MappingLanguageGenerator implements IMappingLanguageGenerator {
 						public static void propagateAttributesFrom«imp.toFirstUpperName»(
 							«typeRef(mapping.correspondenceWrapperClassName)» «mapping.name.toFirstLower»,
 							«typeRef(MappingExecutionState)» state) {
-							«IF mapping.constraintsBody != null»
+							«IF mapping.constraintsBody !== null»
 								«FOR constraint : mapping.constraintsBody.expressions»
 									«FOR updateTuidJava : clg.getEObjectsWithPossiblyChangedTuid(ih, #{#['this']->mapping.name.toFirstLower}, constraint, imp.package)»
 									state.record(«updateTuidJava»);

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/generator/MappingLanguageGeneratorNameProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/generator/MappingLanguageGeneratorNameProvider.xtend
@@ -33,7 +33,7 @@ class MappingLanguageGeneratorNameProvider {
 	}
 
 	public def getMappingName(Mapping mapping) {
-		if ((mapping.name == null) || (mapping.name.empty)) {
+		if ((mapping.name === null) || (mapping.name.empty)) {
 			mapping.name = mapping.nextAnonymousMappingName.toString
 		}
 

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/helpers/EMFHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/helpers/EMFHelper.xtend
@@ -22,7 +22,7 @@ class EMFHelper {
 			iterator = iterator.eContainer
 		}
 		
-		while (iterator != null) {
+		while (iterator !== null) {
 			result.add(iterator)
 			iterator = iterator.eContainer
 		}
@@ -32,7 +32,7 @@ class EMFHelper {
 	static def <T> T getContainerOfType(EObject obj, Class<T> containerType) {
 		var EObject iterator = obj;
 		
-		while (iterator != null) {
+		while (iterator !== null) {
 			if (containerType.isInstance(iterator))
 				return containerType.cast(iterator)
 			iterator = iterator.eContainer

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/helpers/JavaGeneratorHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/helpers/JavaGeneratorHelper.xtend
@@ -33,7 +33,7 @@ class JavaGeneratorHelper {
 		val content = generatorFunction.apply(importHelper)
 
 		'''
-			«IF packageName != null»
+			«IF packageName !== null»
 				package «packageName»;
 			«ENDIF»
 			

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/helpers/MappingLanguageHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/helpers/MappingLanguageHelper.xtend
@@ -35,7 +35,7 @@ class MappingLanguageHelper {
 		val constraints = mapping.constraints.map[it?.package]
 
 		constraints.zipAny(signatures).map [
-			claim[first == second || first == null || second == null]
+			claim[first == second || first === null || second === null]
 			first ?: second
 		]
 	}
@@ -49,7 +49,7 @@ class MappingLanguageHelper {
 	}
 
 	public static def getAllSignatureConstraints(Mapping mapping) {
-		mapping?.allConstraintExpressions.filter[getPackage != null]
+		mapping?.allConstraintExpressions.filter[getPackage !== null]
 			.groupBy[getPackage(it)]
 	}
 
@@ -90,7 +90,7 @@ class MappingLanguageHelper {
 	 */
 	public static def dispatch EPackage getPackage(ConstraintExpression expression) {
 		val signatureConstraintBlock = expression.getContainerOfType(SignatureConstraintBlock)
-		if (signatureConstraintBlock == null)
+		if (signatureConstraintBlock === null)
 			return null
 
 		val mapping = signatureConstraintBlock.eContainer as Mapping
@@ -131,14 +131,14 @@ class MappingLanguageHelper {
 	}
 
 	public static def RequiredMapping getLastMapping(RequiredMappingPathBase mappingPath) {
-		if (mappingPath.tail != null)
+		if (mappingPath.tail !== null)
 			return mappingPath.tail.lastMapping
 		else
 			return mappingPath.requiredMapping
 	}
 
 	public static def RequiredMapping getLastMapping(RequiredMappingPathTail mappingPath) {
-		if (mappingPath.tail != null)
+		if (mappingPath.tail !== null)
 			return mappingPath.tail.lastMapping
 		else
 			return mappingPath.requiredMapping
@@ -158,18 +158,18 @@ class MappingLanguageHelper {
 		val containment = eObject.eContainmentFeature
 		val container = eObject.eContainer
 
-		if (container == null || !containment.many)
+		if (container === null || !containment.many)
 			return baseName
 
 		val siblingsWithSameName = container.eGet(containment)?.requireCollectionType(EObject)?.filterNull.filter [
 			baseName.equals(it.baseName?.toFirstLower)
 		]
-		if ((siblingsWithSameName == null) || (siblingsWithSameName.size == 1))
+		if ((siblingsWithSameName === null) || (siblingsWithSameName.size == 1))
 			return baseName
 
 		val index = siblingsWithSameName.indexOf(eObject)
 
-		if (index == null)
+		if (index === null)
 			throw new IllegalArgumentException
 
 		return '''«baseName»_«index.toString»'''

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/jvmmodel/MappingLanguageJvmModelInferrer.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/jvmmodel/MappingLanguageJvmModelInferrer.xtend
@@ -75,7 +75,7 @@ class MappingLanguageJvmModelInferrer extends AbstractModelInferrer {
 					members += signatureConstraints.map [ signatureConstraint |
 						val imp = signatureConstraint.getPackage?.getImportsForPackage
 
-						if (imp == null)
+						if (imp === null)
 							return #[]
 
 						#[

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/linking/MappingLanguageLinkingService.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/linking/MappingLanguageLinkingService.xtend
@@ -38,11 +38,11 @@ class MappingLanguageLinkingService extends DefaultLinkingService {
 	 */
 	def List<EObject> getEPackage(ILeafNode text) {
 		val nsUri = getMetamodelNsURI(text);
-		if (nsUri == null)
+		if (nsUri === null)
 			return Collections.emptyList();
 			
 		val resolvedEPackage = EPackage.Registry.INSTANCE.getEPackage(nsUri) as EObject
-		if (resolvedEPackage == null)	
+		if (resolvedEPackage === null)	
 			return Collections.emptyList();
 			
 		return #[resolvedEPackage]

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/postprocessor/MappingLanguageDerivedStateComputer.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/postprocessor/MappingLanguageDerivedStateComputer.xtend
@@ -33,13 +33,13 @@ class MappingLanguageDerivedStateComputer extends JvmModelAssociator {
 					newReq
 				]
 
-		mappingFile.eAllContents.filter(Mapping).filter[parentMapping != null].forEach [
+		mappingFile.eAllContents.filter(Mapping).filter[parentMapping !== null].forEach [
 			val parentName = if ((parentMapping.name ?: "").empty)
 					"parent"
 				else
 					parentMapping.toSensibleDefaultName
 			
-//			if ((it.requires ?: #[]).exists[req|req.mapping == null]) {
+//			if ((it.requires ?: #[]).exists[req|req.mapping === null]) {
 //				throw new IllegalStateException
 //			}
 			
@@ -56,11 +56,11 @@ class MappingLanguageDerivedStateComputer extends JvmModelAssociator {
 			
 		]
 
-		mappingFile.eAllContents.filter(NamedMetaclassReference).filter[name == null || name.isEmpty].forEach [
+		mappingFile.eAllContents.filter(NamedMetaclassReference).filter[name === null || name.isEmpty].forEach [
 			it.name = MappingLanguageHelper.toSensibleDefaultName(it)
 		]
 
-		mappingFile.eAllContents.filter(RequiredMapping).filter[name == null || name.isEmpty].forEach [
+		mappingFile.eAllContents.filter(RequiredMapping).filter[name === null || name.isEmpty].forEach [
 			it.name = MappingLanguageHelper.toSensibleDefaultName(it)
 		]
 		

--- a/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/scoping/MappingLanguageScopeProviderDelegate.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mapping/src/tools/vitruv/dsls/mapping/scoping/MappingLanguageScopeProviderDelegate.xtend
@@ -39,7 +39,7 @@ class MappingLanguageScopeProviderDelegate extends MirBaseScopeProviderDelegate 
 
 	def <T extends EObject> IScope createPairScope(IScope parentScope, Iterator<Pair<String, T>> elements) {
 		createScope(parentScope, elements, [
-			if ((it.first != null) && (it.second != null))
+			if ((it.first !== null) && (it.second !== null))
 				EObjectDescription.create(it.first, it.second)
 			else
 				null
@@ -49,7 +49,7 @@ class MappingLanguageScopeProviderDelegate extends MirBaseScopeProviderDelegate 
 	def <T extends EObject> IScope createScope(IScope parentScope, Iterator<T> elements) {
 		createScope(parentScope, elements.filter[hasQualifiedName], [
 			val qn = qualifiedNameProvider.getFullyQualifiedName(it)
-			if ((qn != null) && (!qn.isEmpty))
+			if ((qn !== null) && (!qn.isEmpty))
 				EObjectDescription.create(qn, it)
 			else
 				null
@@ -77,7 +77,7 @@ class MappingLanguageScopeProviderDelegate extends MirBaseScopeProviderDelegate 
 	def IScope createRequiredMappingMappingScope(EObject context) {
 		val allMappings = context.getContainerOfType(MappingFile).eAllContents.filter(Mapping)
 		
-		createPairScope(IScope.NULLSCOPE, allMappings.map[namePair].filter[first != null && second != null])
+		createPairScope(IScope.NULLSCOPE, allMappings.map[namePair].filter[first !== null && second !== null])
 	}
 	
 	def IScope createMappingBaseScope(IScope parentScope, Mapping mapping) {
@@ -124,12 +124,12 @@ class MappingLanguageScopeProviderDelegate extends MirBaseScopeProviderDelegate 
 		val containerMapping = context.getContainerOfType(Mapping)
 		val mappingFile = context.getContainerOfType(MappingFile)
 		return createPairScope(IScope.NULLSCOPE,
-			(containerMapping.requires + mappingFile.defaultRequirements).map[namePair].filter[first != null && second != null].iterator)
+			(containerMapping.requires + mappingFile.defaultRequirements).map[namePair].filter[first !== null && second !== null].iterator)
 	}
 	
 	def createRequiredMappingPathTailScope(EObject context) {
 		if (context instanceof RequiredMappingPathTail) {
-			return createPairScope(IScope.NULLSCOPE, (context.eContainer.requiredMappings).map[namePair].filter[first != null && second != null].iterator)
+			return createPairScope(IScope.NULLSCOPE, (context.eContainer.requiredMappings).map[namePair].filter[first !== null && second !== null].iterator)
 		} else {
 			LOGGER.debug("Unexpected context for tail scope: " + context.toString)
 			return IScope.NULLSCOPE
@@ -154,7 +154,7 @@ class MappingLanguageScopeProviderDelegate extends MirBaseScopeProviderDelegate 
 		val containingMapping = object.getContainerOfType(Mapping).requireNonNull
 
 		var Mapping contextMapping
-		if (context?.requiredMappingPath == null) {
+		if (context?.requiredMappingPath === null) {
 //			LOGGER.debug("ContextVariable has no target mapping: " + context.toString)
 			contextMapping = containingMapping
 		} else {

--- a/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/scoping/MirBaseGlobalScopeProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/scoping/MirBaseGlobalScopeProvider.xtend
@@ -29,7 +29,7 @@ class MirBaseGlobalScopeProvider extends TypesAwareDefaultGlobalScopeProvider {
 	}
 	
 	private def getPackageScope() {
-		if (packageScope == null)
+		if (packageScope === null)
 			packageScope = new SimpleScope(IScope.NULLSCOPE,
 				EPackage.Registry.INSTANCE.keySet.map [
 					from |

--- a/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/scoping/MirBaseScopeProviderDelegate.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/scoping/MirBaseScopeProviderDelegate.xtend
@@ -55,11 +55,11 @@ class MirBaseScopeProviderDelegate extends XImportSectionNamespaceScopeProvider 
 	
 	def hasQualifiedName(EObject eObject) {
 		val qn = qualifiedNameProvider.getFullyQualifiedName(eObject);
-		return ((qn != null) && (!qn.empty));
+		return ((qn !== null) && (!qn.empty));
 	}
 	
 	def createEStructuralFeatureScope(Iterator<? extends EStructuralFeature> featuresIterator) {
-		if (featuresIterator != null) {
+		if (featuresIterator !== null) {
 			createScope(IScope.NULLSCOPE, featuresIterator, [
 				EObjectDescription.create(it.name, it)
 			])
@@ -98,7 +98,7 @@ class MirBaseScopeProviderDelegate extends XImportSectionNamespaceScopeProvider 
 	 */
 	def getMetamodelImports(Resource res) {
 		var contents = res.getAllContentsOfEClass(MirBasePackage.eINSTANCE.getMetamodelImport, true).toList
-		val validImports = contents.filter(MetamodelImport).filter[package != null].map[it.name = it.name ?: it.package.name; it]
+		val validImports = contents.filter(MetamodelImport).filter[package !== null].map[it.name = it.name ?: it.package.name; it]
 
 		return validImports
 	}
@@ -134,7 +134,7 @@ class MirBaseScopeProviderDelegate extends XImportSectionNamespaceScopeProvider 
 	 */
 	private def createQualifiedEClassScope(MetamodelImport metamodelImport, boolean includeAbstract, boolean includeEObject) {
 		val classifierDescriptions = 
-			if (metamodelImport == null || metamodelImport.package == null) {
+			if (metamodelImport === null || metamodelImport.package === null) {
 				if (includeEObject) {
 					#[createEObjectDescription(EcorePackage.Literals.EOBJECT, false)];
 				} else {

--- a/bundles/dsls/tools.vitruv.dsls.reactions.ui/src/tools/vitruv/dsls/reactions/ui/outline/ReactionsLanguageOutlineTreeProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions.ui/src/tools/vitruv/dsls/reactions/ui/outline/ReactionsLanguageOutlineTreeProvider.xtend
@@ -62,7 +62,7 @@ class ReactionsLanguageOutlineTreeProvider extends DefaultOutlineTreeProvider {
 	
 	protected def void _createChildren(EStructuralFeatureNode parentNode, Reaction reaction) {
 		val reactionNode = createEObjectNode(parentNode, reaction);
-		if (reaction.documentation != null) {
+		if (reaction.documentation !== null) {
 			createEStructuralFeatureNode(reactionNode, reaction,
 				ReactionsLanguagePackage.Literals.REACTION__DOCUMENTATION,
 				imageDispatcher.invoke(reaction.documentation),
@@ -70,11 +70,11 @@ class ReactionsLanguageOutlineTreeProvider extends DefaultOutlineTreeProvider {
 		}
 		val triggerNode = createEStructuralFeatureNode(reactionNode, reaction, 
 			ReactionsLanguagePackage.Literals.REACTION__TRIGGER,
-			imageDispatcher.invoke(reaction.trigger), "trigger", reaction.trigger == null);
-		if (reaction.trigger != null) {
+			imageDispatcher.invoke(reaction.trigger), "trigger", reaction.trigger === null);
+		if (reaction.trigger !== null) {
 			createChildren(triggerNode, reaction.trigger);
 		}
-		if (reaction.trigger?.precondition != null) {
+		if (reaction.trigger?.precondition !== null) {
 			createChildren(triggerNode, reaction.trigger.precondition)
 		}
 	}
@@ -92,21 +92,21 @@ class ReactionsLanguageOutlineTreeProvider extends DefaultOutlineTreeProvider {
 //		val changeType = event.changeType;
 //		switch (changeType) {
 //			ElementFeatureChangeType:
-//				if (changeType.feature != null) {
+//				if (changeType.feature !== null) {
 //					createEObjectNode(parentNode, changeType.feature.metaclass);
-//					if (changeType.feature.feature != null) {
+//					if (changeType.feature.feature !== null) {
 //						createEObjectNode(parentNode, changeType.feature.feature);
 //					}
 //				}
 //			ElementRootChangeType:
-//				if (event.elementType != null) {
+//				if (event.elementType !== null) {
 //					createEObjectNode(parentNode, event.elementType.metaclass);
 //				}
 //		}
 //	}
 	
 	protected def void _createChildren(EStructuralFeatureNode parentNode, Routine routine) {
-		if (routine.matcher != null) {
+		if (routine.matcher !== null) {
 			for (element : routine.matcher.matcherStatements) {
 				createEObjectNode(parentNode, element);	
 			}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/AtomicChangeTypeRepresentation.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/AtomicChangeTypeRepresentation.xtend
@@ -46,11 +46,11 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 	}
 
 	public def boolean hasAffectedElement() {
-		return affectedElementClass != null;
+		return affectedElementClass !== null;
 	}
 	
 	public def boolean hasAffectedFeature() {
-		return affectedFeature != null;
+		return affectedFeature !== null;
 	}
 	
 	public def boolean hasOldValue() {
@@ -75,10 +75,10 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 
 	public def Iterable<AccessibleElement> generatePropertiesParameterList() {
 		val result = <AccessibleElement>newArrayList();
-		if (affectedElementClass != null) {
+		if (affectedElementClass !== null) {
 			result.add(new AccessibleElement(affectedElementAttribute, affectedElementClass));
 		}
-		if (affectedFeature != null) {
+		if (affectedFeature !== null) {
 			result.add(new AccessibleElement(affectedFeatureAttribute, affectedFeature.eClass.instanceClass));
 		}
 		if (hasOldValue) {
@@ -95,10 +95,10 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 
 	public def StringConcatenationClient generatePropertiesAssignmentCode(String typedChangeVariableName) {
 		'''
-			«IF affectedElementClass != null»
+			«IF affectedElementClass !== null»
 				«affectedElementClass» «affectedElementAttribute» = «typedChangeVariableName».get«affectedElementAttribute.toFirstUpper»();
 			«ENDIF»
-			«IF affectedFeature != null»
+			«IF affectedFeature !== null»
 				«affectedFeature.eClass.instanceClass» «affectedFeatureAttribute» = «typedChangeVariableName».get«affectedFeatureAttribute.toFirstUpper»();
 			«ENDIF»
 			«IF hasOldValue»

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentationExtractor.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentationExtractor.xtend
@@ -60,7 +60,7 @@ final class ChangeTypeRepresentationExtractor {
 	}
 			
 	public static def dispatch ChangeTypeRepresentation extractChangeTypeRepresentation(ModelElementChange modelElementChange) {
-		if (modelElementChange?.changeType == null) {
+		if (modelElementChange?.changeType === null) {
 			return new AtomicChangeTypeRepresentation(EChange, null, null, false, false, null);
 		}
 		return generateChangeTypeRepresentation(modelElementChange.changeType, modelElementChange.elementType?.metaclass)
@@ -78,7 +78,7 @@ final class ChangeTypeRepresentationExtractor {
 				clazz = RootPackage.Literals.REMOVE_ROOT_EOBJECT
 		} 
 		val affectedEObject = null;
-		val affectedValue = if (elementClass != null) elementClass.instanceClass else EObject;
+		val affectedValue = if (elementClass !== null) elementClass.instanceClass else EObject;
 		return new AtomicChangeTypeRepresentation(clazz.instanceClass, affectedEObject, affectedValue, !hasNewValue, hasNewValue, null);
 	}
 	
@@ -102,7 +102,7 @@ final class ChangeTypeRepresentationExtractor {
 			}
 		}
 		val affectedEObject = modelElementChange.feature.metaclass.instanceClass;
-		val affectedValue = if (elementClass != null) elementClass.instanceClass else modelElementChange.feature.feature.EType.instanceClass;
+		val affectedValue = if (elementClass !== null) elementClass.instanceClass else modelElementChange.feature.feature.EType.instanceClass;
 		val affectedFeature = modelElementChange.feature.feature; 
 		return new AtomicChangeTypeRepresentation(clazz.instanceClass, affectedEObject, affectedValue, hasOldValue, hasNewValue, affectedFeature);
 	}
@@ -116,7 +116,7 @@ final class ChangeTypeRepresentationExtractor {
 			ElementDeletionChangeType:
 				clazz = EobjectPackage.Literals.DELETE_EOBJECT
 		}
-		val affectedEObject = if (elementClass != null) elementClass.instanceClass else EObject;
+		val affectedEObject = if (elementClass !== null) elementClass.instanceClass else EObject;
 		val affectedValue = null; 
 		return new AtomicChangeTypeRepresentation(clazz.instanceClass, affectedEObject, affectedValue, false, false, null);
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
@@ -32,11 +32,11 @@ class ReactionClassGenerator extends ClassGenerator {
 	
 	new(Reaction reaction, TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
 		super(typesBuilderExtensionProvider);
-		if (reaction?.trigger == null || reaction?.callRoutine == null) {
+		if (reaction?.trigger === null || reaction?.callRoutine === null) {
 			throw new IllegalArgumentException();
 		}
 		this.reaction = reaction;
-		this.hasPreconditionBlock = reaction.trigger.precondition != null;
+		this.hasPreconditionBlock = reaction.trigger.precondition !== null;
 		this.changeTypeRepresentation = reaction.trigger.extractChangeTypeRepresentation;
 		this.relevantAtomicChangeTypeRepresentation = changeTypeRepresentation.relevantAtomicChangeTypeRepresentation;
 		this.reactionClassNameGenerator = reaction.reactionClassNameGenerator;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionElementsCompletionChecker.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionElementsCompletionChecker.xtend
@@ -5,11 +5,11 @@ import org.eclipse.emf.ecore.EClass
 
 class ReactionElementsCompletionChecker {
 	public def boolean isComplete(RetrieveModelElement retrieveElement) {
-		return retrieveElement?.correspondenceSource?.code != null && retrieveElement.metaclass.complete;
+		return retrieveElement?.correspondenceSource?.code !== null && retrieveElement.metaclass.complete;
 	}
 	
 	public def boolean isComplete(EClass eClass) {
-		return eClass?.instanceClass != null;
+		return eClass?.instanceClass !== null;
 	}
 	
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
@@ -82,7 +82,7 @@ class RoutineClassGenerator extends ClassGenerator {
 		«FOR parameterName : parameterStrings SEPARATOR ', '»«parameterName»«ENDFOR»'''
 		
 	public override JvmGenericType generateClass() {
-		if (routine == null) {
+		if (routine === null) {
 			return null;
 		}
 		
@@ -129,12 +129,12 @@ class RoutineClassGenerator extends ClassGenerator {
 	
 	private def dispatch StringConcatenationClient createStatements(CreateModelElement createElement) {
 		this.currentlyAccessibleElements += new AccessibleElement(createElement.name, createElement.javaClass)
-		val initializeMethod = if (createElement.initializationBlock != null) 
+		val initializeMethod = if (createElement.initializationBlock !== null) 
 			generateUpdateElementMethod(createElement.name, createElement.initializationBlock, currentlyAccessibleElements);
-		val initializeMethodCall = if (initializeMethod != null) initializeMethod.userExecutionMethodCallString;
+		val initializeMethodCall = if (initializeMethod !== null) initializeMethod.userExecutionMethodCallString;
 		return '''
 			«getElementCreationCode(createElement)»
-			«IF initializeMethod != null»
+			«IF initializeMethod !== null»
 				«initializeMethodCall»;
 			«ENDIF»
 		'''
@@ -147,17 +147,17 @@ class RoutineClassGenerator extends ClassGenerator {
 			«IF !retrieveElement.name.nullOrEmpty»
 				«affectedElementClass.javaClass» «retrieveElement.name» = «retrieveStatement»;
 				«IF !retrieveElement.optional && !retrieveElement.abscence»
-					if («retrieveElement.name» == null) {
+					if («retrieveElement.name» === null) {
 						return;
 					}
 				«ENDIF»
 				registerObjectUnderModification(«retrieveElement.name»);
 			«ELSEIF retrieveElement.abscence»
-				if («retrieveStatement» != null) {
+				if («retrieveStatement» !== null) {
 					return;
 				}
 			«ELSE»
-				if («retrieveStatement» == null) {
+				if («retrieveStatement» === null) {
 					return;
 				} else {
 					registerObjectUnderModification(«retrieveStatement»);
@@ -203,8 +203,8 @@ class RoutineClassGenerator extends ClassGenerator {
 		val getFirstElementMethodCall = getFirstElementMethod.userExecutionMethodCallString;
 		val getSecondElementMethod = generateMethodGetElement(createCorrespondence.secondElement, currentlyAccessibleElements);
 		val getSecondElementMethodCall = getSecondElementMethod.userExecutionMethodCallString;
-		val tagMethod = if (createCorrespondence.tag != null) generateMethodGetCreateTag(createCorrespondence, currentlyAccessibleElements);
-		val tagMethodCall = if (tagMethod != null) tagMethod.userExecutionMethodCallString else '''""''';
+		val tagMethod = if (createCorrespondence.tag !== null) generateMethodGetCreateTag(createCorrespondence, currentlyAccessibleElements);
+		val tagMethodCall = if (tagMethod !== null) tagMethod.userExecutionMethodCallString else '''""''';
 		return '''
 			addCorrespondenceBetween(«getFirstElementMethodCall», «getSecondElementMethodCall», «tagMethodCall»);
 		'''
@@ -231,7 +231,7 @@ class RoutineClassGenerator extends ClassGenerator {
 	protected def generateMethodExecuteEffect() {
 		val methodName = "executeRoutine";
 		val inputParameters = routine.generateInputParameters();
-		val matcherStatements = if (routine.matcher != null) routine.matcher.matcherStatements else #[];
+		val matcherStatements = if (routine.matcher !== null) routine.matcher.matcherStatements else #[];
 		val effectStatements = routine.action.actionStatements;
 		val matcherStatementsMap = <MatcherStatement, StringConcatenationClient>newHashMap();
 		CollectionBridge.mapFixed(matcherStatements, [matcherStatementsMap.put(it, createStatements(it))]);
@@ -259,7 +259,7 @@ class RoutineClassGenerator extends ClassGenerator {
 	}
 		
 	private def StringConcatenationClient getTagString(RetrieveModelElement retrieveElement) {
-		if (retrieveElement.tag != null) {
+		if (retrieveElement.tag !== null) {
 			val tagMethod = generateMethodGetRetrieveTag(retrieveElement, currentlyAccessibleElements);
 			return '''«tagMethod.userExecutionMethodCallString»'''
 		} else {
@@ -269,7 +269,7 @@ class RoutineClassGenerator extends ClassGenerator {
 	
 	private def StringConcatenationClient getPreconditionChecker(RetrieveModelElement retrieveElement) {
 		val affectedElementClass = retrieveElement.javaClass;
-		if (retrieveElement.precondition == null) {
+		if (retrieveElement.precondition === null) {
 			return '''(«affectedElementClass» _element) -> true''';
 		}
 		val preconditionMethod = generateMethodCorrespondencePrecondition(retrieveElement, currentlyAccessibleElements);

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
@@ -136,7 +136,7 @@ class UserExecutionClassGenerator extends ClassGenerator {
 	}
 	
 	protected def JvmOperation generateMethodCallRoutine(RoutineCallBlock routineCall, Iterable<AccessibleElement> accessibleElements, JvmTypeReference facadeClassTypeReference) {
-		if (routineCall.code == null) {
+		if (routineCall.code === null) {
 			return null;
 		}
 		val methodName = "callRoutine" + counterCallRoutineMethods++;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageHelper.xtend
@@ -46,7 +46,7 @@ final class ReactionsLanguageHelper {
 	
 	public static def VitruvDomainProvider<?> getDomainProviderForReference(DomainReference domainReference) {
 		val referencedDomainProvider = VitruvDomainProvider.getDomainProviderFromExtensionPoint(domainReference.domain)
-	    if (referencedDomainProvider == null) {
+	    if (referencedDomainProvider === null) {
 	    	throw new IllegalStateException("Given domain reference references no existing domain");
 	    }
 	    return referencedDomainProvider;
@@ -55,7 +55,7 @@ final class ReactionsLanguageHelper {
 	static def Pair<VitruvDomain, VitruvDomain> getSourceTargetPair(ReactionsSegment reactionsSegment) {
 		val sourceDomain = reactionsSegment.fromDomain.domainForReference;
 		val targetDomain = reactionsSegment.toDomain.domainForReference;
-		if (sourceDomain != null && targetDomain != null) {
+		if (sourceDomain !== null && targetDomain !== null) {
 			return new Pair<VitruvDomain, VitruvDomain>(sourceDomain, targetDomain);
 		} else {
 			return null;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/JvmTypesBuilderWithoutAssociations.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/JvmTypesBuilderWithoutAssociations.xtend
@@ -39,7 +39,7 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	/* @Nullable */
 	public def JvmOperation generateUnassociatedMethod(/* @Nullable */ String name, /* @Nullable */ JvmTypeReference returnType,
 			/* @Nullable */ Procedure1<? super JvmOperation> initializer) {
-		if(name == null) 
+		if(name === null) 
 			return null;
 		val result = typesFactory.createJvmOperation();
 		result.setSimpleName(name);
@@ -70,7 +70,7 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	/* @Nullable */	
 	public def JvmField generateUnassociatedField(/* @Nullable */ String name, /* @Nullable */ JvmTypeReference typeRef, 
 			/* @Nullable */ Procedure1<? super JvmField> initializer) {
-		if(name == null) 
+		if(name === null) 
 			return null;
 		val result = typesFactory.createJvmField();
 		result.setSimpleName(name);
@@ -90,7 +90,7 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	 */
 	/* @Nullable */
 	public override <T extends EObject> T associate(/* @Nullable */ EObject sourceElement, /* @Nullable */ T target) {
-		if(sourceElement != null && target != null && sourceElement.eResource != null && isValidSource(sourceElement))
+		if(sourceElement !== null && target !== null && sourceElement.eResource !== null && isValidSource(sourceElement))
 			associator.associate(sourceElement, target);
 		return target;
 	}
@@ -104,18 +104,18 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	
 	public def JvmGenericType generateUnassociatedClass(/* @Nullable */ String name, /* @Nullable */ Procedure1<? super JvmGenericType> initializer) {
 		val result = createJvmGenericType(name);
-		if (result == null)
+		if (result === null)
 			return null;
 		return initializeSafely(result, initializer);
 	}
 	
 	protected def JvmGenericType createJvmGenericType(/* @Nullable */ String name) {
-		if (name == null)
+		if (name === null)
 			return null;
 		val fullName = splitQualifiedName(name);
 		val result = typesFactory.createJvmGenericType();
 		result.setSimpleName(fullName.getSecond());
-		if (fullName.getFirst() != null)
+		if (fullName.getFirst() !== null)
 			result.setPackageName(fullName.getFirst());
 		result.setVisibility(JvmVisibility.PUBLIC);
 		return result;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
@@ -37,7 +37,7 @@ class ParameterGenerator {
 	}
 	
 	public def JvmFormalParameter generateModelElementParameter(EObject parameterContext, MetaclassReference metaclassReference, String elementName) {
-		if (metaclassReference?.metaclass != null) {
+		if (metaclassReference?.metaclass !== null) {
 			return parameterContext.generateParameter(elementName, metaclassReference.javaClass);
 		}	
 		return null;
@@ -56,7 +56,7 @@ class ParameterGenerator {
 	}
 	
 	public def generateParameter(EObject context, String parameterName, JvmTypeReference parameterType) {
-		if (parameterType == null) {
+		if (parameterType === null) {
 			return null;
 		}
 		return context.toParameter(parameterName, parameterType);
@@ -68,7 +68,7 @@ class ParameterGenerator {
 	}
 	
 	public def generateParameter(EObject context, String parameterName, Class<?> parameterClass, String... typeParameterClassNames) {
-		if (parameterClass == null) {
+		if (parameterClass === null) {
 			return null;
 		}
 		val typeParameters = new ArrayList<JvmTypeReference>(typeParameterClassNames.size);
@@ -125,7 +125,7 @@ class ParameterGenerator {
 			changeTypeParameters = changeRepresentation.genericTypeParameters	
 		}
 		val changeParameter = parameterContext.generateParameterFromClasses(CHANGE_PARAMETER_NAME, changeRepresentation.changeType, changeTypeParameters);
-		if (changeParameter != null) {
+		if (changeParameter !== null) {
 			return changeParameter;
 		}
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/environment/ReactionsEnvironmentGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/environment/ReactionsEnvironmentGenerator.xtend
@@ -58,10 +58,10 @@ class ReactionsEnvironmentGenerator implements IReactionsEnvironmentGenerator {
 	
 	
 	public override void addReaction(String sourceFileName, Reaction reaction) {
-		if (project == null) {
+		if (project === null) {
 			throw new IllegalStateException("Project must be set");
 		}
-		if (reaction == null) {
+		if (reaction === null) {
 			throw new IllegalArgumentException("Reaction must not be null");
 		}
 		val reactionsSegment = getCorrespondingReactionsSegmentInTempResource(sourceFileName, reaction.reactionsSegment);
@@ -80,7 +80,7 @@ class ReactionsEnvironmentGenerator implements IReactionsEnvironmentGenerator {
 						foundSegment = segment;
 					}	
 				}
-				if (foundSegment == null) {
+				if (foundSegment === null) {
 					foundSegment = addReactionsSegment(reactionsFile, reactionsSegment, sourceFileName);
 				}
 				
@@ -105,14 +105,14 @@ class ReactionsEnvironmentGenerator implements IReactionsEnvironmentGenerator {
 	}
 	
 	public def override addReactions(Resource reactionsResource) {
-		if (reactionsResource == null || !(reactionsResource.contents.get(0) instanceof ReactionsFile)) {
+		if (reactionsResource === null || !(reactionsResource.contents.get(0) instanceof ReactionsFile)) {
 			throw new IllegalArgumentException("The given resource is not a reactions file");
 		}
 		this.resources.add(reactionsResource);
 	}
 	
 	public override void generateEnvironment(IFileSystemAccess2 fsa) {
-		if (project == null) {
+		if (project === null) {
 			throw new IllegalStateException("Project must be set");
 		}
 		prepareGeneration();

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/linking/ReactionsLinkingService.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/linking/ReactionsLinkingService.xtend
@@ -38,11 +38,11 @@ class ReactionsLinkingService extends DefaultLinkingService {
 	 */
 	def List<EObject> getEPackage(ILeafNode text) {
 		val nsUri = getMetamodelNsURI(text);
-		if (nsUri == null)
+		if (nsUri === null)
 			return Collections.emptyList();
 			
 		val resolvedEPackage = EPackage.Registry.INSTANCE.getEPackage(nsUri) as EObject
-		if (resolvedEPackage == null)	
+		if (resolvedEPackage === null)	
 			return Collections.emptyList();
 			
 		return #[resolvedEPackage]

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/scoping/ReactionsLanguageScopeProviderDelegate.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/scoping/ReactionsLanguageScopeProviderDelegate.xtend
@@ -50,7 +50,7 @@ class ReactionsLanguageScopeProviderDelegate extends MirBaseScopeProviderDelegat
 	}
 	
 	def createEStructuralFeatureScope(MetaclassFeatureReference featureReference) {
-		if (featureReference?.metaclass != null) {
+		if (featureReference?.metaclass !== null) {
 			val changeType = featureReference.eContainer;
 			val multiplicityFilterFunction = if (changeType instanceof ElementReplacementChangeType) {
 				[EStructuralFeature feat | !feat.many];
@@ -75,7 +75,7 @@ class ReactionsLanguageScopeProviderDelegate extends MirBaseScopeProviderDelegat
 
 	def createQualifiedEClassScopeWithSpecialInputTypes(MetamodelImport metamodelImport) {
 		val classifierDescriptions = 
-			if (metamodelImport == null || metamodelImport.package == null) {
+			if (metamodelImport === null || metamodelImport.package === null) {
 				#[createEObjectDescription(EcorePackage.Literals.EOBJECT, false),
 					createEObjectDescription(InputTypesPackage.Literals.STRING, false),
 					createEObjectDescription(InputTypesPackage.Literals.INTEGER, false),

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/validation/ReactionsLanguageValidator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/validation/ReactionsLanguageValidator.xtend
@@ -77,7 +77,7 @@ class ReactionsLanguageValidator extends AbstractReactionsLanguageValidator {
 
 //	@Check
 //	def checkEffects(Effect effect) {
-//		if (effect.impact.codeBlock == null && !effect.impact..filter(CorrespondingModelElementCreate).nullOrEmpty) {
+//		if (effect.impact.codeBlock === null && !effect.impact..filter(CorrespondingModelElementCreate).nullOrEmpty) {
 //			warning("Created elements must be initialized and inserted into the target model in the execute block.",
 //				ReactionsLanguagePackage.Literals.EFFECT__CODE_BLOCK);
 //		}
@@ -124,7 +124,7 @@ class ReactionsLanguageValidator extends AbstractReactionsLanguageValidator {
 		}
 		if (atomicChangeType instanceof ElementReferenceChangeType) {
 			val featureType = atomicChangeType.feature?.feature?.EType as EClass;
-			if (elementType != null && featureType != null) {
+			if (elementType !== null && featureType !== null) {
 				if (!elementType.equals(featureType) && !elementType.EAllSuperTypes.contains(featureType) && !featureType.EAllSuperTypes.contains(elementType)) {
 					warning("Element of specified type cannot be contained in the specified features",
 						elementChange, ReactionsLanguagePackage.Literals.MODEL_ELEMENT_CHANGE__ELEMENT_TYPE

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.mapping/src/tools/vitruv/extensions/dslsruntime/mapping/MappingExecutionState.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.mapping/src/tools/vitruv/extensions/dslsruntime/mapping/MappingExecutionState.xtend
@@ -65,7 +65,7 @@ class MappingExecutionState {
 	public def updateAllTuidsOfCachedObjects() {
 		for (entry : oldTuidMap.entrySet) {
 			val eObject = entry.key
-			if (eObject != null) { // TODO: do this correctly
+			if (eObject !== null) { // TODO: do this correctly
 				val ciToTuids = entry.value
 				for (ciAndTuids : ciToTuids.entrySet) {
 					for (tuid : ciAndTuids.value) {
@@ -86,7 +86,7 @@ class MappingExecutionState {
 	}
 	
 	public def addResourceToSave(EObject eObject) {
-		if (eObject.eResource != null) {
+		if (eObject.eResource !== null) {
 			this.resourcesToSave.add(eObject.eResource)
 		}
 	}

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutineRealization.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutineRealization.xtend
@@ -86,7 +86,7 @@ abstract class AbstractRepairRoutineRealization extends CallHierarchyHaving impl
 		 */
 		protected def persistProjectRelative(EObject alreadyPersistedObject, EObject elementToPersist,
 			String persistencePath) {
-			if (alreadyPersistedObject == null || elementToPersist == null || persistencePath == null) {
+			if (alreadyPersistedObject === null || elementToPersist === null || persistencePath === null) {
 				throw new IllegalArgumentException(
 					"correspondenceSource, element and persistancePath must be specified");
 			}

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/effects/ReactionElementsHandlerImpl.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/effects/ReactionElementsHandlerImpl.xtend
@@ -27,7 +27,7 @@ class ReactionElementsHandlerImpl implements ReactionElementsHandler {
 	}
 	
 	override void deleteObject(EObject element) {
-		if (element == null) {
+		if (element === null) {
 			return;
 		}
 		ReactionsCorrespondenceHelper.removeCorrespondencesOfObject(correspondenceModel, element);
@@ -44,9 +44,9 @@ class ReactionElementsHandlerImpl implements ReactionElementsHandler {
 	}
 	
 	override registerObjectUnderModification(EObject element) {
-		if (element != null) {
+		if (element !== null) {
 			TuidManager.instance.registerObjectUnderModification(element);
-			if (element.eContainer != null) {
+			if (element.eContainer !== null) {
 				TuidManager.instance.registerObjectUnderModification(element.eContainer);
 			}
 

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/Change2ReactionsMap.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/Change2ReactionsMap.xtend
@@ -17,7 +17,7 @@ class Change2ReactionsMap {
 	}
 	
 	public def addReaction(Class<? extends EChange> eventType, IReactionRealization reaction) {
-		if (this.change2reactionsMap.get(eventType) == null) {
+		if (this.change2reactionsMap.get(eventType) === null) {
 			this.change2reactionsMap.put(eventType, (new ArrayList<IReactionRealization>()))
 		}
 		this.change2reactionsMap.get(eventType).add(reaction);
@@ -27,16 +27,16 @@ class Change2ReactionsMap {
 		val result = new HashSet<IReactionRealization>();
 		var dependantInterfaces = newLinkedList(event.class.interfaces);
 		var superClass = event.class as Class<?>;
-		while (superClass != null) {
+		while (superClass !== null) {
 			val currentReactions = this.change2reactionsMap.get(superClass);
-			if (currentReactions != null) result.addAll(currentReactions);
+			if (currentReactions !== null) result.addAll(currentReactions);
 			dependantInterfaces.addAll(superClass.interfaces);
 			superClass = superClass.superclass;
 		} 
 		while (!dependantInterfaces.empty) {
 			val currentInterface = dependantInterfaces.remove(0);
 			val currentReactions = this.change2reactionsMap.get(currentInterface);
-			if (currentReactions != null) result.addAll(currentReactions);
+			if (currentReactions !== null) result.addAll(currentReactions);
 			dependantInterfaces.addAll(currentInterface.interfaces);
 		}
 				

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/PersistenceHelper.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/PersistenceHelper.xtend
@@ -11,7 +11,7 @@ public final class PersistenceHelper {
 	
 	public static def EObject getModelRoot(EObject modelObject) {
 		var result = modelObject;
-		while (result.eContainer() != null) {
+		while (result.eContainer() !== null) {
 			result = result.eContainer();
 		}
 		return result;

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/ReactionsCorrespondenceHelper.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/ReactionsCorrespondenceHelper.xtend
@@ -75,7 +75,7 @@ final class ReactionsCorrespondenceHelper {
 
 	public static def <T> List<T> getCorrespondingModelElements(EObject sourceElement, Class<T> affectedElementClass,
 		String expectedTag, Function1<T, Boolean> preconditionMethod, CorrespondenceModel correspondenceModel) {
-		val nonNullPreconditionMethod = if(preconditionMethod != null) preconditionMethod else [T input|true];
+		val nonNullPreconditionMethod = if(preconditionMethod !== null) preconditionMethod else [T input|true];
 		val targetElements = new ArrayList<T>();
 		try {
 			val correspondingObjects = getCorrespondingObjectsOfType(correspondenceModel,

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/structure/CallHierarchyHaving.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/structure/CallHierarchyHaving.xtend
@@ -16,6 +16,6 @@ class CallHierarchyHaving extends Loggable {
 	}
 	
 	public def String getCalledByString() {
-		return '''(«this.class.simpleName»)«IF calledBy != null» called by «calledBy.calledByString»«ENDIF»''';
+		return '''(«this.class.simpleName»)«IF calledBy !== null» called by «calledBy.calledByString»«ENDIF»''';
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringAtomicEChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringAtomicEChangeFactory.xtend
@@ -43,7 +43,7 @@ class TypeInferringAtomicEChangeFactory {
 	 * @return The singleton instance.
 	 */
 	def public static TypeInferringAtomicEChangeFactory getInstance() {
-		if (instance == null) {
+		if (instance === null) {
 			instance = new TypeInferringAtomicEChangeFactory()
 		}
 		return instance

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringCompoundEChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringCompoundEChangeFactory.xtend
@@ -32,7 +32,7 @@ class TypeInferringCompoundEChangeFactory {
 	 * @return The singleton instance.
 	 */
 	def public static TypeInferringCompoundEChangeFactory getInstance() {
-		if (instance == null) {
+		if (instance === null) {
 			instance = new TypeInferringCompoundEChangeFactory(TypeInferringAtomicEChangeFactory.instance)
 		}
 		return instance

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringUnresolvingAtomicEChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringUnresolvingAtomicEChangeFactory.xtend
@@ -29,7 +29,7 @@ final class TypeInferringUnresolvingAtomicEChangeFactory extends TypeInferringAt
 	 * @return The singleton instance.
 	 */
 	def public static TypeInferringUnresolvingAtomicEChangeFactory getInstance() {
-		if (instance == null) {
+		if (instance === null) {
 			instance = new TypeInferringUnresolvingAtomicEChangeFactory()
 		}
 		return instance

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringUnresolvingCompoundEChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringUnresolvingCompoundEChangeFactory.xtend
@@ -23,7 +23,7 @@ final class TypeInferringUnresolvingCompoundEChangeFactory extends TypeInferring
 	 * @return The singleton instance.
 	 */
 	def public static TypeInferringUnresolvingCompoundEChangeFactory getInstance() {
-		if (instance == null) {
+		if (instance === null) {
 			instance = new TypeInferringUnresolvingCompoundEChangeFactory(
 				TypeInferringUnresolvingAtomicEChangeFactory.instance)
 		}

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/command/AddToStagingAreaCommand.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/command/AddToStagingAreaCommand.xtend
@@ -38,6 +38,6 @@ class AddToStagingAreaCommand extends AbstractOverrideableCommand {
 	}
 
 	override public boolean prepare() {
-		return stagingArea != null && object != null
+		return stagingArea !== null && object !== null
 	}	
 }

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/command/RemoveFromStagingAreaCommand.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/command/RemoveFromStagingAreaCommand.xtend
@@ -38,7 +38,7 @@ class RemoveFromStagingAreaCommand extends AbstractOverrideableCommand {
 	}
 	
 	override public boolean prepare() {
-		return stagingArea != null && object != null
+		return stagingArea !== null && object !== null
 			&& !stagingArea.empty && stagingArea.peek == object
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/AtomicEChangeResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/AtomicEChangeResolver.xtend
@@ -34,7 +34,7 @@ class AtomicEChangeResolver {
 	 * 						{@code false} if the model is in state after.
 	 */
 	def package static boolean resolveEChange(EChange change, ResourceSet resourceSet, boolean resolveBefore) {
-		if (resourceSet == null) {
+		if (resourceSet === null) {
 			return false
 		}
 		return true
@@ -50,13 +50,13 @@ class AtomicEChangeResolver {
 	 */
 	def private static <A extends EObject, F extends EStructuralFeature> boolean resolveFeatureEChange(
 		FeatureEChange<A, F> change, ResourceSet resourceSet, boolean resolveBefore) {
-		if (change.affectedEObject == null || !resolveEChange(change, resourceSet, true)) {
+		if (change.affectedEObject === null || !resolveEChange(change, resourceSet, true)) {
 			return false
 		}
 
 		change.affectedEObject = EChangeUtil.resolveProxy(change.affectedEObject, resourceSet) as A
 
-		if (change.affectedFeature == null || change.affectedEObject == null || change.affectedEObject.eIsProxy) {
+		if (change.affectedFeature === null || change.affectedEObject === null || change.affectedEObject.eIsProxy) {
 			return false
 		}
 		return true
@@ -76,7 +76,7 @@ class AtomicEChangeResolver {
 	 */
 	def private static <A extends EObject, T extends EObject> EObject resolveReferenceValue(UpdateReferenceEChange<A> change, T value,
 		ResourceSet resourceSet, boolean isInserted, int index) {
-		if (value == null) {
+		if (value === null) {
 			return null
 		}
 		if (!change.affectedFeature.containment) {
@@ -111,7 +111,7 @@ class AtomicEChangeResolver {
 	 */
 	def private static <A extends EObject> boolean resolveEObjectExistenceEChange(EObjectExistenceEChange<A> change,
 		ResourceSet resourceSet, boolean newObject) {
-		if (change.affectedEObject == null || !change.resolveEChange(resourceSet, true)) {
+		if (change.affectedEObject === null || !change.resolveEChange(resourceSet, true)) {
 			return false
 		}
 		// Get the staging area where the created object will placed in or deleted from.
@@ -127,7 +127,7 @@ class AtomicEChangeResolver {
 			change.affectedEObject = change.stagingArea.peek as A
 		}
 
-		if (change.affectedEObject == null || change.affectedEObject.eIsProxy || change.stagingArea == null) {
+		if (change.affectedEObject === null || change.affectedEObject.eIsProxy || change.stagingArea === null) {
 			return false
 		}
 		return true
@@ -149,7 +149,7 @@ class AtomicEChangeResolver {
 		// Get resource where the root object will be inserted / removed.
 		change.resource = resourceSet.getResource(URI.createURI(change.uri), false)
 
-		if (change.resource == null) {
+		if (change.resource === null) {
 			return false
 		}
 		return true
@@ -221,7 +221,7 @@ class AtomicEChangeResolver {
 		
 		change.newValue = change.resolveReferenceValue(change.newValue, resourceSet, !resolveBefore, change.index)
 
-		if (change.newValue != null && change.newValue.eIsProxy) {
+		if (change.newValue !== null && change.newValue.eIsProxy) {
 			return false
 		}
 		return true
@@ -243,7 +243,7 @@ class AtomicEChangeResolver {
 		
 		change.oldValue = change.resolveReferenceValue(change.oldValue, resourceSet, resolveBefore, change.index)
 
-		if (change.oldValue != null && change.oldValue.eIsProxy) {
+		if (change.oldValue !== null && change.oldValue.eIsProxy) {
 			return false
 		}
 		return true
@@ -266,8 +266,8 @@ class AtomicEChangeResolver {
 		change.newValue = change.resolveReferenceValue(change.newValue, resourceSet, !resolveBefore, -1)
 		change.oldValue = change.resolveReferenceValue(change.oldValue, resourceSet, resolveBefore, -1)
 
-		if ((change.newValue != null && change.newValue.eIsProxy) ||
-			(change.oldValue != null && change.oldValue.eIsProxy)) {
+		if ((change.newValue !== null && change.newValue.eIsProxy) ||
+			(change.oldValue !== null && change.oldValue.eIsProxy)) {
 			return false
 		}
 		return true
@@ -289,7 +289,7 @@ class AtomicEChangeResolver {
 
 		change.newValue = change.resolveRootValue(change.newValue, resourceSet, !resolveBefore)
 
-		if (change.newValue == null || change.newValue.eIsProxy) {
+		if (change.newValue === null || change.newValue.eIsProxy) {
 			return false
 		}
 		return true
@@ -311,7 +311,7 @@ class AtomicEChangeResolver {
 
 		change.oldValue = change.resolveRootValue(change.oldValue, resourceSet, resolveBefore)
 		
-		if (change.oldValue == null || change.oldValue.eIsProxy) {
+		if (change.oldValue === null || change.oldValue.eIsProxy) {
 			return false
 		}
 		return true

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/CompoundEChangeResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/CompoundEChangeResolver.xtend
@@ -97,14 +97,14 @@ class CompoundEChangeResolver {
 	 * 								the compound change.
 	 */	
 	def package static dispatch boolean resolve(ExplicitUnsetEFeature<EObject, EStructuralFeature> change, ResourceSet resourceSet, boolean resolveBefore, boolean revertAfterResolving) {
-		if (change.affectedEObject == null || change.affectedFeature == null 
+		if (change.affectedEObject === null || change.affectedFeature === null 
 			|| !resolveCompoundEChange(change, resourceSet, resolveBefore, revertAfterResolving)) {
 			return false
 		}
 			
 		change.affectedEObject = EChangeUtil.resolveProxy(change.affectedEObject, resourceSet)
 
-		if (change.affectedEObject == null || change.affectedEObject.eIsProxy) {
+		if (change.affectedEObject === null || change.affectedEObject.eIsProxy) {
 			return false
 		}	
 		

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/EChangeUnresolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/EChangeUnresolver.xtend
@@ -30,7 +30,7 @@ public class EChangeUnresolver {
 	 * @return The proxy object of the given EObject.
 	 */
 	def static public <A extends EObject> A createProxy(A resolvedObject) {
-		if (resolvedObject != null) {
+		if (resolvedObject !== null) {
 			// TODO: Elbert S. Change when eobjects are removed recursively
 			val proxy = EcoreUtil.copy(resolvedObject) as InternalEObject
 			//val proxy = EcoreUtil.create(resolvedObject.eClass) as InternalEObject

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/ResolutionChecker.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/ResolutionChecker.xtend
@@ -28,9 +28,9 @@ class ResolutionChecker {
 	}
 	
 	public static def dispatch isResolved(EObjectExistenceEChange<?> existenceChange) {
-		return (existenceChange.getAffectedEObject() != null &&
+		return (existenceChange.getAffectedEObject() !== null &&
 			!existenceChange.getAffectedEObject().eIsProxy() && 
-			existenceChange.getStagingArea() != null);
+			existenceChange.getStagingArea() !== null);
 	}
 	
 	public static def dispatch isResolved(FeatureEChange<?,?> featureChange) {
@@ -38,27 +38,27 @@ class ResolutionChecker {
 	}
 	
 	public static def isFeatureChangeResolved(FeatureEChange<?,?> featureChange) {
-		return (featureChange.getAffectedEObject() != null &&
+		return (featureChange.getAffectedEObject() !== null &&
 			!featureChange.getAffectedEObject().eIsProxy() && 
-			featureChange.getAffectedFeature() != null);
+			featureChange.getAffectedFeature() !== null);
 	}
 	
 	public static def dispatch isResolved(InsertEReference<?,?> insertEReferenceChange) {
-		return (insertEReferenceChange.newValue == null
+		return (insertEReferenceChange.newValue === null
 			|| ! insertEReferenceChange.newValue.eIsProxy)
 			&& insertEReferenceChange.featureChangeResolved;	
 	}
 	
 	public static def dispatch isResolved(RemoveEReference<?,?> removeEReferenceChange) {
-		return (removeEReferenceChange.oldValue == null
+		return (removeEReferenceChange.oldValue === null
 			|| ! removeEReferenceChange.oldValue.eIsProxy)
 			&& removeEReferenceChange.featureChangeResolved;	
 	}
 	
 	public static def dispatch isResolved(ReplaceSingleValuedEReference<?,?> replaceSingleValuedEReferenceChange) {
-		return (replaceSingleValuedEReferenceChange.oldValue == null
+		return (replaceSingleValuedEReferenceChange.oldValue === null
 			|| ! replaceSingleValuedEReferenceChange.oldValue.eIsProxy)
-			&& (replaceSingleValuedEReferenceChange.newValue == null
+			&& (replaceSingleValuedEReferenceChange.newValue === null
 			|| ! replaceSingleValuedEReferenceChange.newValue.eIsProxy)
 			&& replaceSingleValuedEReferenceChange.featureChangeResolved;	
 	}
@@ -68,17 +68,17 @@ class ResolutionChecker {
 	}
 	
 	public static def isRootChangeResolved(RootEChange rootChange) {
-		return rootChange.resource != null;
+		return rootChange.resource !== null;
 	}
 	
 	public static def dispatch isResolved(InsertRootEObject<?> insertRootChange) {
-		return insertRootChange.newValue != null &&
+		return insertRootChange.newValue !== null &&
 			!insertRootChange.newValue.eIsProxy && 
 			insertRootChange.isRootChangeResolved;
 	}
 	
 	public static def dispatch isResolved(RemoveRootEObject<?> removeRootChange) {
-		return removeRootChange.oldValue != null &&
+		return removeRootChange.oldValue !== null &&
 			!removeRootChange.oldValue.eIsProxy && 
 			removeRootChange.isRootChangeResolved;
 	}

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/StagingArea.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/StagingArea.xtend
@@ -26,11 +26,11 @@ final public class StagingArea {
 	 * 		resource set is {@code null} it returns {@code null}
 	 */
 	def public static StagingArea getStagingArea(ResourceSet resourceSet) {
-		if (resourceSet == null) {
+		if (resourceSet === null) {
 			return null
 		}
 		
-		if (stagingAreas.get(resourceSet) == null) {
+		if (stagingAreas.get(resourceSet) === null) {
 			stagingAreas.put(resourceSet, new StagingArea())
 		}
 		return stagingAreas.get(resourceSet)
@@ -44,7 +44,7 @@ final public class StagingArea {
 	 * 		If the resource is {@code null} it returns {@code null}
 	 */
 	def public static StagingArea getStagingArea(Resource resource) {
-		if (resource == null) {
+		if (resource === null) {
 			return null
 		}
 		return getStagingArea(resource.resourceSet)

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/ApplyBackwardCommandSwitch.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/ApplyBackwardCommandSwitch.xtend
@@ -100,11 +100,11 @@ package class ApplyBackwardCommandSwitch {
 		val stagingArea = StagingArea.getStagingArea(change.affectedEObject.eResource)
 		val compoundCommand = new CompoundCommand()
 
-		if (change.containment && change.oldValue != null) {
+		if (change.containment && change.oldValue !== null) {
 			compoundCommand.append(new RemoveFromStagingAreaCommand(editingDomain, stagingArea, change.oldValue))
 		}
 		compoundCommand.append(new SetCommand(editingDomain, change.affectedEObject, change.affectedFeature, change.oldValue))
-		if (change.containment && change.newValue != null) {
+		if (change.containment && change.newValue !== null) {
 			compoundCommand.append(new AddToStagingAreaCommand(editingDomain, stagingArea, change.newValue))
 		}
 

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/ApplyEChangeSwitch.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/ApplyEChangeSwitch.xtend
@@ -33,7 +33,7 @@ public class ApplyEChangeSwitch {
 			commands = ApplyBackwardCommandSwitch.getCommands(change)
 		}
 
-		if (commands != null) {
+		if (commands !== null) {
 			for (Command c : commands) {
 				if (c.canExecute()) {
 					c.execute()

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/ApplyForwardCommandSwitch.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/ApplyForwardCommandSwitch.xtend
@@ -105,11 +105,11 @@ package class ApplyForwardCommandSwitch {
 		val stagingArea = StagingArea.getStagingArea(change.affectedEObject.eResource)
 		val compoundCommand = new CompoundCommand()
 
-		if (change.containment && change.newValue != null) {
+		if (change.containment && change.newValue !== null) {
 			compoundCommand.append(new RemoveFromStagingAreaCommand(editingDomain, stagingArea, change.newValue))
 		}
 		compoundCommand.append(new SetCommand(editingDomain, change.affectedEObject, change.affectedFeature, change.newValue))
-		if (change.containment && change.oldValue != null) {
+		if (change.containment && change.oldValue !== null) {
 			compoundCommand.append(new AddToStagingAreaCommand(editingDomain, stagingArea, change.oldValue))
 		}
 

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
@@ -21,7 +21,7 @@ class EChangeUtil {
 	 * @return The resolved EObject. If resolving the proxy fails, the proxy object itself.
 	 */
 	public static def resolveProxy(EObject proxy, ResourceSet resourceSet) {
-		if (proxy != null && resourceSet != null) {
+		if (proxy !== null && resourceSet !== null) {
 			return EcoreUtil.resolve(proxy, resourceSet)
 		}
 		return proxy
@@ -35,7 +35,7 @@ class EChangeUtil {
 	 */
 	public static def EditingDomain getEditingDomain(EObject object) {
 		val ed = AdapterFactoryEditingDomain.getEditingDomainFor(object)
-		if (ed == null) {
+		if (ed === null) {
 			return new AdapterFactoryEditingDomain(new ComposedAdapterFactory(), new BasicCommandStack());
 		}
 		return ed

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeChangePropagationSpecification.xtend
@@ -78,8 +78,8 @@ abstract class CompositeChangePropagationSpecification extends AbstractChangePro
 	private def getAllProcessors() {
 		val processors = new ArrayList<ChangePropagationSpecification>();
 		// processor arrays can be null when calling setUserInteracting from the super constructor
-		if (changePreprocessors != null) processors += changePreprocessors;
-		if (changeMainprocessors != null) processors += changeMainprocessors;
+		if (changePreprocessors !== null) processors += changePreprocessors;
+		if (changeMainprocessors !== null) processors += changeMainprocessors;
 		return processors;
 	}
 	

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChangeFactory.xtend
@@ -30,7 +30,7 @@ class VitruviusChangeFactory {
 	private new() {}
 	
 	public static def VitruviusChangeFactory getInstance() {
-		if (instance == null) {
+		if (instance === null) {
 			instance = new VitruviusChangeFactory();
 		}
 		return instance;
@@ -98,7 +98,7 @@ class VitruviusChangeFactory {
             throw new RuntimeException(
                     "The requested model instance resource '" + resource + "' has to contain at most one root element "
                             + "in order to be added to the VSUM without an explicit import!");
-        } else { // resource.getContents().size() == null --> no element in newModelInstance
+        } else { // resource.getContents().size() === null --> no element in newModelInstance
             logger.info("Empty model file created: " + VURI.getInstance(resource)
                     + ". Propagation of 'root element created' not triggered.");
             return null;

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractCompositeChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractCompositeChangeImpl.xtend
@@ -24,11 +24,11 @@ abstract class AbstractCompositeChangeImpl<C extends VitruviusChange> implements
     }
 
     override addChange(C change) {
-		if (change != null) this.changes.add(change);
+		if (change !== null) this.changes.add(change);
     }
 	
 	override removeChange(C change) {
-		if (change != null) this.changes.remove(change);
+		if (change !== null) this.changes.remove(change);
 	}
 				
 	override containsConcreteChange() {

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractConcreteChange.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractConcreteChange.xtend
@@ -22,7 +22,7 @@ abstract class AbstractConcreteChange implements ConcreteChange {
 	}
 	
 	override validate() {
-		return containsConcreteChange() && URI != null;
+		return containsConcreteChange() && URI !== null;
 	}
 	
 	override getEChanges() {

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/CompositeTransactionalChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/CompositeTransactionalChangeImpl.xtend
@@ -8,7 +8,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet
 class CompositeTransactionalChangeImpl extends AbstractCompositeChangeImpl<TransactionalChange> implements CompositeTransactionalChange {
 	
 	override removeChange(TransactionalChange change) {
-		if (change != null && this.changes.contains(change)) {
+		if (change !== null && this.changes.contains(change)) {
 			if (changes.size == 1) {
 				val emptyChange = VitruviusChangeFactory.instance.createEmptyChange(change.URI);
 				this.changes += emptyChange;	

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/ChangeDescription2EChangesTransformation.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/ChangeDescription2EChangesTransformation.xtend
@@ -107,7 +107,7 @@ public class ChangeDescription2EChangesTransformation {
 	}
 
 	public def List<EChange> transform() {
-		if (changeDescription == null) {
+		if (changeDescription === null) {
 			return eChanges
 		} else {
 
@@ -271,7 +271,7 @@ public class ChangeDescription2EChangesTransformation {
 					it.referenceValues)
 			].flatten.toList
 			val elementsReferencedAfterChange = featureChange.referenceValue
-			if (elementsReferencedAfterChange == null && listChanges != null && listChanges.isEmpty) {
+			if (elementsReferencedAfterChange === null && listChanges !== null && listChanges.isEmpty) {
 				val elementsReferencedBeforeChange = affectedEObject.getReferenceValueList(affectedReference)
 				for (var index = elementsReferencedBeforeChange.size - 1; index >= 0; index--) {
 					var elementReferencedBeforeChange = elementsReferencedBeforeChange.get(index)
@@ -338,7 +338,7 @@ public class ChangeDescription2EChangesTransformation {
 				createChangeForMultiAttributeChange(affectedEObject, affectedAttribute, it.index, it.kind, it.values)
 			].flatten.toList
 			val elementsReferencedAfterChange = featureChange.referenceValue
-			if (elementsReferencedAfterChange == null && listChanges != null && listChanges.isEmpty) {
+			if (elementsReferencedAfterChange === null && listChanges !== null && listChanges.isEmpty) {
 				val elementsReferencedBeforeChange = affectedEObject.getReferenceValueList(affectedAttribute)
 				for (var index = elementsReferencedBeforeChange.size-1; index >= 0; index--) {
 					var elementReferencedBeforeChange = elementsReferencedBeforeChange.get(index)

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/EMFModelChangeTransformationUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/EMFModelChangeTransformationUtil.xtend
@@ -84,7 +84,7 @@ package class EMFModelChangeTransformationUtil {
 	}
 	
 	def private static boolean isRootContainer(EObject container) {
-		return container == null //|| container instanceof ChangeDescription
+		return container === null //|| container instanceof ChangeDescription
 }
 	
 	def static boolean hasNonDefaultValue(EObject eObject) {
@@ -111,7 +111,7 @@ package class EMFModelChangeTransformationUtil {
 		val value = eObject.eGet(feature)
 		if (feature.many) {
 			val list = value as List<?>
-			return list != null && !list.isEmpty
+			return list !== null && !list.isEmpty
 		} else {
 			// TODO MK is equals (== in Xtend) for feature default value comparison okay or is identity (===) needed?
 			return value != feature.defaultValue
@@ -138,11 +138,11 @@ package class EMFModelChangeTransformationUtil {
 	}
 	
 	def static boolean isCreate(EObject oldContainer, Resource oldResource) {
-		return (oldContainer == null || oldContainer instanceof ChangeDescription) && oldResource == null
+		return (oldContainer === null || oldContainer instanceof ChangeDescription) && oldResource === null
 	}
 	
 	def static boolean isDelete(EObject newContainer, Resource newResource) {
-		return (newContainer == null || newContainer instanceof ChangeDescription) && newResource == null
+		return (newContainer === null || newContainer instanceof ChangeDescription) && newResource === null
 	}
 
 	def static EChange createRemoveRootChange(EObject rootToRemove, EObject newRootContainer, Resource newRootResource, Resource oldResource, int index) {
@@ -161,7 +161,7 @@ package class EMFModelChangeTransformationUtil {
 
 		val oldResource = referenceValue.eResource
 
-		val isCreate = forceCreate || (isContainment && oldResource == null)
+		val isCreate = forceCreate || (isContainment && oldResource === null)
 		if (isCreate) {
 
 			return TypeInferringCompoundEChangeFactory.instance.createCreateAndInsertNonRootChange(affectedEObject, affectedReference, referenceValue, index);
@@ -188,9 +188,9 @@ package class EMFModelChangeTransformationUtil {
 		val isContainment = affectedReference.containment
 
 		if (forceCreate || isContainment) {
-			if (oldReferenceValue == null) {
+			if (oldReferenceValue === null) {
 				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceNonRootChange(affectedEObject, affectedReference, newReferenceValue)
-			} else if (newReferenceValue == null) {
+			} else if (newReferenceValue === null) {
 				return TypeInferringCompoundEChangeFactory.instance.createReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue)
 			} else {
 				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue, newReferenceValue);				

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelImpl.xtend
@@ -82,7 +82,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	def private registerTuidList(List<Tuid> tuidList) {
 		for (Tuid tuid : tuidList) {
 			var tuidLists = this.tuid2tuidListsMap.get(tuid)
-			if (tuidLists == null) {
+			if (tuidLists === null) {
 				tuidLists = new HashSet<List<Tuid>>()
 				this.tuid2tuidListsMap.put(tuid,tuidLists)
 			}
@@ -133,7 +133,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 		 val correspondences = getCorrespondences(aEObjects)
 		 for (Correspondence correspondence : correspondences) {
 		 	val correspondingBs = if (correspondence.^as.containsAll(aEObjects)) correspondence.bs else correspondence.^as
-		 	if (correspondingBs != null && correspondingBs.equals(bEObjects)) {
+		 	if (correspondingBs !== null && correspondingBs.equals(bEObjects)) {
 		 		return correspondence;
 		 	}
 		 }
@@ -234,7 +234,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	override boolean hasCorrespondences(List<EObject> eObjects) {
 		var List<Tuid> tuids = calculateTuidsFromEObjects(eObjects)
 		var Set<Correspondence> correspondences = this.tuid2CorrespondencesMap.get(tuids)
-		return correspondences != null && correspondences.size() > 0
+		return correspondences !== null && correspondences.size() > 0
 	}
 
 	def private Correspondences loadAndRegisterCorrespondences(Resource correspondencesResource) {
@@ -393,10 +393,10 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	private def EObject resolveEObjectInModelInstance(ModelInstance modelInstance, Tuid tuid) {
 		val TuidAwareVitruvDomain domain = getMetamodelHavingTuid(tuid)
 		// if the tuid is cached because it has no resource the rootEObject is null
-		var rootEObjects = if (modelInstance != null) modelInstance.rootElements + #[null] else #[null];
+		var rootEObjects = if (modelInstance !== null) modelInstance.rootElements + #[null] else #[null];
 		return rootEObjects.
 			map[domain.resolveEObjectFromRootAndFullTuid(it, tuid)].
-			findFirst[it != null];
+			findFirst[it !== null];
 	}
 
 	def public void setChangeAfterLastSaveFlag() {
@@ -415,7 +415,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	}
 
 	override getAllCorrespondencesWithoutDependencies() {
-		this.correspondences.correspondences.filter[it.dependsOn == null || it.dependsOn.size == 0].toSet
+		this.correspondences.correspondences.filter[it.dependsOn === null || it.dependsOn.size == 0].toSet
 	}
 	
 	override getCorrespondencesThatInvolveAtLeast(Set<EObject> eObjects) {
@@ -481,7 +481,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	 * @return oldCurrentTuidAndStringAndMapEntriesTriple
 	 */
 	override performPreAction(Tuid oldCurrentTuid) {
-		if (tuidUpdateData != null) {
+		if (tuidUpdateData !== null) {
 			throw new IllegalStateException("Two update calls were running at the same time");
 		}
 		// The Tuid is used as key in this map. Therefore the entry has to be removed before
@@ -505,7 +505,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 		// The correspondence model is an EMF-based model, so modifications have to be
 		// performed within a transaction.
 		this.modelProviding.createRecordingCommandAndExecuteCommandOnTransactionalDomain([ |
-			if (tuidUpdateData == null) {
+			if (tuidUpdateData === null) {
 				throw new IllegalStateException("Update was not started before performing post action");
 			}
 			val oldTuidList2Correspondences = tuidUpdateData;

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.xtend
@@ -45,7 +45,7 @@ class CorrespondenceModelView<T extends Correspondence> implements GenericCorres
 		val correspondences = getCorrespondences(aEObjects)
 		for (T correspondence : correspondences) {
 			val correspondingBs = correspondence.bs
-			if (correspondingBs != null && correspondingBs.equals(bEObjects)) {
+			if (correspondingBs !== null && correspondingBs.equals(bEObjects)) {
 				return correspondence;
 			}
 		}
@@ -92,7 +92,7 @@ class CorrespondenceModelView<T extends Correspondence> implements GenericCorres
 
 	override hasCorrespondences(List<EObject> eObjects) {
 		var Set<T> correspondences = this.getCorrespondences(eObjects);
-		return correspondences != null && correspondences.size() > 0
+		return correspondences !== null && correspondences.size() > 0
 	}
 
 	override hasCorrespondences() {

--- a/bundles/framework/tools.vitruv.framework.modelsynchronization/src/tools/vitruv/framework/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.modelsynchronization/src/tools/vitruv/framework/modelsynchronization/ChangePropagatorImpl.xtend
@@ -47,7 +47,7 @@ class ChangePropagatorImpl implements ChangePropagator {
 	}
 
 	override synchronized List<List<VitruviusChange>> propagateChange(VitruviusChange change) {
-		if (change == null || !change.containsConcreteChange()) {
+		if (change === null || !change.containsConcreteChange()) {
 			logger.info('''The change does not contain any changes to synchronize: «change»''')
 			return Collections.emptyList()
 		}

--- a/bundles/framework/tools.vitruv.framework.modelsynchronization/src/tools/vitruv/framework/modelsynchronization/ChangedResourcesTracker.xtend
+++ b/bundles/framework/tools.vitruv.framework.modelsynchronization/src/tools/vitruv/framework/modelsynchronization/ChangedResourcesTracker.xtend
@@ -31,7 +31,7 @@ package class ChangedResourcesTracker {
 	}
 	
 	public def void addInvolvedModelResource(Resource resource) {
-		if (resource == null) {
+		if (resource === null) {
 			return;
 		}
 		this.involvedModelResources += resource;

--- a/bundles/framework/tools.vitruv.framework.monitorededitor/src/tools/vitruv/framework/monitorededitor/VitruviusProjectBuilderApplicator.xtend
+++ b/bundles/framework/tools.vitruv.framework.monitorededitor/src/tools/vitruv/framework/monitorededitor/VitruviusProjectBuilderApplicator.xtend
@@ -19,7 +19,7 @@ class VitruviusProjectBuilderApplicator {
 	}
 	
 	public def void addToProject(IProject project, File vmodelFolder, List<String> fileExtensions) {
-        if (project != null) {
+        if (project !== null) {
             try {
                 // verify already registered builders
                 if (hasBuilder(project)) {
@@ -55,7 +55,7 @@ class VitruviusProjectBuilderApplicator {
 	
 	
 	public def void removeBuilderFromProject(IProject project) {
-        if (project != null) {
+        if (project !== null) {
             try {
                 val IProjectDescription description = project.getDescription();
                 val List<ICommand> commands = new ArrayList<ICommand>();

--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/Tuid.xtend
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/Tuid.xtend
@@ -86,10 +86,10 @@ final class Tuid implements Serializable {
 			val splitTuidString = split(tuidString)
 			var lastSegmentOrPrefix = SEGMENTS.getMaximalPrefix(splitTuidString)
 			var Tuid instance
-			val lastSegmentOrPrefixString = if (lastSegmentOrPrefix != null) {
+			val lastSegmentOrPrefixString = if (lastSegmentOrPrefix !== null) {
 					lastSegmentOrPrefix.toString(VitruviusConstants.getTuidSegmentSeperator());
 				}
-			if (lastSegmentOrPrefixString != null && lastSegmentOrPrefixString.equals(tuidString)) {
+			if (lastSegmentOrPrefixString !== null && lastSegmentOrPrefixString.equals(tuidString)) {
 				// the complete specified tuidString was already mapped
 				val instances = LAST_SEGMENT_2_Tuid_INSTANCES_MAP.get(lastSegmentOrPrefix);
 				if (instances.
@@ -118,7 +118,7 @@ final class Tuid implements Serializable {
 
 	private static def void mapSegmentToTuid(Segment segment, Tuid tuid) {
 		val segmentToTuidsListImmutable = LAST_SEGMENT_2_Tuid_INSTANCES_MAP.get(segment);
-		val segmentToTuidsList = if (segmentToTuidsListImmutable != null) {
+		val segmentToTuidsList = if (segmentToTuidsListImmutable !== null) {
 				new ArrayList(segmentToTuidsListImmutable);
 			} else {
 				new ArrayList<Tuid>();

--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidCalculatorAndResolverBase.xtend
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidCalculatorAndResolverBase.xtend
@@ -211,7 +211,7 @@ abstract class TuidCalculatorAndResolverBase implements TuidCalculatorAndResolve
 		var root = root_finalParam_
 		if (root === null) {
 			root = claimRootFromCache(tuid)
-			if (root == null) {
+			if (root === null) {
 				LOGGER.warn('''No EObject found for Tuid: «tuid» in the cache''')
 				return null;
 			}
@@ -234,7 +234,7 @@ abstract class TuidCalculatorAndResolverBase implements TuidCalculatorAndResolve
 
 	def private EObject claimRootFromCache(String tuid) {
 		var key = claimCacheKey(tuid)
-		if (key == null) return null;
+		if (key === null) return null;
 		return this.cachedResourcelessRoots.claimValueForKey(key)
 	}
 
@@ -247,7 +247,7 @@ abstract class TuidCalculatorAndResolverBase implements TuidCalculatorAndResolve
 	def private String getTuidWithoutRootObjectPrefix(EObject root, String extTuid) {
 		var String rootTuid = calculateTuidFromEObject(root)
 		var String normalizedExtTuid = extTuid;
-		if (root.eResource != null) {
+		if (root.eResource !== null) {
 			val uriConverter = root.eResource.resourceSet.URIConverter
 			rootTuid = rootTuid.getUriNormalizedTuid(uriConverter);
 			normalizedExtTuid = extTuid.getUriNormalizedTuid(uriConverter);

--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidManager.xtend
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidManager.xtend
@@ -26,7 +26,7 @@ final class TuidManager {
 	}
 	
 	public def void addTuidUpdateListener(TuidUpdateListener updateListener) {
-		if (updateListener != null) {
+		if (updateListener !== null) {
 			tuidUpdateListener += updateListener;
 		}
 	}
@@ -36,7 +36,7 @@ final class TuidManager {
 	}
 	
 	public def void addTuidCalculator(TuidCalculator calculator) {
-		if (calculator != null) {
+		if (calculator !== null) {
 			tuidCalculator += calculator;
 		}
 	}
@@ -54,7 +54,7 @@ final class TuidManager {
 		var TuidCalculator resultCalculator = null;
 		for (potentialCalculator : tuidCalculator) {
 			if (potentialCalculator.canCalculateTuid(object)) {
-				if (resultCalculator != null) {
+				if (resultCalculator !== null) {
 					throw new IllegalStateException("There are two Tuid calculators registered that can handle the EObject: " + object + ", which are " + resultCalculator + " and " + potentialCalculator);
 				}
 				resultCalculator = potentialCalculator;
@@ -64,12 +64,12 @@ final class TuidManager {
 	}
 	
 	def private boolean hasTuidCalculator(EObject object) {
-		return object.tuidCalculator != null;
+		return object.tuidCalculator !== null;
 	}
 	
 	def private Tuid calculateTuid(EObject object) {
 		val tuidCalculator = object.tuidCalculator;
-		if (tuidCalculator != null) {
+		if (tuidCalculator !== null) {
 			return tuidCalculator.calculateTuid(object);
 		} else {
 			throw new IllegalArgumentException("No Tuid calculator registered for EObject: " + object);

--- a/tests/dsls/tools.vitruv.dsls.mapping.testframework/src/tools/vitruv/dsls/mapping/testframework/tests/MappingLanguageTestRunner.xtend
+++ b/tests/dsls/tools.vitruv.dsls.mapping.testframework/src/tools/vitruv/dsls/mapping/testframework/tests/MappingLanguageTestRunner.xtend
@@ -35,7 +35,7 @@
 //
 //		val c2cTransforming = getChange2CommandTransforming(pluginName)
 //
-//		if (c2cTransforming == null) {
+//		if (c2cTransforming === null) {
 //			throw new InitializationError(
 //			'''
 //				Could not find «Change2CommandTransforming.name» for plugin "«pluginName»" for extension point "«Change2CommandTransforming.ID»".

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.xtend
@@ -111,7 +111,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	
 	private def void replaceMultiValuedContainmentNonRootObject(Root rootObject, String oldId, String newId) {
 		val oldElement = rootObject.multiValuedContainmentEReference.findFirst(nonRoot | nonRoot.id == oldId);
-		if (oldElement == null) {
+		if (oldElement === null) {
 			throw new IllegalStateException("There is no element with the specified old element id.");
 		}
 		val oldIndex = rootObject.multiValuedContainmentEReference.indexOf(oldElement);
@@ -123,7 +123,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	
 	private def removeMultiValuedContainmentNonRootObject(Root rootObject, String id) {
 		val objectToRemove = rootObject.multiValuedContainmentEReference.findFirst(nonRoot | nonRoot.id == id);
-		if (objectToRemove == null) {
+		if (objectToRemove === null) {
 			throw new IllegalStateException("There is no element with the specified element id.");
 		}
 		rootObject.multiValuedContainmentEReference.remove(objectToRemove);
@@ -132,7 +132,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	
 	private def void insertMultiValuedNonContainmentNonRootObject(Root rootObject, String id) {
 		val nonRoot = rootObject.nonRootObjectContainerHelper.nonRootObjectsContainment.findFirst(nonRoot | nonRoot.id == id);
-		if (nonRoot == null) {
+		if (nonRoot === null) {
 			throw new IllegalStateException("There is no element with the specified element id.");
 		}
 		rootObject.multiValuedNonContainmentEReference.add(nonRoot);
@@ -142,10 +142,10 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	private def void replaceMultiValuedNonContainmentNonRootObject(Root rootObject, String oldId, String newId) {
 		val oldElement = rootObject.nonRootObjectContainerHelper.nonRootObjectsContainment.findFirst(nonRoot | nonRoot.id == oldId);
 		val newElement = rootObject.nonRootObjectContainerHelper.nonRootObjectsContainment.findFirst(nonRoot | nonRoot.id == newId);
-		if (oldElement == null) {
+		if (oldElement === null) {
 			throw new IllegalStateException("There is no element with the specified old element id.");
 		}
-		if (newElement == null) {
+		if (newElement === null) {
 			throw new IllegalStateException("There is no element with the specified new element id.");
 		}
 		val oldIndex = rootObject.multiValuedNonContainmentEReference.indexOf(oldElement);
@@ -158,7 +158,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	
 	private def void removeMultiValuedNonContainmentNonRootObject(Root rootObject, String id) {
 		val objectToRemove = rootObject.nonRootObjectContainerHelper.nonRootObjectsContainment.findFirst(nonRoot | nonRoot.id == id);
-		if (objectToRemove == null) {
+		if (objectToRemove === null) {
 			throw new IllegalStateException("There is no element with the specified element id.");
 		}
 		if (!rootObject.multiValuedNonContainmentEReference.contains(objectToRemove)) {

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTestsExecutionMonitor.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTestsExecutionMonitor.xtend
@@ -7,7 +7,7 @@ final class SimpleChangesTestsExecutionMonitor {
 	private static var SimpleChangesTestsExecutionMonitor INSTANCE;
 	
 	public static def getInstance() {
-		if (INSTANCE == null) {
+		if (INSTANCE === null) {
 			INSTANCE = new SimpleChangesTestsExecutionMonitor();
 		}
 		return INSTANCE;

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTestsUtils.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTestsUtils.xtend
@@ -5,7 +5,7 @@ import org.eclipse.emf.ecore.EObject
 class SimpleChangesTestsUtils {
 	static def findTypeInContainmentHierarchy(EObject startElement, Class<? extends EObject> searchedContainerType) {
 		var EObject currentObject = startElement;
-		while (!searchedContainerType.isInstance(currentObject) && currentObject != null) {
+		while (!searchedContainerType.isInstance(currentObject) && currentObject !== null) {
 			currentObject = currentObject.eContainer();
 		}
 		return currentObject;

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/EChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/EChangeTest.xtend
@@ -93,7 +93,7 @@ import org.eclipse.emf.ecore.EObject
 	 * 		Clears and sets the 0th element.
 	 */
 	protected def void prepareStagingArea(EObject object) {
-		if (object != null) {
+		if (object !== null) {
 			stagingArea.add(object)			
 		}
 	}

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/command/RemoveAtCommandTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/command/RemoveAtCommandTest.xtend
@@ -68,7 +68,7 @@ class RemoveAtCommandTest extends CommandTest {
 		createRemoveAtCommand(list, -1, 0).assertIsNotPreparable // List doesn't contain the value
 		createRemoveAtCommand(list, 44, 0).assertIsNotPreparable // List doesn't contain the value
 		
-		createRemoveAtCommand(null, 0, 0).assertIsNotPreparable // List == null
+		createRemoveAtCommand(null, 0, 0).assertIsNotPreparable // List === null
 	}
 	
 	/**

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/ReplaceSingleValuedEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/ReplaceSingleValuedEReferenceTest.xtend
@@ -368,7 +368,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	def private void assertIsStateBefore(NonRoot valueInStagingArea) {
 		resourceIsStateBefore
 		oldValue.assertEqualsOrCopy(affectedEObject.eGet(affectedFeature) as EObject)
-		if (affectedFeature.containment && valueInStagingArea != null) {
+		if (affectedFeature.containment && valueInStagingArea !== null) {
 			valueInStagingArea.assertEqualsOrCopy(stagingArea.peek)
 		} else {
 			Assert.assertTrue(stagingArea.empty)
@@ -395,7 +395,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	def private void assertIsStateAfter(NonRoot valueInStagingArea) {
 		resourceIsStateBefore
 		newValue.assertEqualsOrCopy(affectedEObject.eGet(affectedFeature) as EObject)		
-		if (affectedFeature.containment && valueInStagingArea != null) {
+		if (affectedFeature.containment && valueInStagingArea !== null) {
 			valueInStagingArea.assertEqualsOrCopy(stagingArea.peek)
 		} else {
 			Assert.assertTrue(stagingArea.empty)

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/ChangeDescription2ChangeTransformationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/ChangeDescription2ChangeTransformationTest.xtend
@@ -85,7 +85,7 @@ abstract class ChangeDescription2ChangeTransformationTest {
 	}
 
 	protected def List<EChange> getChanges() {
-		if (this.changes == null) {
+		if (this.changes === null) {
 			this.changes = endRecording()
 			if (this.unresolveAndResolveRecordedEChanges) {
 				for (var i = this.changes.length - 1; i >= 0; i--) {

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/AtomicEChangeAssertHelper.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/AtomicEChangeAssertHelper.xtend
@@ -29,7 +29,7 @@ class AtomicEChangeAssertHelper {
 	public def static assertEObjectExistenceChange(EChange change, EObject affectedEObject, StagingArea stagingArea) {
 		val eObjectExistingChange = assertObjectInstanceOf(change, EObjectExistenceEChange);
 		eObjectExistingChange.assertAffectedEObject(affectedEObject)
-		if (stagingArea != null) {
+		if (stagingArea !== null) {
 			eObjectExistingChange.assertStagingArea(stagingArea)
 		}
 	}

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/ChangeAssertHelper.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/ChangeAssertHelper.xtend
@@ -51,13 +51,13 @@ class ChangeAssertHelper {
 
 	public static def assertNewValue(AdditiveEChange<?> eChange, Object newValue) {
 		val newValueInChange = eChange.newValue
-		var condition = newValue == null && newValueInChange == null;
+		var condition = newValue === null && newValueInChange === null;
 		if (newValue instanceof EObject && newValueInChange instanceof EObject) {
 			val newEObject = newValue as EObject
 			var newEObjectInChange = newValueInChange as EObject
 			condition = EcoreUtil.equals(newEObject, newEObjectInChange)
 		} else if (!condition) {
-			condition = newValue != null && newValue.equals(newValueInChange)
+			condition = newValue !== null && newValue.equals(newValueInChange)
 		}
 		Assert.assertTrue(
 			"new value in change ' " + newValueInChange + "' must be the same than the given new value '" + newValue +


### PR DESCRIPTION
This PR simply makes all comparisons with `null` identity checks. This leads to slightly better optimised compilation results. But more importantly, it removes a lot of warnings.