### PR TITLE
Don’t use the UI Harness for DSL Tests

### DIFF
--- a/tests/dsls/pom.xml
+++ b/tests/dsls/pom.xml
@@ -30,7 +30,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<useUIHarness>true</useUIHarness>
+					<useUIHarness>false</useUIHarness>
 					<failIfNoTests>false</failIfNoTests>
 					<includes>
 						<include>**/*Test*.class</include>


### PR DESCRIPTION
This has the advantage that no Eclipse window opens when running the tests locally. It also removes the many GTK errors from the test output (which is Linux specific, I guess). Most importantly, it makes the tests run faster (locally, at least).

I could not find any downsides of this change.