### PR TITLE
ProjectBuildUtils: Don’t issue a fatal message for closed projects

### DIFF
--- a/bundles/framework/tools.vitruv.framework.monitorededitor/src/tools/vitruv/framework/monitorededitor/ProjectBuildUtils.java
+++ b/bundles/framework/tools.vitruv.framework.monitorededitor/src/tools/vitruv/framework/monitorededitor/ProjectBuildUtils.java
@@ -11,25 +11,28 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
 /**
- * {@link ProjectBuildUtils} is a utility class providing methods issuing the execution of a certain builder
- * for all projects which can be built with this builder.
+ * {@link ProjectBuildUtils} is a utility class providing methods issuing the execution of a certain
+ * builder for all projects which can be built with this builder.
  */
 public final class ProjectBuildUtils {
     private static final Logger LOGGER = Logger.getLogger(ProjectBuildUtils.class);
-    
+
     private ProjectBuildUtils() {
-        
+
     }
-    
+
     /**
      * Issues an incremental build of all projects supporting a given builder.
-     * @param builderId 
-     *       An Eclipse builder ID. Only this builder is executed on the currently
-     *       existing projects supporting this builder.
+     *
+     * @param builderId
+     *            An Eclipse builder ID. Only this builder is executed on the currently existing
+     *            projects supporting this builder.
      */
     public static void issueIncrementalBuildForAllProjectsWithBuilder(final String builderId) {
         for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
-        	issueIncrementalBuild(project, builderId);
+            if (project.isOpen()) {
+                issueIncrementalBuild(project, builderId);
+            }
         }
     }
 
@@ -38,8 +41,8 @@ public final class ProjectBuildUtils {
         try {
             for (ICommand buildCommand : project.getDescription().getBuildSpec()) {
                 if (buildCommand.getBuilderName().equals(builderId)) {
-                	 project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, builderId, new HashMap<String, String>(),
-                             new NullProgressMonitor());
+                    project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, builderId, new HashMap<String, String>(),
+                            new NullProgressMonitor());
                 }
             }
         } catch (CoreException e) {


### PR DESCRIPTION
ProjectBuildUtils try to build closed projects, which fails, so a fatal message is logged.

So this PR just skips closed projects