### PR TITLE
Formatters for MirBase and Reactions

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.mirbase/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase/META-INF/MANIFEST.MF
@@ -22,16 +22,17 @@ Require-Bundle: org.eclipse.xtext,
  tools.vitruv.dsls.common,
  tools.vitruv.framework.metamodel
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: tools.vitruv.dsls.mirbase.jvmmodel,
+Export-Package: tools.vitruv.dsls.mirbase,
+ tools.vitruv.dsls.mirbase.formatting,
+ tools.vitruv.dsls.mirbase.jvmmodel,
+ tools.vitruv.dsls.mirbase.mirBase,
  tools.vitruv.dsls.mirbase.mirBase.impl,
  tools.vitruv.dsls.mirbase.mirBase.util,
- tools.vitruv.dsls.mirbase.mirBase,
  tools.vitruv.dsls.mirbase.parser.antlr,
  tools.vitruv.dsls.mirbase.parser.antlr.internal,
  tools.vitruv.dsls.mirbase.scoping,
  tools.vitruv.dsls.mirbase.serializer,
  tools.vitruv.dsls.mirbase.services,
- tools.vitruv.dsls.mirbase.validation,
- tools.vitruv.dsls.mirbase
+ tools.vitruv.dsls.mirbase.validation
 Import-Package: org.apache.log4j
 Bundle-Vendor: vitruv.tools

--- a/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/formatting/MirBaseFormatter.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/formatting/MirBaseFormatter.xtend
@@ -1,0 +1,28 @@
+package tools.vitruv.dsls.mirbase.formatting
+
+import org.eclipse.xtext.formatting2.AbstractFormatter2
+import org.eclipse.xtext.formatting2.IFormattableDocument
+import tools.vitruv.dsls.mirbase.mirBase.MirBaseFile
+import tools.vitruv.dsls.mirbase.mirBase.MetaclassReference
+import tools.vitruv.dsls.mirbase.mirBase.MetaclassEAttributeReference
+
+class MirBaseFormatter extends AbstractFormatter2 {
+	
+	def dispatch format(MirBaseFile mirBaseFile, extension IFormattableDocument document) {
+		mirBaseFile.formatStatic(document)
+	}
+	
+	def protected void formatStatic(MirBaseFile mirBaseFile, extension IFormattableDocument document) {
+		mirBaseFile.metamodelImports.tail.forEach [prepend [newLine]]
+	}
+	
+	def protected void formatStatic(MetaclassReference metaclassReference, extension IFormattableDocument document) {
+		metaclassReference.regionFor.keyword('::').prepend[noSpace].append[noSpace]
+	}
+	
+	def protected void formatStatic(MetaclassEAttributeReference attributeReference, extension IFormattableDocument document) {
+		(attributeReference as MetaclassReference).formatStatic(document)
+		attributeReference.regionFor.keyword('[').prepend[noSpace].append[noSpace]
+		attributeReference.regionFor.keyword(']').prepend[noSpace]
+	}
+}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguageRuntimeModule.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguageRuntimeModule.xtend
@@ -14,6 +14,8 @@ import tools.vitruv.dsls.reactions.scoping.ReactionsLanguageGlobalScopeProvider
 import tools.vitruv.dsls.mirbase.scoping.MirBaseQualifiedNameConverter
 import org.eclipse.xtext.generator.IGenerator2
 import tools.vitruv.dsls.reactions.generator.ReactionsLanguageGenerator
+import org.eclipse.xtext.formatting2.IFormatter2
+import tools.vitruv.dsls.reactions.formatting.ReactionsLanguageFormatter
 
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
@@ -41,8 +43,14 @@ class ReactionsLanguageRuntimeModule extends AbstractReactionsLanguageRuntimeMod
 		ReactionsLanguageGenerator
 	}
 	
+	def Class<? extends IFormatter2> bindIFormatter2() {
+		ReactionsLanguageFormatter
+	}
+	
 	override configure(Binder binder) {
 		super.configure(binder);
-		binder.bind(IGenerator2).to(bindIGenerator2());
+		
+		binder.bind(IFormatter2).to(bindIFormatter2)		
 	}
