### PR TITLE
Put VSUM and Project Files in the Same Test Workspace

### DIFF
--- a/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusTest.java
+++ b/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusTest.java
@@ -22,7 +22,7 @@ public abstract class VitruviusTest {
 	@Rule
 	public TestName testName = new TestName();
 
-	private static File workspace;
+	protected static File workspace;
 	private File folder;
 	private Function<String, File> testProjectCreator;
 

--- a/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusUnmonitoredApplicationTest.java
+++ b/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusUnmonitoredApplicationTest.java
@@ -69,7 +69,7 @@ public abstract class VitruviusUnmonitoredApplicationTest extends VitruviusTest 
 		String currentTestProjectVsumName = testName + "_vsum_";
 		Iterable<VitruvDomain> domains = this.getVitruvDomains();
 		this.testUserInteractor = new TestUserInteractor();
-		this.virtualModel = TestUtil.createVirtualModel(currentTestProjectVsumName, true, domains,
+		this.virtualModel = TestUtil.createVirtualModel(new File(workspace, currentTestProjectVsumName), true, domains,
 				createChangePropagationSpecifications(), testUserInteractor);
 		this.correspondenceModel = virtualModel.getCorrespondenceModel();
 	}


### PR DESCRIPTION
Was missing in #139. Puts the project folder in the same workspace folder as the VSUM folder.