### PR TITLE
Support Derived IDs

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/AtomicEChangeResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/AtomicEChangeResolver.xtend
@@ -128,7 +128,11 @@ class AtomicEChangeResolver {
 		}
 		
 		if (change.idAttributeValue !== null) {
-			EcoreUtil.setID(change.affectedEObject, change.idAttributeValue);
+			val idAttribute = change.affectedEObject.eClass.EIDAttribute
+			// ECoreUtil will throw the exception for us if there is no ID attribute.
+		 	if (idAttribute === null || !idAttribute.isDerived) {
+				EcoreUtil.setID(change.affectedEObject, change.idAttributeValue);
+			}
 		}
 		
 		return true


### PR DESCRIPTION
The part in question was throwing an exception if the ID attribute was not changeable. But that’s okay if the attribute is derived.