### PR TITLE
Adaptions to the Reactions’ JVM Inferers

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/AtomicChangeTypeRepresentation.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/AtomicChangeTypeRepresentation.xtend
@@ -3,13 +3,10 @@ package tools.vitruv.dsls.reactions.codegen.changetyperepresentation
 import org.eclipse.emf.ecore.EStructuralFeature
 import org.eclipse.xtend2.lib.StringConcatenationClient
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
+import static tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageConstants.*
 
 public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 	public static final String changeName = "change";
-	public static final String affectedElementAttribute = "affectedEObject";
-	public static final String affectedFeatureAttribute = "affectedFeature";
-	public static final String oldValueAttribute = "oldValue";
-	public static final String newValueAttribute = "newValue";
 
 	protected final Class<?> changeType;
 	protected final String affectedElementClassCanonicalName
@@ -75,16 +72,16 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 	public def Iterable<AccessibleElement> generatePropertiesParameterList() {
 		val result = <AccessibleElement>newArrayList();
 		if (affectedElementClass !== null) {
-			result.add(new AccessibleElement(affectedElementAttribute, affectedElementClass));
+			result.add(new AccessibleElement(CHANGE_AFFECTED_ELEMENT_ATTRIBUTE, affectedElementClass));
 		}
 		if (affectedFeature !== null) {
-			result.add(new AccessibleElement(affectedFeatureAttribute, affectedFeature.eClass.instanceClass));
+			result.add(new AccessibleElement(CHANGE_AFFECTED_FEATURE_ATTRIBUTE, affectedFeature.eClass.instanceClass));
 		}
 		if (hasOldValue) {
-			result.add(new AccessibleElement(oldValueAttribute, affectedValueClass));
+			result.add(new AccessibleElement(CHANGE_OLD_VALUE_ATTRIBUTE, affectedValueClass));
 		}
 		if (hasNewValue) {
-			result.add(new AccessibleElement(newValueAttribute, affectedValueClass));
+			result.add(new AccessibleElement(CHANGE_NEW_VALUE_ATTRIBUTE, affectedValueClass));
 		}
 		if (result.empty) {
 			result.add(new AccessibleElement(changeName, changeType));
@@ -95,16 +92,16 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 	public def StringConcatenationClient generatePropertiesAssignmentCode(String typedChangeVariableName) {
 		'''
 			«IF affectedElementClass !== null»
-				«affectedElementClass» «affectedElementAttribute» = «typedChangeVariableName».get«affectedElementAttribute.toFirstUpper»();
+				«affectedElementClass» «CHANGE_AFFECTED_ELEMENT_ATTRIBUTE» = «typedChangeVariableName».get«CHANGE_AFFECTED_ELEMENT_ATTRIBUTE.toFirstUpper»();
 			«ENDIF»
 			«IF affectedFeature !== null»
-				«affectedFeature.eClass.instanceClass» «affectedFeatureAttribute» = «typedChangeVariableName».get«affectedFeatureAttribute.toFirstUpper»();
+				«affectedFeature.eClass.instanceClass» «CHANGE_AFFECTED_FEATURE_ATTRIBUTE» = «typedChangeVariableName».get«CHANGE_AFFECTED_FEATURE_ATTRIBUTE.toFirstUpper»();
 			«ENDIF»
 			«IF hasOldValue»
-				«affectedValueClass» «oldValueAttribute» = «typedChangeVariableName».get«oldValueAttribute.toFirstUpper»();
+				«affectedValueClass» «CHANGE_OLD_VALUE_ATTRIBUTE» = «typedChangeVariableName».get«CHANGE_OLD_VALUE_ATTRIBUTE.toFirstUpper»();
 			«ENDIF»
 			«IF hasNewValue»
-				«affectedValueClass» «newValueAttribute» = «typedChangeVariableName».get«newValueAttribute.toFirstUpper»();
+				«affectedValueClass» «CHANGE_NEW_VALUE_ATTRIBUTE» = «typedChangeVariableName».get«CHANGE_NEW_VALUE_ATTRIBUTE.toFirstUpper»();
 			«ENDIF»
 		'''
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/AtomicChangeTypeRepresentation.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/AtomicChangeTypeRepresentation.xtend
@@ -2,7 +2,6 @@ package tools.vitruv.dsls.reactions.codegen.changetyperepresentation
 
 import org.eclipse.emf.ecore.EStructuralFeature
 import org.eclipse.xtend2.lib.StringConcatenationClient
-import java.util.List
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
 
 public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
@@ -13,32 +12,32 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 	public static final String newValueAttribute = "newValue";
 
 	protected final Class<?> changeType;
-	protected final Class<?> affectedElementClass;
-	protected final Class<?> affectedValueClass;
+	protected final String affectedElementClassCanonicalName
+	protected final String affectedValueClassCanonicalName
 	protected final boolean hasOldValue;
 	protected final boolean hasNewValue;
 	protected final EStructuralFeature affectedFeature;
 
-	protected new(Class<?> changeType, Class<?> affectedElementClass, Class<?> affectedValueClass, boolean hasOldValue,
+	protected new(Class<?> changeType, String affectedElementClassCanonicalName, String affectedValueClassCanonicalName, boolean hasOldValue,
 		boolean hasNewValue, EStructuralFeature affectedFeature) {
-		this.changeType = changeType;
-		this.affectedElementClass = affectedElementClass.mapToNonPrimitiveType;
-		this.affectedValueClass = affectedValueClass.mapToNonPrimitiveType;
-		this.affectedFeature = affectedFeature;
-		this.hasOldValue = hasOldValue;
-		this.hasNewValue = hasNewValue;
+		this.changeType = changeType
+		this.affectedElementClassCanonicalName = affectedElementClassCanonicalName.mapToNonPrimitiveType
+		this.affectedValueClassCanonicalName = affectedValueClassCanonicalName.mapToNonPrimitiveType
+		this.affectedFeature = affectedFeature
+		this.hasOldValue = hasOldValue
+		this.hasNewValue = hasNewValue
 	}
 
 	public override Class<?> getChangeType() {
 		return changeType;
 	}
 
-	public def Class<?> getAffectedElementClass() {
-		return affectedElementClass;
+	def getAffectedElementClass() {
+		affectedElementClassCanonicalName;
 	}
 
-	public def Class<?> getAffectedValueClass() {
-		return affectedValueClass;
+	def getAffectedValueClass() {
+		affectedValueClassCanonicalName
 	}
 
 	public def EStructuralFeature getAffectedFeature() {
@@ -61,8 +60,8 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 		return hasNewValue;
 	}
 
-	public override List<Class<?>> getGenericTypeParameters() {
-		return #[affectedElementClass, affectedValueClass].filterNull.toList;
+	public override getGenericTypeParameters() {
+		#[affectedElementClassCanonicalName, affectedValueClassCanonicalName].filterNull
 	}
 
 	public override StringConcatenationClient getUntypedChangeTypeRepresentation() {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentation.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentation.xtend
@@ -1,8 +1,6 @@
 package tools.vitruv.dsls.reactions.codegen.changetyperepresentation
 
-import java.util.List
 import org.eclipse.xtend2.lib.StringConcatenationClient
-import java.util.Map
 
 /**
  * This class is responsible for representing the relevant change information for generating reactions
@@ -12,15 +10,11 @@ import java.util.Map
  */
 public abstract class ChangeTypeRepresentation {
 	
-	protected static def Class<?> mapToNonPrimitiveType(Class<?> potentiallyPrimitiveType) {
-		return 
-			if (primitveToWrapperTypesMap.containsKey(potentiallyPrimitiveType)) 
-				primitveToWrapperTypesMap.get(potentiallyPrimitiveType) 
-			else 
-				potentiallyPrimitiveType;
+	protected static def mapToNonPrimitiveType(String potentiallyPrimitiveTypeCName) {
+		return primitveToWrapperTypesMap.getOrDefault(potentiallyPrimitiveTypeCName, potentiallyPrimitiveTypeCName)
 	}	
 
-	private static Map<Class<?>, Class<?>> primitveToWrapperTypesMap = #{
+	static val primitveToWrapperTypesMap = newHashMap(#[
 		short -> Short,
 		int-> Integer,
 		long -> Long,
@@ -30,11 +24,11 @@ public abstract class ChangeTypeRepresentation {
 		char -> Character,
 		byte -> Byte,
 		void -> Void
-	}
+	].map [key.canonicalName -> value.canonicalName])
 
 	public def Class<?> getChangeType();
 
-	public def List<Class<?>> getGenericTypeParameters();
+	public def Iterable<String> getGenericTypeParameters()
 
 	public def StringConcatenationClient getUntypedChangeTypeRepresentation() {
 		return '''«changeType»'''

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentationExtractor.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentationExtractor.xtend
@@ -53,8 +53,8 @@ final class ChangeTypeRepresentationExtractor {
 				hasNewValue = true;
 			}
 		}
-		val affectedEObject = modelAttributeChange.feature.metaclass.instanceClass;
-		val affectedValue = modelAttributeChange.feature.feature.EType.instanceClass;
+		val affectedEObject = modelAttributeChange.feature.metaclass.instanceClassName
+		val affectedValue = modelAttributeChange.feature.feature.EType.instanceClassName
 		val affectedFeature = modelAttributeChange.feature.feature;
 		return new AtomicChangeTypeRepresentation(clazz.instanceClass, affectedEObject, affectedValue, hasOldValue, hasNewValue, affectedFeature);
 	}
@@ -78,7 +78,7 @@ final class ChangeTypeRepresentationExtractor {
 				clazz = RootPackage.Literals.REMOVE_ROOT_EOBJECT
 		} 
 		val affectedEObject = null;
-		val affectedValue = if (elementClass !== null) elementClass.instanceClass else EObject;
+		val affectedValue = if (elementClass !== null) elementClass.instanceClassName else EObject.canonicalName
 		return new AtomicChangeTypeRepresentation(clazz.instanceClass, affectedEObject, affectedValue, !hasNewValue, hasNewValue, null);
 	}
 	
@@ -101,8 +101,8 @@ final class ChangeTypeRepresentationExtractor {
 				hasNewValue = true;
 			}
 		}
-		val affectedEObject = modelElementChange.feature.metaclass.instanceClass;
-		val affectedValue = if (elementClass !== null) elementClass.instanceClass else modelElementChange.feature.feature.EType.instanceClass;
+		val affectedEObject = modelElementChange.feature.metaclass.instanceClassName;
+		val affectedValue = if (elementClass !== null) elementClass.instanceClassName else modelElementChange.feature.feature.EType.instanceClassName;
 		val affectedFeature = modelElementChange.feature.feature; 
 		return new AtomicChangeTypeRepresentation(clazz.instanceClass, affectedEObject, affectedValue, hasOldValue, hasNewValue, affectedFeature);
 	}
@@ -116,7 +116,7 @@ final class ChangeTypeRepresentationExtractor {
 			ElementDeletionChangeType:
 				clazz = EobjectPackage.Literals.DELETE_EOBJECT
 		}
-		val affectedEObject = if (elementClass !== null) elementClass.instanceClass else EObject;
+		val affectedEObject = if (elementClass !== null) elementClass.instanceClassName else EObject.canonicalName;
 		val affectedValue = null; 
 		return new AtomicChangeTypeRepresentation(clazz.instanceClass, affectedEObject, affectedValue, false, false, null);
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
@@ -135,7 +135,7 @@ class RoutineClassGenerator extends ClassGenerator {
 	}
 
 	private def dispatch StringConcatenationClient createStatements(CreateModelElement createElement) {
-		this.currentlyAccessibleElements += new AccessibleElement(createElement.name, createElement.javaClass)
+		this.currentlyAccessibleElements += new AccessibleElement(createElement.name, createElement.javaClassName)
 		val initializeMethod = if (createElement.initializationBlock !== null)
 				generateUpdateElementMethod(createElement.name, createElement.initializationBlock,
 					currentlyAccessibleElements);
@@ -153,7 +153,7 @@ class RoutineClassGenerator extends ClassGenerator {
 		val affectedElementClass = retrieveElement.metaclass;
 		val StringConcatenationClient statements = '''
 			«IF !retrieveElement.name.nullOrEmpty»
-				«affectedElementClass.javaClass» «retrieveElement.name» = «retrieveStatement»;
+				«affectedElementClass.javaClassName» «retrieveElement.name» = «retrieveStatement»;
 				«IF !retrieveElement.optional && !retrieveElement.abscence»
 					if («retrieveElement.name» == null) {
 						return;
@@ -173,7 +173,7 @@ class RoutineClassGenerator extends ClassGenerator {
 			«ENDIF»
 		'''
 		if (!retrieveElement.abscence) {
-			currentlyAccessibleElements += new AccessibleElement(retrieveElement.name, retrieveElement.javaClass);
+			currentlyAccessibleElements += new AccessibleElement(retrieveElement.name, retrieveElement.javaClassName);
 		}
 		return statements;
 	}
@@ -271,7 +271,7 @@ class RoutineClassGenerator extends ClassGenerator {
 			body = '''
 				getLogger().debug("Called routine «routineClassNameGenerator.simpleName» with input:");
 				«FOR inputParameter : inputParameters»
-					getLogger().debug("   «inputParameter.parameterType.type.simpleName»: " + this.«inputParameter.name»);
+					getLogger().debug("   «inputParameter.name»: " + this.«inputParameter.name»);
 				«ENDFOR»
 				
 				«FOR matcherStatement : matcherStatements»
@@ -296,7 +296,7 @@ class RoutineClassGenerator extends ClassGenerator {
 	}
 
 	private def StringConcatenationClient getPreconditionChecker(RetrieveModelElement retrieveElement) {
-		val affectedElementClass = retrieveElement.javaClass;
+		val affectedElementClass = retrieveElement.javaClassName;
 		if (retrieveElement.precondition === null) {
 			return '''(«affectedElementClass» _element) -> true''';
 		}
@@ -305,7 +305,7 @@ class RoutineClassGenerator extends ClassGenerator {
 	}
 
 	private def StringConcatenationClient getGetCorrespondingElementStatement(RetrieveModelElement retrieveElement) {
-		val affectedElementClass = retrieveElement.javaClass;
+		val affectedElementClass = retrieveElement.javaClassName;
 		val correspondingElementPreconditionChecker = getPreconditionChecker(retrieveElement);
 		val correspondenceSourceMethod = generateMethodGetCorrespondenceSource(retrieveElement,
 			currentlyAccessibleElements);
@@ -323,7 +323,7 @@ class RoutineClassGenerator extends ClassGenerator {
 		val affectedElementClass = elementCreate.metaclass;
 		val createdClassFactory = affectedElementClass.EPackage.EFactoryInstance.class;
 		return '''
-		«affectedElementClass.javaClass» «elementCreate.name» = «createdClassFactory».eINSTANCE.create«affectedElementClass.name»();
+		«affectedElementClass.javaClassName» «elementCreate.name» = «createdClassFactory».eINSTANCE.create«affectedElementClass.name»();
 		notifyObjectCreated(«elementCreate.name»);'''
 	}
 

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
@@ -15,23 +15,24 @@ import org.eclipse.xtext.common.types.JvmGenericType
 class RoutineFacadeClassGenerator extends ClassGenerator {
 	val ReactionsSegment reactionsSegment
 	val ClassNameGenerator routinesFacadeNameGenerator;
-	
+
 	new(ReactionsSegment reactionsSegment, TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
 		super(typesBuilderExtensionProvider);
 		this.reactionsSegment = reactionsSegment
 		this.routinesFacadeNameGenerator = reactionsSegment.routinesFacadeClassNameGenerator
 	}
-	
+
 	public override generateEmptyClass() {
-		reactionsSegment.toClass(routinesFacadeNameGenerator.qualifiedName) []
+		reactionsSegment.toClass(routinesFacadeNameGenerator.qualifiedName)[]
 	}
-	
+
 	override generateBody(JvmGenericType generatedClass) {
 		generatedClass => [
 			superTypes += typeRef(AbstractRepairRoutinesFacade);
 			members += reactionsSegment.toConstructor() [
 				val reactionExecutionStateParameter = generateReactionExecutionStateParameter();
-				val calledByParameter = generateParameter(EFFECT_FACADE_CALLED_BY_FIELD_NAME, typeRef(CallHierarchyHaving));
+				val calledByParameter = generateParameter(EFFECT_FACADE_CALLED_BY_FIELD_NAME,
+					typeRef(CallHierarchyHaving));
 				parameters += reactionExecutionStateParameter;
 				parameters += calledByParameter;
 				body = '''super(«reactionExecutionStateParameter.name», «calledByParameter.name»);'''
@@ -39,18 +40,19 @@ class RoutineFacadeClassGenerator extends ClassGenerator {
 			members += reactionsSegment.routines.map[generateCallMethod];
 		]
 	}
-	
+
 	private def JvmOperation generateCallMethod(Routine routine) {
 		val routineNameGenerator = routine.routineClassNameGenerator;
-		return routine.toMethod(routine.name, typeRef(Void.TYPE)) [
+		routine.associatePrimary(routine.toMethod(routine.name, typeRef(Void.TYPE)) [
 			visibility = JvmVisibility.PUBLIC;
-			parameters += generateMethodInputParameters(routine.input.modelInputElements, routine.input.javaInputElements);
+			parameters +=
+				generateMethodInputParameters(routine.input.modelInputElements, routine.input.javaInputElements);
 			body = '''
 				«routineNameGenerator.qualifiedName» effect = new «routineNameGenerator.qualifiedName»(this.executionState, «EFFECT_FACADE_CALLED_BY_FIELD_NAME»«
 					»«FOR parameter : parameters BEFORE ', ' SEPARATOR ', '»«parameter.name»«ENDFOR»);
 				effect.applyRoutine();
-				'''			
-		]
+			'''
+		])
 	}
-	
+
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
@@ -19,28 +19,24 @@ import tools.vitruv.dsls.reactions.codegen.typesbuilder.TypesBuilderExtensionPro
 import org.eclipse.xtext.common.types.JvmGenericType
 import org.eclipse.xtext.xbase.XExpression
 import tools.vitruv.dsls.reactions.reactionsLanguage.ExecuteActionStatement
+import static tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageConstants.*
+
 
 class UserExecutionClassGenerator extends ClassGenerator {
 	private val EObject objectMappedToClass;
 	private val String qualifiedClassName;
-	private var int counterGetTagMethods;
-	private var int counterGetElementMethods;
-	private var int counterGetRetrieveTagMethods;
-	private var int counterCallRoutineMethods;
-	private var int counterExecuteActionMethods;
-	private var int counterCheckMatcherPreconditionMethods;
+	var counterGetTagMethods = 1
+	var counterGetElementMethods = 1
+	var counterGetRetrieveTagMethods = 1
+	var counterCallRoutineMethods = 1
+	var counterExecuteActionMethods = 1
+	var counterCheckMatcherPreconditionMethods = 1
 
 	new(TypesBuilderExtensionProvider typesBuilderExtensionProvider, EObject objectMappedToClass,
 		String qualifiedClassName) {
 		super(typesBuilderExtensionProvider)
 		this.objectMappedToClass = objectMappedToClass;
 		this.qualifiedClassName = qualifiedClassName;
-		this.counterGetTagMethods = 1;
-		this.counterGetElementMethods = 1;
-		this.counterGetRetrieveTagMethods = 1;
-		this.counterCallRoutineMethods = 1;
-		this.counterExecuteActionMethods = 1;
-		this.counterCheckMatcherPreconditionMethods = 1;
 	}
 
 	public def String getQualifiedClassName() {
@@ -122,9 +118,9 @@ class UserExecutionClassGenerator extends ClassGenerator {
 		Iterable<AccessibleElement> accessibleElements) {
 		val methodName = "getCorrepondenceSource" + elementRetrieve.name.toFirstUpper;
 
-		return elementRetrieve.correspondenceSource.getOrGenerateMethod(methodName, typeRef(EObject)) [
+		val correspondenceSourceBlock = elementRetrieve.correspondenceSource?.code;
+		return correspondenceSourceBlock.getOrGenerateMethod(methodName, typeRef(EObject)) [
 			parameters += generateAccessibleElementsParameters(accessibleElements);
-			val correspondenceSourceBlock = elementRetrieve.correspondenceSource?.code;
 			if (correspondenceSourceBlock instanceof SimpleTextXBlockExpression) {
 				body = correspondenceSourceBlock.text;
 			} else {
@@ -182,7 +178,7 @@ class UserExecutionClassGenerator extends ClassGenerator {
 		}
 		return codeBlock.getOrGenerateMethod(methodName, typeRef(Void.TYPE)) [
 			parameters += generateAccessibleElementsParameters(accessibleElements);
-			val facadeParam = toParameter("_routinesFacade", facadeClassTypeReference);
+			val facadeParam = toParameter(REACTION_USER_EXECUTION_ROUTINE_CALL_FACADE_PARAMETER_NAME, facadeClassTypeReference);
 			facadeParam.annotations += annotationRef(Extension);
 			parameters += facadeParam
 			if (codeBlock instanceof SimpleTextXBlockExpression) {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageConstants.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageConstants.xtend
@@ -1,6 +1,8 @@
 package tools.vitruv.dsls.reactions.codegen.helper
 
-final class ReactionsLanguageConstants {
+import edu.kit.ipd.sdq.activextendannotations.Utility
+
+@Utility class ReactionsLanguageConstants {
 	private static val BLACKBOARD_NAME = "blackboard";
 	public static val BLACKBOARD_PARAMETER_NAME = BLACKBOARD_NAME;
 	public static val BLACKBOARD_FIELD_NAME = BLACKBOARD_NAME;
@@ -19,4 +21,10 @@ final class ReactionsLanguageConstants {
 	public static val EFFECT_FACADE_CALLED_BY_FIELD_NAME = "calledBy";
 	
 	public static val EFFECT_USER_EXECUTION_SIMPLE_NAME = "ActionUserExecution";
+	public static val REACTION_USER_EXECUTION_ROUTINE_CALL_FACADE_PARAMETER_NAME = "_routinesFacade"
+	
+	public static val CHANGE_AFFECTED_ELEMENT_ATTRIBUTE = "affectedEObject"
+	public static val CHANGE_AFFECTED_FEATURE_ATTRIBUTE = "affectedFeature"
+	public static val CHANGE_OLD_VALUE_ATTRIBUTE = "oldValue"
+	public static val CHANGE_NEW_VALUE_ATTRIBUTE = "newValue"
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageHelper.xtend
@@ -32,12 +32,12 @@ final class ReactionsLanguageHelper {
 		blockExpression.text.toString;
 	}
 
-	public static def Class<?> getJavaClass(EClass element) {
-		return element.instanceClass;
+	public static def getJavaClassName(EClass element) {
+		element.instanceClassName;
 	}
 
-	public static def Class<?> getJavaClass(MetaclassReference metaclassReference) {
-		return metaclassReference.metaclass.javaClass;
+	public static def getJavaClassName(MetaclassReference metaclassReference) {
+		metaclassReference.metaclass.javaClassName;
 	}
 
 	public static def VitruvDomainProvider<?> getProviderForDomain(VitruvDomain domain) {
@@ -67,9 +67,9 @@ final class ReactionsLanguageHelper {
 	}
 
 	def static ReactionsFile getReactionsFile(Resource resource) {
-		val firstContentElement = resource?.contents?.get(0)
+		val firstContentElement = resource?.contents?.head
 		checkArgument(firstContentElement instanceof ReactionsFile,
-			"The given resource %s was expected to contain a ReactionsFile element (was %s).", resource,
+			"The given resource %s was expected to contain a ReactionsFile element! (was %s)", resource,
 			firstContentElement?.class?.simpleName);
 
 		return firstContentElement as ReactionsFile;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/JvmTypesBuilderWithoutAssociations.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/JvmTypesBuilderWithoutAssociations.xtend
@@ -12,15 +12,16 @@ import org.eclipse.xtext.common.types.JvmField
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociator
 import org.eclipse.xtext.common.types.JvmFormalParameter
 import org.eclipse.xtext.common.types.JvmGenericType
+import com.google.inject.Singleton
 
+@Singleton
 class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	@Inject
 	private TypesFactory typesFactory;
-		
+
 	@Inject
 	private IJvmModelAssociator associator;
-	
-	
+
 	/**
 	 * Creates a public method with the given name and the given return type and associates it with the given
 	 * sourceElement.
@@ -37,9 +38,8 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	 * @return a result representing a Java method with the given name, <code>null</code> if sourceElement or name are <code>null</code>.
 	 */
 	/* @Nullable */
-	public def JvmOperation generateUnassociatedMethod(/* @Nullable */ String name, /* @Nullable */ JvmTypeReference returnType,
-			/* @Nullable */ Procedure1<? super JvmOperation> initializer) {
-		if(name === null) 
+	public def JvmOperation generateUnassociatedMethod( /* @Nullable */ String name, /* @Nullable */ JvmTypeReference returnType, /* @Nullable */ Procedure1<? super JvmOperation> initializer) {
+		if (name === null)
 			return null;
 		val result = typesFactory.createJvmOperation();
 		result.setSimpleName(name);
@@ -47,9 +47,7 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 		result.setReturnType(cloneWithProxies(returnType));
 		return initializeSafely(result, initializer);
 	}
-	
-	
-	
+
 	/**
 	 * Creates a private field with the given name and the given type associated to the given sourceElement.
 	 * 
@@ -60,17 +58,16 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	 * @return a {@link JvmField} representing a Java field with the given simple name and type.
 	 */
 	/* @Nullable */
-	public def JvmField generateUnassociatedField(/* @Nullable */ String name, /* @Nullable */ JvmTypeReference typeRef) {
+	public def JvmField generateUnassociatedField( /* @Nullable */ String name, /* @Nullable */ JvmTypeReference typeRef) {
 		return generateUnassociatedField(name, typeRef, null);
 	}
-	
+
 	/**
 	 * Same as {@link #toField(EObject, String, JvmTypeReference)} but with an initializer passed as the last argument.
 	 */
-	/* @Nullable */	
-	public def JvmField generateUnassociatedField(/* @Nullable */ String name, /* @Nullable */ JvmTypeReference typeRef, 
-			/* @Nullable */ Procedure1<? super JvmField> initializer) {
-		if(name === null) 
+	/* @Nullable */
+	public def JvmField generateUnassociatedField( /* @Nullable */ String name, /* @Nullable */ JvmTypeReference typeRef, /* @Nullable */ Procedure1<? super JvmField> initializer) {
+		if (name === null)
 			return null;
 		val result = typesFactory.createJvmField();
 		result.setSimpleName(name);
@@ -78,7 +75,7 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 		result.setType(cloneWithProxies(typeRef));
 		return initializeSafely(result, initializer);
 	}
-	
+
 	/**
 	 * Associates a source element with a target element. This association is used for tracing. Navigation, for
 	 * instance, uses this information to find the real declaration of a Jvm element.
@@ -89,27 +86,46 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	 * @return the target for convenience.
 	 */
 	/* @Nullable */
-	public override <T extends EObject> T associate(/* @Nullable */ EObject sourceElement, /* @Nullable */ T target) {
-		if(sourceElement !== null && target !== null && sourceElement.eResource !== null && isValidSource(sourceElement))
+	public override <T extends EObject> T associate( /* @Nullable */ EObject sourceElement, /* @Nullable */ T target) {
+		if (sourceElement !== null && target !== null && sourceElement.eResource !== null &&
+			isValidSource(sourceElement))
 			associator.associate(sourceElement, target);
 		return target;
 	}
-	
+
+	/**
+	 * Associates a source element with a target elementand marks the association as primary
+	 * on both sides. This association is used for tracing. Navigation, for
+	 * instance, uses this information to find the real declaration of a Jvm element.
+	 * 
+	 * @see IJvmModelAssociator
+	 * @see IJvmModelAssociations
+	 * 
+	 * @return the target for convenience.
+	 */
+	/* @Nullable */
+	def <T extends EObject> T associatePrimary( /* @Nullable */ EObject sourceElement, /* @Nullable */ T target) {
+		if (sourceElement !== null && target !== null && sourceElement.eResource !== null &&
+			isValidSource(sourceElement))
+			associator.associatePrimary(sourceElement, target);
+		return target;
+	}
+
 	public def JvmFormalParameter createParameter(String name, JvmTypeReference typeRef) {
 		val result = typesFactory.createJvmFormalParameter();
 		result.setName(name);
 		result.setParameterType(cloneWithProxies(typeRef));
 		return result;
 	}
-	
-	public def JvmGenericType generateUnassociatedClass(/* @Nullable */ String name, /* @Nullable */ Procedure1<? super JvmGenericType> initializer) {
+
+	public def JvmGenericType generateUnassociatedClass( /* @Nullable */ String name, /* @Nullable */ Procedure1<? super JvmGenericType> initializer) {
 		val result = createJvmGenericType(name);
 		if (result === null)
 			return null;
 		return initializeSafely(result, initializer);
 	}
-	
-	protected def JvmGenericType createJvmGenericType(/* @Nullable */ String name) {
+
+	protected def JvmGenericType createJvmGenericType( /* @Nullable */ String name) {
 		if (name === null)
 			return null;
 		val fullName = splitQualifiedName(name);

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
@@ -8,7 +8,6 @@ import org.eclipse.xtext.common.types.JvmTypeReference
 import tools.vitruv.framework.userinteraction.UserInteracting
 import tools.vitruv.dsls.mirbase.mirBase.NamedJavaElement
 import tools.vitruv.dsls.reactions.reactionsLanguage.Trigger
-import java.util.List
 import tools.vitruv.extensions.dslsruntime.reactions.ReactionExecutionState
 import org.eclipse.emf.ecore.EClass
 import tools.vitruv.dsls.reactions.reactionsLanguage.inputTypes.InputTypesPackage
@@ -38,7 +37,7 @@ class ParameterGenerator {
 	
 	public def JvmFormalParameter generateModelElementParameter(EObject parameterContext, MetaclassReference metaclassReference, String elementName) {
 		if (metaclassReference?.metaclass !== null) {
-			return parameterContext.generateParameter(elementName, metaclassReference.javaClass);
+			return parameterContext.generateParameter(elementName, typeRef(metaclassReference.javaClassName))
 		}	
 		return null;
 	}
@@ -63,8 +62,8 @@ class ParameterGenerator {
 	}
 
 		
-	public def generateParameterFromClasses(EObject context, String parameterName, Class<?> parameterClass, List<Class<?>> typeParameterClasses) {
-		return generateParameter(context, parameterName, parameterClass, typeParameterClasses.map[name]);
+	public def generateParameterFromClasses(EObject context, String parameterName, Class<?> parameterClass, Iterable<String> typeParameterClasses) {
+		return generateParameter(context, parameterName, parameterClass, typeParameterClasses);
 	}
 	
 	public def generateParameter(EObject context, String parameterName, Class<?> parameterClass, String... typeParameterClassNames) {
@@ -80,7 +79,7 @@ class ParameterGenerator {
 	}
 	
 	public def Iterable<AccessibleElement> getInputElements(EObject contextObject, Iterable<NamedMetaclassReference> metaclassReferences, Iterable<NamedJavaElement> javaElements) {
-		return metaclassReferences.map[new AccessibleElement(it.name, it.metaclass.mappedInstanceClass)]
+		return metaclassReferences.map[new AccessibleElement(it.name, it.metaclass.mappedInstanceClassCanonicalName)]
 			+ javaElements.map[new AccessibleElement(it.name, it.type.qualifiedName)];
 	}
 	
@@ -90,28 +89,19 @@ class ParameterGenerator {
 		];
 	}
 	
-	private def getMappedInstanceClass(EClass eClass) {
-		if (eClass.equals(InputTypesPackage.Literals.STRING)) {
-			return String;
-		} else if (eClass.equals(InputTypesPackage.Literals.INTEGER)) {
-			return Integer;
-		} else if (eClass.equals(InputTypesPackage.Literals.LONG)) {
-			return Long;
-		} else if (eClass.equals(InputTypesPackage.Literals.SHORT)) {
-			return Short;
-		} else if (eClass.equals(InputTypesPackage.Literals.BOOLEAN)) {
-			return Boolean;
-		} else if (eClass.equals(InputTypesPackage.Literals.CHARACTER)) {
-			return Character;
-		} else if (eClass.equals(InputTypesPackage.Literals.BYTE)) {
-			return Byte;
-		} else if (eClass.equals(InputTypesPackage.Literals.FLOAT)) {
-			return Float;
-		} else if (eClass.equals(InputTypesPackage.Literals.DOUBLE)) {
-			return Double;
+	private def getMappedInstanceClassCanonicalName(EClass eClass) {
+		switch eClass {
+			case InputTypesPackage.Literals.STRING: String.name
+			case InputTypesPackage.Literals.INTEGER: Integer.name
+			case InputTypesPackage.Literals.LONG: Long.name
+			case InputTypesPackage.Literals.SHORT: Short.name
+			case InputTypesPackage.Literals.BOOLEAN: Boolean.name
+			case InputTypesPackage.Literals.CHARACTER: Character.name
+			case InputTypesPackage.Literals.BYTE: Byte.name
+			case InputTypesPackage.Literals.FLOAT: Float.name
+			case InputTypesPackage.Literals.DOUBLE: Double.name
+			default: eClass.instanceClassName
 		}
-		
-		return eClass.instanceClass
 	}
 	
 	public def JvmFormalParameter generateUntypedChangeParameter(EObject parameterContext) {
@@ -120,7 +110,7 @@ class ParameterGenerator {
 	
 	public def JvmFormalParameter generateChangeParameter(EObject parameterContext, Trigger trigger) {
 		val changeRepresentation = extractChangeTypeRepresentation(trigger);
-		var List<Class<?>> changeTypeParameters = <Class<?>>newArrayList;
+		var Iterable<String> changeTypeParameters = new ArrayList<String>
 		if (trigger instanceof ConcreteModelChange) {
 			changeTypeParameters = changeRepresentation.genericTypeParameters	
 		}


### PR DESCRIPTION
These adaptions are necessary to artificially create reactions. The changes should not be visible outside of the reactions project.

… except for that generated reactions now use fully qualified names instead of an import + a simple name. I’ll see if I can fix that at a later point if that’s okay for you.