+	
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/formatting/ReactionsLanguageFormatter.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/formatting/ReactionsLanguageFormatter.xtend
@@ -1,0 +1,123 @@
+package tools.vitruv.dsls.reactions.formatting
+
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.formatting2.IFormattableDocument
+import tools.vitruv.dsls.mirbase.formatting.MirBaseFormatter
+import tools.vitruv.dsls.mirbase.mirBase.MetaclassReference
+import tools.vitruv.dsls.mirbase.mirBase.MirBaseFile
+import tools.vitruv.dsls.reactions.reactionsLanguage.Action
+import tools.vitruv.dsls.reactions.reactionsLanguage.ActionStatement
+import tools.vitruv.dsls.reactions.reactionsLanguage.CreateModelElement
+import tools.vitruv.dsls.reactions.reactionsLanguage.Matcher
+import tools.vitruv.dsls.reactions.reactionsLanguage.ModelAttributeChange
+import tools.vitruv.dsls.reactions.reactionsLanguage.ModelElementChange
+import tools.vitruv.dsls.reactions.reactionsLanguage.Reaction
+import tools.vitruv.dsls.reactions.reactionsLanguage.ReactionsFile
+import tools.vitruv.dsls.reactions.reactionsLanguage.ReactionsSegment
+import tools.vitruv.dsls.reactions.reactionsLanguage.Routine
+import tools.vitruv.dsls.reactions.reactionsLanguage.Trigger
+import tools.vitruv.dsls.reactions.reactionsLanguage.MatcherStatement
+import tools.vitruv.dsls.reactions.reactionsLanguage.RoutineInput
+import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveModelElement
+
+class ReactionsLanguageFormatter extends MirBaseFormatter {
+
+	def dispatch void format(ReactionsFile reactionsFile, extension IFormattableDocument document) {
+		(reactionsFile as MirBaseFile).formatStatic(document)
+		reactionsFile.formatStatic(document)
+	}
+
+	def formatStatic(ReactionsFile reactionsFile, extension IFormattableDocument document) {
+		reactionsFile.reactionsSegments.forEach [formatStatic(document)]
+	}
+
+	def formatStatic(ReactionsSegment segment, extension IFormattableDocument document) {
+		segment.prepend [newLines = 3]
+		segment.regionFor.keyword('in reaction to changes in').prepend [newLine;indent]
+		segment.regionFor.keyword('execute actions in').prepend [newLine;indent]
+		segment.interior [indent]
+		segment.reactions.forEach [formatStatic(document)]
+		segment.routines.forEach [formatStatic(document)]
+	}
+
+	def formatStatic(Reaction reaction, extension IFormattableDocument document) {
+		reaction.prepend [newLines = 2]
+		if (reaction.documentation !== null) {
+			reaction.regionFor.keyword('reaction').prepend [newLine]
+		}
+		reaction.formatInteriorBlock(document)
+		reaction.trigger.formatStatic(document)
+		reaction.callRoutine.prepend [newLine]
+		reaction.callRoutine.code.regionFor.keyword('(').prepend [noSpace].append [noSpace]
+		reaction.callRoutine.code.regionFor.keyword(')').prepend [noSpace]
+	}
+	
+	def formatStatic(Trigger trigger, extension IFormattableDocument document) {
+		trigger.regionFor.keyword('with').prepend [newLine;indent]
+		trigger.format(document)
+	}
+	
+	def dispatch void format(ModelElementChange modelElementChange, extension IFormattableDocument document) {
+		modelElementChange.elementType.formatStatic(document)
+	}
+	
+	def dispatch void format(ModelAttributeChange modelAttributeChange, extension IFormattableDocument document) {
+		modelAttributeChange.feature.formatStatic(document)
+	}
+	
+	def formatStatic(Routine routine, extension IFormattableDocument document) {
+		routine.prepend [newLines = 2 ]
+		if (routine.documentation !== null) {
+			routine.regionFor.keyword('routine').prepend [newLine]
+		}
+		routine.input.formatStatic(document)
+		routine.formatInteriorBlock(document)
+		routine.matcher?.formatStatic(document)
+		routine.action.formatStatic(document)
+	}
+	
+	def formatStatic(RoutineInput routineInput, extension IFormattableDocument document) {
+		routineInput.regionFor.keyword('(').prepend [noSpace].append [noSpace]
+		routineInput.modelInputElements.forEach [formatStatic(document)]
+		routineInput.allRegionsFor.keyword(',').prepend [noSpace].append [oneSpace]
+		routineInput.regionFor.keyword(')').prepend [noSpace]
+	}
+	
+	def formatStatic(Matcher matcher, extension IFormattableDocument document) {
+		matcher.prepend [newLine]
+		matcher.formatInteriorBlock(document)
+		matcher.matcherStatements.forEach [formatStatic(document)]
+	}
+	
+	def formatStatic(MatcherStatement matcherStatement, extension IFormattableDocument document) {
+		matcherStatement.prepend [newLine]
+		matcherStatement.format(document)
+	}
+	
+	def dispatch void format(RetrieveModelElement retrieveStatement, extension IFormattableDocument document) {
+		(retrieveStatement as MetaclassReference).formatStatic(document)
+	}
+	
+	def formatStatic(Action action, extension IFormattableDocument document) {
+		action.prepend [newLine]
+		action.formatInteriorBlock(document)
+		action.actionStatements.forEach [formatStatic(document)]
+	}
+	
+	def formatStatic(ActionStatement actionStatement, extension IFormattableDocument document) {
+		actionStatement.prepend [newLine]
+		actionStatement.format(document)
+	}
+	
+	def dispatch void format(CreateModelElement createModelElement, extension IFormattableDocument document) {
+		(createModelElement as MetaclassReference).formatStatic(document)
+	}
+	
+	def formatInteriorBlock(EObject element, extension IFormattableDocument document) {
+		interior(
+			element.regionFor.keyword('{').append [newLine],
+        	element.regionFor.keyword('}').prepend [newLine],
+        	[indent]
+		)
+	}
+}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/formatting/ReactionsLanguageFormatter.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/formatting/ReactionsLanguageFormatter.xtend
@@ -29,13 +29,13 @@ class ReactionsLanguageFormatter extends MirBaseFormatter {
 
 	def formatStatic(ReactionsFile reactionsFile, extension IFormattableDocument document) {
 		reactionsFile.reactionsSegments.forEach [formatStatic(document)]
+		reactionsFile.reactionsSegments.head.prepend [newLines = 2]
+		reactionsFile.reactionsSegments.tail.forEach [prepend [newLines = 4]]
 	}
 
 	def formatStatic(ReactionsSegment segment, extension IFormattableDocument document) {
-		segment.prepend [newLines = 3]
-		segment.regionFor.keyword('in reaction to changes in').prepend [newLine;indent]
-		segment.regionFor.keyword('execute actions in').prepend [newLine;indent]
-		segment.interior [indent]
+		segment.regionFor.keyword('in reaction to changes in').prepend [newLine]
+		segment.regionFor.keyword('execute actions in').prepend [newLine]
 		segment.reactions.forEach [formatStatic(document)]
 		segment.routines.forEach [formatStatic(document)]
 	}


### PR DESCRIPTION
When serializing MirBase or Reactions models, they get serialized in one line. These formatters make the serialization result look pretty (personal opinion ;))

