### PR TITLE
New EPackage Scope for MirBase

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.mirbase/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.pde.core,
  org.eclipse.core.runtime,
  tools.vitruv.dsls.common,
- tools.vitruv.framework.metamodel
+ tools.vitruv.framework.metamodel,
+ edu.kit.ipd.sdq.activextendannotations;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: tools.vitruv.dsls.mirbase.jvmmodel,
  tools.vitruv.dsls.mirbase.mirBase.impl,

--- a/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/scoping/EPackageRegistryScope.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/scoping/EPackageRegistryScope.xtend
@@ -1,0 +1,105 @@
+package tools.vitruv.dsls.mirbase.scoping
+
+import org.eclipse.xtext.scoping.IScope
+import org.eclipse.xtext.naming.QualifiedName
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.resource.IEObjectDescription
+import org.eclipse.emf.ecore.EPackage
+import com.google.inject.Singleton
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.resource.EObjectDescription
+import com.google.inject.Inject
+import org.eclipse.xtext.naming.IQualifiedNameConverter
+import edu.kit.ipd.sdq.activextendannotations.Lazy
+
+@Singleton
+class EPackageRegistryScope implements IScope {
+	@Inject
+	extension IQualifiedNameConverter qualifiedNameConverter
+
+	override getAllElements() {
+		allDescriptions.filter[exists]
+	}
+
+	def allEPackages() {
+		allDescriptions.filter[exists].map[EObjectOrProxy]
+	}
+
+	def private getAvailableEPackageUris() {
+		EPackage.Registry.INSTANCE.keySet
+	}
+
+	def private getAllDescriptions() {
+		availableEPackageUris.map[getDescription]
+	}
+
+	def private IEObjectDescription getDescription(String uri) {
+		new EPackageDescription(uri.toQualifiedName)
+	}
+
+	override getElements(QualifiedName name) {
+		val el = getSingleElement(name)
+		if (el === null) #[] else #[el]
+	}
+
+	override getElements(EObject object) {
+		#[getSingleElement(object)].filterNull
+	}
+
+	override getSingleElement(QualifiedName name) {
+		if (!EPackage.Registry.INSTANCE.containsKey(name.toString)) return null
+		val package = new EPackageDescription(name)
+		if (package.exists) package else null
+	}
+
+	override getSingleElement(EObject object) {
+		// allow using existing, not registered packages too (only relevant
+		// when artificially creating mirbase files)
+		if (object instanceof EPackage) {
+			return EObjectDescription.create(object.nsURI.toQualifiedName, object)
+		}
+		return null
+	}
+
+	def private static exists(IEObjectDescription description) {
+		description.EObjectOrProxy !== null
+	}
+
+	private static class EPackageDescription implements IEObjectDescription {
+
+		val QualifiedName uriName
+		@Lazy val EPackage ePackage = EPackage::Registry.INSTANCE.getEPackage(uriName.toString)
+
+		new(QualifiedName name) {
+			this.uriName = name
+		}
+
+		override getEClass() {
+			getEPackage.eClass
+		}
+
+		override getEObjectOrProxy() {
+			getEPackage
+		}
+
+		override getEObjectURI() {
+			URI.createURI(getEPackage.nsURI)
+		}
+
+		override getQualifiedName() {
+			uriName
+		}
+
+		override getUserData(String key) {
+			null
+		}
+
+		override getUserDataKeys() {
+			#[]
+		}
+
+		override getName() {
+			uriName
+		}
+	}
+}

--- a/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/scoping/MirBaseGlobalScopeProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/scoping/MirBaseGlobalScopeProvider.xtend
@@ -1,52 +1,26 @@
 package tools.vitruv.dsls.mirbase.scoping
 
 import com.google.common.base.Predicate
-import com.google.inject.Inject
-import java.util.Collections
-import org.eclipse.emf.common.util.URI
-import org.eclipse.emf.ecore.EPackage
 import org.eclipse.emf.ecore.EReference
-import org.eclipse.emf.ecore.EcoreFactory
-import org.eclipse.emf.ecore.InternalEObject
 import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.naming.IQualifiedNameConverter
-import org.eclipse.xtext.resource.EObjectDescription
 import org.eclipse.xtext.resource.IEObjectDescription
-import org.eclipse.xtext.scoping.IScope
-import org.eclipse.xtext.scoping.impl.SimpleScope
 
 import static tools.vitruv.dsls.mirbase.mirBase.MirBasePackage.Literals.*
 import org.eclipse.xtext.common.types.xtext.TypesAwareDefaultGlobalScopeProvider
+import com.google.inject.Inject
+import com.google.inject.Provider
 
 class MirBaseGlobalScopeProvider extends TypesAwareDefaultGlobalScopeProvider {
-	@Inject
-	IQualifiedNameConverter qualifiedNameConverter
 	
-	private IScope packageScope = null;
+	@Inject Provider<EPackageRegistryScope> packagesScope
 	
 	override getScope(Resource resource, EReference reference) {
 		super.getScope(resource, reference)
 	}
 	
-	private def getPackageScope() {
-		if (packageScope === null)
-			packageScope = new SimpleScope(IScope.NULLSCOPE,
-				EPackage.Registry.INSTANCE.keySet.map [
-					from |
-					val InternalEObject proxyPackage = EcoreFactory.eINSTANCE.createEPackage as InternalEObject;
-					proxyPackage.eSetProxyURI(URI.createURI(from));
-					return EObjectDescription.create(
-						qualifiedNameConverter.toQualifiedName(from),
-						proxyPackage, Collections.singletonMap("nsURI", "true")
-					);
-				])
-		
-		return packageScope
-	}
-	
 	override getScope(Resource resource, EReference ref, Predicate<IEObjectDescription> filter) {
 		if (ref.equals(METAMODEL_IMPORT__PACKAGE)) {
-			return getPackageScope
+			return packagesScope.get()
 		}
 		
 		return super.getScope(resource, ref, filter)


### PR DESCRIPTION
Allows to use existing, not registered ePackages in reactions files, which is relevant when artificially building reactions (the user will see no difference).