### PR TITLE
Reaction JVM Model Inferer Refactor

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ClassGenerator.xtend
@@ -10,40 +10,53 @@ import java.util.HashMap
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
 import tools.vitruv.dsls.reactions.codegen.typesbuilder.TypesBuilderExtensionProvider
 
+/**
+ * JVM Model inference should happen in two phases:
+ * <ol>
+ * <li>Create empty classes so they can be found when linking</li>
+ * <li>After linking is done, generate the bodies</li>
+ * </ol>
+ * Therefore, the {@link ClassGenerator}s provide separated methods 
+ * {@link ClassGenerator#generateEmptyClass() generateEmptyClass}
+ * and {@link ClassGenerator#generateBody(JvmGenericType) generateBody} for those steps.
+ */
 abstract class ClassGenerator extends TypesBuilderExtensionProvider implements IJvmOperationRegistry {
 	private Map<String, JvmOperation> methodMap;
-	
-	protected def generateAccessibleElementsParameters(EObject sourceObject, Iterable<AccessibleElement> accessibleElements) {
+
+	protected def generateAccessibleElementsParameters(EObject sourceObject,
+		Iterable<AccessibleElement> accessibleElements) {
 		accessibleElements.map[sourceObject.toParameter(name, typeRef(fullyQualifiedType))];
 	}
-	
+
 	public new(TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
 		typesBuilderExtensionProvider.copyBuildersTo(this);
 		this.methodMap = new HashMap<String, JvmOperation>();
 	}
-	
-	def JvmGenericType generateClass()
-	
+
+	def JvmGenericType generateEmptyClass()
+
 	def JvmGenericType generateBody(JvmGenericType generatedClass) {}
-	
-	override JvmOperation getOrGenerateMethod(EObject contextObject, String methodName, JvmTypeReference returnType, Procedure1<? super JvmOperation> initializer) {
+
+	override JvmOperation getOrGenerateMethod(EObject contextObject, String methodName, JvmTypeReference returnType,
+		Procedure1<? super JvmOperation> initializer) {
 		if (!methodMap.containsKey(methodName)) {
 			val operation = contextObject.toMethod(methodName, returnType, initializer);
 			methodMap.put(operation.simpleName, operation);
 		}
-		
+
 		return methodMap.get(methodName);
 	}
-	
-	override JvmOperation getOrGenerateMethod(String methodName, JvmTypeReference returnType, Procedure1<? super JvmOperation> initializer) {
+
+	override JvmOperation getOrGenerateMethod(String methodName, JvmTypeReference returnType,
+		Procedure1<? super JvmOperation> initializer) {
 		if (!methodMap.containsKey(methodName)) {
 			val operation = generateUnassociatedMethod(methodName, returnType, initializer);
 			methodMap.put(operation.simpleName, operation);
 		}
-		
+
 		return methodMap.get(methodName);
 	}
-	
+
 	protected def Iterable<JvmOperation> getGeneratedMethods() {
 		return methodMap.values;
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ClassGenerator.xtend
@@ -22,7 +22,9 @@ abstract class ClassGenerator extends TypesBuilderExtensionProvider implements I
 		this.methodMap = new HashMap<String, JvmOperation>();
 	}
 	
-	public def JvmGenericType generateClass();
+	def JvmGenericType generateClass()
+	
+	def JvmGenericType generateBody(JvmGenericType generatedClass) {}
 	
 	override JvmOperation getOrGenerateMethod(EObject contextObject, String methodName, JvmTypeReference returnType, Procedure1<? super JvmOperation> initializer) {
 		if (!methodMap.containsKey(methodName)) {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ExecutorClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ExecutorClassGenerator.xtend
@@ -16,7 +16,7 @@ class ExecutorClassGenerator extends ClassGenerator {
 		this.reactionsSegment = reactionsSegment;
 	}
 	
-	override generateClass() {
+	override generateEmptyClass() {
 		val executorNameGenerator = reactionsSegment.executorClassNameGenerator;
 		reactionsSegment.toClass(executorNameGenerator.qualifiedName) [
 			superTypes += typeRef(AbstractReactionsExecutor);

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
@@ -46,8 +46,8 @@ class ReactionClassGenerator extends ClassGenerator {
 			reactionClassNameGenerator.qualifiedName + "." + EFFECT_USER_EXECUTION_SIMPLE_NAME);
 	}
 		
-	public override JvmGenericType generateClass() {
-		userExecutionClass = userExecutionClassGenerator.generateClass()
+	public override JvmGenericType generateEmptyClass() {
+		userExecutionClass = userExecutionClassGenerator.generateEmptyClass()
 		reaction.toClass(reactionClassNameGenerator.qualifiedName) [
 			visibility = JvmVisibility.DEFAULT
 		]

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
@@ -21,14 +21,15 @@ import tools.vitruv.dsls.reactions.codegen.typesbuilder.TypesBuilderExtensionPro
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
 
 class ReactionClassGenerator extends ClassGenerator {
-	protected final Reaction reaction;
-	protected final ChangeTypeRepresentation changeTypeRepresentation;
-	protected final AtomicChangeTypeRepresentation relevantAtomicChangeTypeRepresentation;
-	protected final boolean hasPreconditionBlock;
-	private final ClassNameGenerator reactionClassNameGenerator;
-	private final UserExecutionClassGenerator userExecutionClassGenerator;
-	private final ClassNameGenerator routinesFacadeClassNameGenerator;
-	private final static val typedChangeVariableName = "typedChange";
+	protected final Reaction reaction
+	protected final ChangeTypeRepresentation changeTypeRepresentation
+	protected final AtomicChangeTypeRepresentation relevantAtomicChangeTypeRepresentation
+	protected final boolean hasPreconditionBlock
+	private final ClassNameGenerator reactionClassNameGenerator
+	private final UserExecutionClassGenerator userExecutionClassGenerator
+	private final ClassNameGenerator routinesFacadeClassNameGenerator
+	private final static val typedChangeVariableName = "typedChange"
+	var JvmGenericType userExecutionClass
 	
 	new(Reaction reaction, TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
 		super(typesBuilderExtensionProvider);
@@ -46,16 +47,22 @@ class ReactionClassGenerator extends ClassGenerator {
 	}
 		
 	public override JvmGenericType generateClass() {
-		generateMethodGetExpectedChangeType();
-		generateMethodCheckPrecondition();
-		generateMethodExecuteReaction();
-				
+		userExecutionClass = userExecutionClassGenerator.generateClass()
 		reaction.toClass(reactionClassNameGenerator.qualifiedName) [
-			visibility = JvmVisibility.DEFAULT;
-			superTypes += typeRef(AbstractReactionRealization);
-			members += generatedMethods;
-			members += userExecutionClassGenerator.generateClass();
-		];
+			visibility = JvmVisibility.DEFAULT
+		]
+	}
+	
+	override generateBody(JvmGenericType generatedClass) {
+		generateMethodGetExpectedChangeType()
+		generateMethodCheckPrecondition()
+		generateMethodExecuteReaction()
+		
+		generatedClass => [
+			superTypes += typeRef(AbstractReactionRealization)
+			members += generatedMethods
+			members += userExecutionClassGenerator.generateBody(userExecutionClass)
+		]
 	}
 	
 	protected def generateMethodGetExpectedChangeType() {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
@@ -82,12 +82,12 @@ class RoutineClassGenerator extends ClassGenerator {
 	protected def getParameterCallList(String... parameterStrings) '''
 	«FOR parameterName : parameterStrings SEPARATOR ', '»«parameterName»«ENDFOR»'''
 
-	override JvmGenericType generateClass() {
+	override JvmGenericType generateEmptyClass() {
 		if (routine === null) {
 			return null;
 		}
 
-		userExecutionClass = userExecutionClassGenerator.generateClass()
+		userExecutionClass = userExecutionClassGenerator.generateEmptyClass()
 		routine.toClass(routineClassNameGenerator.qualifiedName) [
 			visibility = JvmVisibility.PUBLIC
 		]

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
@@ -22,7 +22,7 @@ class RoutineFacadeClassGenerator extends ClassGenerator {
 		this.routinesFacadeNameGenerator = reactionsSegment.routinesFacadeClassNameGenerator
 	}
 	
-	public override generateClass() {
+	public override generateEmptyClass() {
 		reactionsSegment.toClass(routinesFacadeNameGenerator.qualifiedName) []
 	}
 	

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
@@ -1,6 +1,5 @@
 package tools.vitruv.dsls.reactions.codegen.classgenerators
 
-import java.util.List
 import org.eclipse.xtext.common.types.JvmOperation
 import org.eclipse.xtext.common.types.JvmVisibility
 import static tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageConstants.*;
@@ -11,28 +10,33 @@ import tools.vitruv.extensions.dslsruntime.reactions.AbstractRepairRoutinesFacad
 import tools.vitruv.dsls.reactions.reactionsLanguage.ReactionsSegment
 import static extension tools.vitruv.dsls.reactions.codegen.helper.ClassNamesGenerators.*
 import tools.vitruv.dsls.reactions.codegen.typesbuilder.TypesBuilderExtensionProvider
+import org.eclipse.xtext.common.types.JvmGenericType
 
 class RoutineFacadeClassGenerator extends ClassGenerator {
-	private val List<Routine> routines;
-	private val ClassNameGenerator routinesFacadeNameGenerator;
+	val ReactionsSegment reactionsSegment
+	val ClassNameGenerator routinesFacadeNameGenerator;
 	
 	new(ReactionsSegment reactionsSegment, TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
 		super(typesBuilderExtensionProvider);
-		this.routines = reactionsSegment.routines;
-		this.routinesFacadeNameGenerator = reactionsSegment.routinesFacadeClassNameGenerator;
+		this.reactionsSegment = reactionsSegment
+		this.routinesFacadeNameGenerator = reactionsSegment.routinesFacadeClassNameGenerator
 	}
 	
 	public override generateClass() {
-		generateUnassociatedClass(routinesFacadeNameGenerator.qualifiedName) [
+		reactionsSegment.toClass(routinesFacadeNameGenerator.qualifiedName) []
+	}
+	
+	override generateBody(JvmGenericType generatedClass) {
+		generatedClass => [
 			superTypes += typeRef(AbstractRepairRoutinesFacade);
-			members += toConstructor() [
+			members += reactionsSegment.toConstructor() [
 				val reactionExecutionStateParameter = generateReactionExecutionStateParameter();
 				val calledByParameter = generateParameter(EFFECT_FACADE_CALLED_BY_FIELD_NAME, typeRef(CallHierarchyHaving));
 				parameters += reactionExecutionStateParameter;
 				parameters += calledByParameter;
 				body = '''super(«reactionExecutionStateParameter.name», «calledByParameter.name»);'''
 			]
-			members += routines.map[generateCallMethod];
+			members += reactionsSegment.routines.map[generateCallMethod];
 		]
 	}
 	

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
@@ -6,6 +6,7 @@ import org.eclipse.xtext.common.types.JvmVisibility
 import tools.vitruv.extensions.dslsruntime.reactions.structure.CallHierarchyHaving
 import org.eclipse.xtext.common.types.JvmOperation
 import tools.vitruv.dsls.reactions.reactionsLanguage.CodeBlock
+import tools.vitruv.dsls.reactions.generator.SimpleTextXBlockExpression
 import tools.vitruv.dsls.reactions.reactionsLanguage.Taggable
 import tools.vitruv.dsls.reactions.reactionsLanguage.ExistingElementReference
 import org.eclipse.xtext.common.types.JvmTypeReference
@@ -15,7 +16,7 @@ import tools.vitruv.extensions.dslsruntime.reactions.AbstractRepairRoutineRealiz
 import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveModelElement
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
 import tools.vitruv.dsls.reactions.codegen.typesbuilder.TypesBuilderExtensionProvider
-import tools.vitruv.dsls.reactions.generator.SimpleTextXBlockExpression
+import org.eclipse.xtext.common.types.JvmGenericType
 
 class UserExecutionClassGenerator extends ClassGenerator {
 	private val EObject objectMappedToClass;
@@ -25,8 +26,9 @@ class UserExecutionClassGenerator extends ClassGenerator {
 	private var int counterGetRetrieveTagMethods;
 	private var int counterCallRoutineMethods;
 	private var int counterCheckMatcherPreconditionMethods;
-	
-	new(TypesBuilderExtensionProvider typesBuilderExtensionProvider, EObject objectMappedToClass, String qualifiedClassName) {
+
+	new(TypesBuilderExtensionProvider typesBuilderExtensionProvider, EObject objectMappedToClass,
+		String qualifiedClassName) {
 		super(typesBuilderExtensionProvider)
 		this.objectMappedToClass = objectMappedToClass;
 		this.qualifiedClassName = qualifiedClassName;
@@ -36,30 +38,40 @@ class UserExecutionClassGenerator extends ClassGenerator {
 		this.counterCallRoutineMethods = 1;
 		this.counterCheckMatcherPreconditionMethods = 1;
 	}
-	
+
 	public def String getQualifiedClassName() {
 		return qualifiedClassName;
 	}
-	
+
 	override generateClass() {
 		return objectMappedToClass.toClass(qualifiedClassName) [
-			visibility = JvmVisibility.PRIVATE;
-			static = true;
-			superTypes += typeRef(AbstractRepairRoutineRealization.UserExecution);
-			members += toConstructor() [
-				val reactionExecutionStateParameter = generateReactionExecutionStateParameter();
-				val calledByParameter = generateParameter("calledBy", typeRef(CallHierarchyHaving));
-				parameters += reactionExecutionStateParameter;
-				parameters += calledByParameter;
-				body = '''
-					super(«parameters.get(0).name»);
-				'''
-			]
-			members += generatedMethods;
+			visibility = JvmVisibility.PRIVATE
+			static = true
 		]
 	}
 
-	protected def JvmOperation generateUpdateElementMethod(String elementName, CodeBlock codeBlock, Iterable<AccessibleElement> accessibleElements) {
+	override generateBody(JvmGenericType generatedClass) {
+		generatedClass => [
+			superTypes += typeRef(AbstractRepairRoutineRealization.UserExecution)
+			members += generateConstructor()
+			members += generatedMethods
+		]
+	}
+
+	def private generateConstructor() {
+		objectMappedToClass.toConstructor() [
+			val reactionExecutionStateParameter = generateReactionExecutionStateParameter()
+			val calledByParameter = generateParameter("calledBy", typeRef(CallHierarchyHaving))
+			parameters += reactionExecutionStateParameter
+			parameters += calledByParameter
+			body = '''
+				super(«parameters.get(0).name»);
+			'''
+		]
+	}
+
+	protected def JvmOperation generateUpdateElementMethod(String elementName, CodeBlock codeBlock,
+		Iterable<AccessibleElement> accessibleElements) {
 		return codeBlock.getOrGenerateMethod("update" + elementName.toFirstUpper + "Element", typeRef(Void.TYPE)) [
 			parameters += generateAccessibleElementsParameters(accessibleElements);
 			val code = codeBlock.code;
@@ -68,28 +80,31 @@ class UserExecutionClassGenerator extends ClassGenerator {
 			} else {
 				body = code;
 			}
-		] 
+		]
 	}
-	
-	protected def JvmOperation generateMethodGetRetrieveTag(Taggable taggable, Iterable<AccessibleElement> accessibleElements) {
+
+	protected def JvmOperation generateMethodGetRetrieveTag(Taggable taggable,
+		Iterable<AccessibleElement> accessibleElements) {
 		val methodName = "getRetrieveTag" + counterGetRetrieveTagMethods++;
-		
+
 		return taggable.tag.getOrGenerateMethod(methodName, typeRef(String)) [
 			parameters += generateAccessibleElementsParameters(accessibleElements);
 			body = taggable.tag.code;
-		];		
+		];
 	}
-	
-	protected def JvmOperation generateMethodGetCreateTag(Taggable taggable, Iterable<AccessibleElement> accessibleElements) {
+
+	protected def JvmOperation generateMethodGetCreateTag(Taggable taggable,
+		Iterable<AccessibleElement> accessibleElements) {
 		val methodName = "getTag" + counterGetTagMethods++;
-		
+
 		return taggable.tag.getOrGenerateMethod(methodName, typeRef(String)) [
 			parameters += generateAccessibleElementsParameters(accessibleElements);
 			body = taggable.tag.code;
-		];		
+		];
 	}
-	
-	protected def generateMethodCorrespondencePrecondition(RetrieveModelElement elementRetrieve, Iterable<AccessibleElement> accessibleElements) {
+
+	protected def generateMethodCorrespondencePrecondition(RetrieveModelElement elementRetrieve,
+		Iterable<AccessibleElement> accessibleElements) {
 		val methodName = "getCorrespondingModelElementsPrecondition" + elementRetrieve.name.toFirstUpper;
 		return elementRetrieve.precondition.getOrGenerateMethod(methodName, typeRef(Boolean.TYPE)) [
 			val elementParameter = generateModelElementParameter(elementRetrieve, elementRetrieve.name);
@@ -98,10 +113,11 @@ class UserExecutionClassGenerator extends ClassGenerator {
 			body = elementRetrieve.precondition.code;
 		];
 	}
-	
-	protected def generateMethodGetCorrespondenceSource(RetrieveModelElement elementRetrieve, Iterable<AccessibleElement> accessibleElements) {
+
+	protected def generateMethodGetCorrespondenceSource(RetrieveModelElement elementRetrieve,
+		Iterable<AccessibleElement> accessibleElements) {
 		val methodName = "getCorrepondenceSource" + elementRetrieve.name.toFirstUpper;
-		
+
 		return elementRetrieve.correspondenceSource.getOrGenerateMethod(methodName, typeRef(EObject)) [
 			parameters += generateAccessibleElementsParameters(accessibleElements);
 			val correspondenceSourceBlock = elementRetrieve.correspondenceSource?.code;
@@ -112,10 +128,11 @@ class UserExecutionClassGenerator extends ClassGenerator {
 			}
 		];
 	}
-	
-	protected def generateMethodGetElement(ExistingElementReference reference, Iterable<AccessibleElement> accessibleElements) {
+
+	protected def generateMethodGetElement(ExistingElementReference reference,
+		Iterable<AccessibleElement> accessibleElements) {
 		val methodName = "getElement" + counterGetElementMethods++;
-		
+
 		return reference.code.getOrGenerateMethod(methodName, typeRef(EObject)) [
 			parameters += generateAccessibleElementsParameters(accessibleElements);
 			val correspondenceSourceBlock = reference?.code;
@@ -126,16 +143,18 @@ class UserExecutionClassGenerator extends ClassGenerator {
 			}
 		];
 	}
-	
-	protected def JvmOperation generateMethodMatcherPrecondition(MatcherCheckStatement checkStatement, Iterable<AccessibleElement> accessibleElements) {
+
+	protected def JvmOperation generateMethodMatcherPrecondition(MatcherCheckStatement checkStatement,
+		Iterable<AccessibleElement> accessibleElements) {
 		val methodName = "checkMatcherPrecondition" + counterCheckMatcherPreconditionMethods++;
 		return checkStatement.getOrGenerateMethod(methodName, typeRef(Boolean.TYPE)) [
 			parameters += generateAccessibleElementsParameters(accessibleElements);
 			body = checkStatement.code;
 		];
 	}
-	
-	protected def JvmOperation generateMethodCallRoutine(RoutineCallBlock routineCall, Iterable<AccessibleElement> accessibleElements, JvmTypeReference facadeClassTypeReference) {
+
+	protected def JvmOperation generateMethodCallRoutine(RoutineCallBlock routineCall,
+		Iterable<AccessibleElement> accessibleElements, JvmTypeReference facadeClassTypeReference) {
 		if (routineCall.code === null) {
 			return null;
 		}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
@@ -43,7 +43,7 @@ class UserExecutionClassGenerator extends ClassGenerator {
 		return qualifiedClassName;
 	}
 
-	override generateClass() {
+	override generateEmptyClass() {
 		return objectMappedToClass.toClass(qualifiedClassName) [
 			visibility = JvmVisibility.PRIVATE
 			static = true

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/jvmmodel/ReactionsLanguageJvmModelInferrer.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/jvmmodel/ReactionsLanguageJvmModelInferrer.xtend
@@ -15,6 +15,7 @@ import tools.vitruv.dsls.reactions.reactionsLanguage.ReactionsFile
 import tools.vitruv.dsls.reactions.codegen.typesbuilder.JvmTypesBuilderWithoutAssociations
 import tools.vitruv.dsls.reactions.codegen.typesbuilder.TypesBuilderExtensionProvider
 import tools.vitruv.dsls.reactions.codegen.classgenerators.ReactionClassGenerator
+import tools.vitruv.dsls.reactions.codegen.classgenerators.ClassGenerator
 
 /**
  * <p>Infers a JVM model for the Xtend code blocks of the reaction file model.</p> 
@@ -28,44 +29,36 @@ class ReactionsLanguageJvmModelInferrer extends AbstractModelInferrer  {
 	@Inject extension JvmTypesBuilderWithoutAssociations _typesBuilder
 	@Inject TypesBuilderExtensionProvider typesBuilderExtensionProvider;
 	
+	
 	private def void updateBuilders() {
 		typesBuilderExtensionProvider.setBuilders(_typesBuilder, _typeReferenceBuilder, _annotationTypesBuilder);
 	}
 	
 	def dispatch void generate(Reaction reaction, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
-		if (isPreIndexingPhase) {
-			return;
-		}
-		
-		val reactionClassGenerator = new ReactionClassGenerator(reaction, typesBuilderExtensionProvider);
-		acceptor.accept(reactionClassGenerator.generateClass());
+		acceptor.accept(new ReactionClassGenerator(reaction, typesBuilderExtensionProvider));
 	}
 	
 	def dispatch void generate(Routine routine, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
-		if (isPreIndexingPhase) {
-			return;
-		}
-		
-		acceptor.accept(new RoutineClassGenerator(routine, typesBuilderExtensionProvider).generateClass());
+		acceptor.accept(new RoutineClassGenerator(routine, typesBuilderExtensionProvider));
 	}
 	
 	def dispatch void infer(ReactionsFile file, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
-		if (isPreIndexingPhase) {
-			return;
-		}
 		updateBuilders();
 		
 		for (reactionsSegment : file.reactionsSegments) {
-			acceptor.accept(new RoutineFacadeClassGenerator(reactionsSegment, typesBuilderExtensionProvider).generateClass());
+			acceptor.accept(new RoutineFacadeClassGenerator(reactionsSegment, typesBuilderExtensionProvider));
 			for (effect : reactionsSegment.routines) {
 				generate(effect, acceptor, isPreIndexingPhase);
 			}
 			for (reaction : reactionsSegment.reactions) {
 				generate(reaction, acceptor, isPreIndexingPhase);
 			}
-			acceptor.accept(new ExecutorClassGenerator(reactionsSegment, typesBuilderExtensionProvider).generateClass());			
+			acceptor.accept(new ExecutorClassGenerator(reactionsSegment, typesBuilderExtensionProvider));			
 		}
 
 	}
-
+	
+	def private static accept(IJvmDeclaredTypeAcceptor acceptor, extension ClassGenerator generator) {
+		acceptor.accept(generator.generateClass()) [generateBody]
+	}
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/jvmmodel/ReactionsLanguageJvmModelInferrer.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/jvmmodel/ReactionsLanguageJvmModelInferrer.xtend
@@ -59,6 +59,6 @@ class ReactionsLanguageJvmModelInferrer extends AbstractModelInferrer  {
 	}
 	
 	def private static accept(IJvmDeclaredTypeAcceptor acceptor, extension ClassGenerator generator) {
-		acceptor.accept(generator.generateClass()) [generateBody]
+		acceptor.accept(generator.generateEmptyClass()) [generateBody]
 	}
 }


### PR DESCRIPTION
:warning: Contains the changes of #101, do **not** merge before #101 :warning: 
(and reviewing will also be a lot easier once #101 is merged)

JVM Model inference should [happen in two phases](https://www.eclipse.org/Xtext/documentation/305_xbase.html#xbase-inferred-type): 

 1. Create empty classes so they can be found when linking
 2. After linking is done, generate the bodies

The reaction language did not follow this pattern, which had some bad consequences:

 * Eclipse showed error that were directly disappearing
 * When building the language through the generator, links to routines could not be resolved

This PR fixes that.