That is more important than you might first things, as validating artificially created language models is easiest done by serializing them. But the serialization result is only usable if it is properly formatted.

Reactions formatted by these formatters look like this:

```
import "http://vitruv.tools/commonalities/ObjectOrientation" as objectorientation
import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
import "http://www.emftext.org/java/classifiers" as classifiers


reactions: ClassToUML
	in reaction to changes in ObjectOrientation
	execute actions in UML

	reaction ClassDelete {
		after element objectorientation::Class deleted
		call classDeleteRepair(affectedEObject)
	}

	reaction ClassCreate {
		after element objectorientation::Class created
		call classCreateRepair(affectedEObject)
	}

	routine classDeleteRepair(objectorientation::Class affectedEObject) {
		match {
			val danglingCorrespondence = retrieve uml::Class corresponding to affectedEObject
		}
		action {
			delete danglingCorrespondence
		}
	}

	routine classCreateRepair(objectorientation::Class affectedEObject) {
		action {
			val newCorrespondence = create uml::Class
			add correspondence between affectedEObject and newCorrespondence
		}
}


reactions: ClassFromUML
	in reaction to changes in UML
	execute actions in ObjectOrientation

	reaction ClassDelete {
		after element uml::Class deleted
		call classDeleteRepair(affectedEObject)
	}

	reaction ClassCreate {
		after element uml::Class created
		call classCreateRepair(affectedEObject)
	}

	routine classDeleteRepair(uml::Class affectedEObject) {
		match {
			val danglingCorrespondence = retrieve objectorientation::Class corresponding to affectedEObject
		}
		action {
			delete danglingCorrespondence
		}
	}

	routine classCreateRepair(uml::Class affectedEObject) {
		action {
			val newCorrespondence = create objectorientation::Class
			add correspondence between affectedEObject and newCorrespondence
		}
}


reactions: ClassToJava
	in reaction to changes in ObjectOrientation
	execute actions in Java

	reaction ClassDelete {
		after element objectorientation::Class deleted
		call classDeleteRepair(affectedEObject)
	}

	reaction ClassCreate {
		after element objectorientation::Class created
		call classCreateRepair(affectedEObject)
	}

	routine classDeleteRepair(objectorientation::Class affectedEObject) {
		match {
			val danglingCorrespondence = retrieve classifiers::Class corresponding to affectedEObject
		}
		action {
			delete danglingCorrespondence
		}
	}

	routine classCreateRepair(objectorientation::Class affectedEObject) {
		action {
			val newCorrespondence = create classifiers::Class
			add correspondence between affectedEObject and newCorrespondence
		}
}


reactions: ClassFromJava
	in reaction to changes in Java
	execute actions in ObjectOrientation

	reaction ClassDelete {
		after element classifiers::Class deleted
		call classDeleteRepair(affectedEObject)
	}

	reaction ClassCreate {
		after element classifiers::Class created
		call classCreateRepair(affectedEObject)
	}

	routine classDeleteRepair(classifiers::Class affectedEObject) {
		match {
			val danglingCorrespondence = retrieve objectorientation::Class corresponding to affectedEObject
		}
		action {
			delete danglingCorrespondence
		}
	}

	routine classCreateRepair(classifiers::Class affectedEObject) {
		action {
			val newCorrespondence = create objectorientation::Class
			add correspondence between affectedEObject and newCorrespondence
		}
}
```

I unfortunately have no idea how to fix the last bracket (that should be indented by one).