### PR TITLE
Reactions Tests Improvements

### DIFF
--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
@@ -32,7 +32,8 @@ Require-Bundle: org.junit,
  org.eclipse.xtext.testing;bundle-version="2.12.0",
  org.eclipse.xtext.xbase.testing,
  tools.vitruv.extensions.emf;bundle-version="0.2.0",
- org.eclipse.xtext.xtext.generator;bundle-version="2.12.0"
+ org.eclipse.xtext.xtext.generator;bundle-version="2.12.0",
+ org.eclipse.jdt.core;bundle-version="3.13.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0",

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/generator/ReactionsGeneratorTest.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/generator/ReactionsGeneratorTest.xtend
@@ -1,4 +1,4 @@
-package tools.vitruv.dsls.reactions.tests.manualTests
+package tools.vitruv.dsls.reactions.generator
 
 import org.junit.Test
 import com.google.inject.Provider

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangeReactionsCompiler.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangeReactionsCompiler.xtend
@@ -28,8 +28,8 @@ class SimpleChangeReactionsCompiler {
 	static var Supplier<? extends ChangePropagationSpecification> SIMPLE_CHANGES_PROPGATION_SPEC_SUPLLIER
 	static val String COMPLIANCE_LEVEL = "1.8";
 
-	static val compilationPackageFolders = #['tools/vitruv', 'org/eclipse/xtext/xbase', 'allElementTypes',
-		'com/google/common', 'org/eclipse/emf', 'org/apache/log4j']
+	static val compilationPackageFolders = #['tools/vitruv', 'org/eclipse/xtext/xbase/lib', 'allElementTypes',
+		'com/google/common/base', 'org/eclipse/emf/ecore', 'org/eclipse/emf/common/util', 'org/apache/log4j']
 
 	static var compiled = false
 

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangeReactionsCompiler.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangeReactionsCompiler.xtend
@@ -8,7 +8,6 @@ import com.google.inject.Provider
 import java.util.function.Supplier
 import tools.vitruv.framework.change.processing.ChangePropagationSpecification
 import java.nio.file.Files
-import org.eclipse.core.runtime.Platform
 import org.osgi.framework.wiring.BundleWiring
 import com.google.common.io.ByteStreams
 import java.io.FileOutputStream
@@ -20,6 +19,7 @@ import org.eclipse.xtext.generator.JavaIoFileSystemAccess
 import org.eclipse.emf.common.util.URI
 import org.eclipse.jdt.core.compiler.batch.BatchCompiler
 import java.io.PrintWriter
+import org.osgi.framework.FrameworkUtil
 
 class SimpleChangeReactionsCompiler {
 	static val INPUT_REACTION_FILES = #["SimpleChangesTests.reactions", "SimpleChangesRootTests.reactions"]
@@ -61,7 +61,7 @@ class SimpleChangeReactionsCompiler {
 
 	def private compileGeneratedJavaClasses(Path outputFolder) {
 		// copy in compile dependencies
-		val bundle = Platform.getBundle('tools.vitruv.dsls.reactions.tests')
+		val bundle = FrameworkUtil.getBundle(SimpleChangeReactionsCompiler)
 		val availableClassFiles = bundle.adapt(BundleWiring).listResources('/', '*.class',
 			BundleWiring.LISTRESOURCES_RECURSE)
 		val neededClassFiles = availableClassFiles.filter [ classFile |

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangeReactionsCompiler.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangeReactionsCompiler.xtend
@@ -79,7 +79,7 @@ class SimpleChangeReactionsCompiler {
 		val out = new ByteArrayOutputStream
 		val err = out
 		val ioFolder = outputFolder.toAbsolutePath.toString
-		val success = BatchCompiler.compile(#["-" + COMPLIANCE_LEVEL, "-d", ioFolder, "-classpath", ioFolder, ioFolder],
+		val success = BatchCompiler.compile(#["-" + COMPLIANCE_LEVEL, "-d", ioFolder, "-classpath", ioFolder, "-proc:none", ioFolder],
 			new PrintWriter(out), new PrintWriter(err), null)
 
 		if (!success) {


### PR DESCRIPTION
 * Use the Eclipse compiler instead of the one from the JDK so tests also work in a JRE 
 * Reduce the amount of files copied in for compilation from 30 MB to 9.5MB
 * Fix package declaration (why did it even compile with the wrong one?) 