### PR TITLE
Remove MaxPerm from MAVEN_OPTS on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
     - sh -e /etc/init.d/xvfb start - sleep 10
     - git clone --depth 1 https://github.com/kit-sdq/BuildUtilities.git /tmp/BuildUtilities
     - . /tmp/BuildUtilities/travis-ci/installMaven.sh
-    - "echo \"export MAVEN_OPTS='-Dmaven.repo.local=$HOME/.m2/repository -Xmx2g -XX:MaxPermSize=2048m'\" > ~/.mavenrc"
+    - "echo \"export MAVEN_OPTS='-Dmaven.repo.local=$HOME/.m2/repository -Xmx2g'\" > ~/.mavenrc"
 install: true
 
 script: mvn clean verify


### PR DESCRIPTION
There is no permanent generation in Java 8 anymore, and thus no need to specify the permanent size (the JVM issues an [according warning](https://travis-ci.org/vitruv-tools/Vitruv/builds/250416885#L345)).

See http://openjdk.java.net/jeps/122