### PR TITLE
Ignore derived ID attributes

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringAtomicEChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringAtomicEChangeFactory.xtend
@@ -24,6 +24,7 @@ import tools.vitruv.framework.change.echange.root.RemoveRootEObject
 import tools.vitruv.framework.change.echange.root.RootEChange
 import tools.vitruv.framework.change.echange.root.RootFactory
 import org.eclipse.emf.ecore.resource.Resource
+import tools.vitruv.framework.change.echange.util.EChangeUtil
 
 /**
  * Factory singleton class for elements of change models.
@@ -97,10 +98,10 @@ class TypeInferringAtomicEChangeFactory {
 	 * @param resource The resource which contains the staging area, where the object will be placed in / removed from.
 	 */
 	def protected <A extends EObject> void setEObjectExistenceChange(EObjectExistenceEChange<A> change,
-		A affectedEObject, Resource resource, String objectId) {
+		A affectedEObject, Resource resource) {
 		change.affectedEObject = affectedEObject;
 		change.affectedEObjectType = change.affectedEObject.eClass
-		change.idAttributeValue = objectId;
+		change.idAttributeValue = EChangeUtil.getID(change.affectedEObject);
 	}
 
 	/**
@@ -239,12 +240,12 @@ class TypeInferringAtomicEChangeFactory {
 	 * @param resource The resource, in which staging area the EObject is inserted.
 	 * @return The created CreateEObject EChange.
 	 */
-	def <A extends EObject> CreateEObject<A> createCreateEObjectChange(A affectedEObject, Resource resource, String objectId) {
+	def <A extends EObject> CreateEObject<A> createCreateEObjectChange(A affectedEObject, Resource resource) {
 		if (affectedEObject === null) {
 			throw new IllegalArgumentException();
 		}
 		val c = EobjectFactory.eINSTANCE.createCreateEObject()
-		setEObjectExistenceChange(c, affectedEObject, resource, objectId)
+		setEObjectExistenceChange(c, affectedEObject, resource)
 		return c
 	}
 
@@ -254,12 +255,12 @@ class TypeInferringAtomicEChangeFactory {
 	 * @param resource The resource, from which staging area the EObject is removed.
 	 * @return The created DeleteEObject EChange.
 	 */
-	def <A extends EObject> DeleteEObject<A> createDeleteEObjectChange(A affectedEObject, Resource resource, String objectId) {
+	def <A extends EObject> DeleteEObject<A> createDeleteEObjectChange(A affectedEObject, Resource resource) {
 		if (affectedEObject === null) {
 			throw new IllegalArgumentException();
 		}
 		val c = EobjectFactory.eINSTANCE.createDeleteEObject()
-		setEObjectExistenceChange(c, affectedEObject, resource, objectId)
+		setEObjectExistenceChange(c, affectedEObject, resource)
 		return c
 	}
 

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringCompoundEChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringCompoundEChangeFactory.xtend
@@ -82,9 +82,9 @@ class TypeInferringCompoundEChangeFactory {
 	 * @return The created change.
 	 */
 	def <T extends EObject> CreateAndInsertRoot<T> createCreateAndInsertRootChange(T affectedEObject, Resource resource,
-		int index, String objectId) {
+		int index) {
 		val c = CompoundFactory.eINSTANCE.createCreateAndInsertRoot();
-		c.createChange = atomicFactory.createCreateEObjectChange(affectedEObject, resource, objectId);
+		c.createChange = atomicFactory.createCreateEObjectChange(affectedEObject, resource);
 		c.insertChange = atomicFactory.createInsertRootChange(affectedEObject, resource, index);
 		return c
 	}
@@ -97,9 +97,9 @@ class TypeInferringCompoundEChangeFactory {
 	 * @return The created change.
 	 */
 	def <T extends EObject> RemoveAndDeleteRoot<T> createRemoveAndDeleteRootChange(T affectedEObject, Resource resource,
-		int index, String objectId) {
+		int index) {
 		val c = CompoundFactory.eINSTANCE.createRemoveAndDeleteRoot();
-		c.deleteChange = atomicFactory.createDeleteEObjectChange(affectedEObject, resource, objectId);
+		c.deleteChange = atomicFactory.createDeleteEObjectChange(affectedEObject, resource);
 		c.removeChange = atomicFactory.createRemoveRootChange(affectedEObject, resource, index);
 		return c
 	}
@@ -113,9 +113,9 @@ class TypeInferringCompoundEChangeFactory {
 	 * @return The created change.
 	 */
 	def <A extends EObject, T extends EObject> CreateAndInsertNonRoot<A, T> createCreateAndInsertNonRootChange(
-		A affectedEObject, EReference reference, T newValue, int index, String objectId) {
+		A affectedEObject, EReference reference, T newValue, int index) {
 		val c = CompoundFactory.eINSTANCE.createCreateAndInsertNonRoot();
-		c.createChange = atomicFactory.createCreateEObjectChange(newValue, affectedEObject.eResource, objectId);
+		c.createChange = atomicFactory.createCreateEObjectChange(newValue, affectedEObject.eResource);
 		c.insertChange = atomicFactory.createInsertReferenceChange(affectedEObject, reference, newValue, index);
 		return c
 	}
@@ -129,9 +129,9 @@ class TypeInferringCompoundEChangeFactory {
 	 * @return The created change.
 	 */
 	def <A extends EObject, T extends EObject> RemoveAndDeleteNonRoot<A, T> createRemoveAndDeleteNonRootChange(
-		A affectedEObject, EReference reference, T oldValue, int index, String objectId) {
+		A affectedEObject, EReference reference, T oldValue, int index) {
 		val c = CompoundFactory.eINSTANCE.createRemoveAndDeleteNonRoot()
-		c.deleteChange = atomicFactory.createDeleteEObjectChange(oldValue, affectedEObject.eResource, objectId)
+		c.deleteChange = atomicFactory.createDeleteEObjectChange(oldValue, affectedEObject.eResource)
 		c.removeChange = atomicFactory.createRemoveReferenceChange(affectedEObject, reference, oldValue, index)
 		return c
 	}
@@ -144,9 +144,9 @@ class TypeInferringCompoundEChangeFactory {
 	 * @return The created change.
 	 */
 	def <A extends EObject, T extends EObject> CreateAndReplaceNonRoot<A, T> createCreateAndReplaceNonRootChange(
-		A affectedEObject, EReference reference, T newValue, String objectId) {
+		A affectedEObject, EReference reference, T newValue) {
 		val c = CompoundFactory.eINSTANCE.createCreateAndReplaceNonRoot()
-		c.createChange = atomicFactory.createCreateEObjectChange(newValue, affectedEObject.eResource, objectId)
+		c.createChange = atomicFactory.createCreateEObjectChange(newValue, affectedEObject.eResource)
 		c.insertChange = atomicFactory.createReplaceSingleReferenceChange(affectedEObject, reference, null, newValue)
 		return c
 	}
@@ -159,10 +159,10 @@ class TypeInferringCompoundEChangeFactory {
 	 * @return The created change.
 	 */
 	def <A extends EObject, T extends EObject> ReplaceAndDeleteNonRoot<A, T> createReplaceAndDeleteNonRootChange(
-		A affectedEObject, EReference reference, T oldValue, String objectId) {
+		A affectedEObject, EReference reference, T oldValue) {
 		val c = CompoundFactory.eINSTANCE.createReplaceAndDeleteNonRoot()
 		c.removeChange = atomicFactory.createReplaceSingleReferenceChange(affectedEObject, reference, oldValue, null)
-		c.deleteChange = atomicFactory.createDeleteEObjectChange(oldValue,affectedEObject.eResource, objectId)
+		c.deleteChange = atomicFactory.createDeleteEObjectChange(oldValue,affectedEObject.eResource)
 		return c
 	}
 
@@ -175,10 +175,10 @@ class TypeInferringCompoundEChangeFactory {
 	 * @return The created change.
 	 */
 	def <A extends EObject, T extends EObject> CreateAndReplaceAndDeleteNonRoot<A, T> createCreateAndReplaceAndDeleteNonRootChange(
-		A affectedEObject, EReference reference, T oldValue, T newValue, String oldObjectId, String newObjectId) {
+		A affectedEObject, EReference reference, T oldValue, T newValue) {
 		val c = CompoundFactory.eINSTANCE.createCreateAndReplaceAndDeleteNonRoot();
-		c.deleteChange = atomicFactory.createDeleteEObjectChange(oldValue, affectedEObject.eResource, oldObjectId);
-		c.createChange = atomicFactory.createCreateEObjectChange(newValue, affectedEObject.eResource, newObjectId);
+		c.deleteChange = atomicFactory.createDeleteEObjectChange(oldValue, affectedEObject.eResource);
+		c.createChange = atomicFactory.createCreateEObjectChange(newValue, affectedEObject.eResource);
 		c.replaceChange = atomicFactory.createReplaceSingleReferenceChange(affectedEObject, reference, oldValue,
 			newValue);
 		return c

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringUnresolvingAtomicEChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringUnresolvingAtomicEChangeFactory.xtend
@@ -26,15 +26,15 @@ final class TypeInferringUnresolvingAtomicEChangeFactory extends TypeInferringAt
 		eChangeIdManager.setOrGenerateIds(change);
 	}
 	
-	override <A extends EObject> createCreateEObjectChange(A affectedEObject, Resource resource, String objectId) {
-		val result = super.<A>createCreateEObjectChange(affectedEObject, resource, objectId)
+	override <A extends EObject> createCreateEObjectChange(A affectedEObject, Resource resource) {
+		val result = super.<A>createCreateEObjectChange(affectedEObject, resource)
 		setIds(result);
 		result.unresolve
 		return result;
 	}
 	
-	override <A extends EObject> createDeleteEObjectChange(A affectedEObject, Resource resource, String objectId) {
-		val result = super.<A>createDeleteEObjectChange(affectedEObject, resource, objectId)
+	override <A extends EObject> createDeleteEObjectChange(A affectedEObject, Resource resource) {
+		val result = super.<A>createDeleteEObjectChange(affectedEObject, resource)
 		setIds(result);
 		result.unresolve
 		return result;

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
@@ -7,6 +7,7 @@ import org.eclipse.emf.edit.provider.ComposedAdapterFactory
 import org.eclipse.emf.common.command.BasicCommandStack
 import org.eclipse.emf.ecore.EReference
 import java.util.List
+import org.eclipse.emf.ecore.util.EcoreUtil
 
 /**
  * Static utility class for the EChange package and subpackages.
@@ -41,5 +42,25 @@ class EChangeUtil {
 			return true;
 		}
 		return false;
+	}
+	
+	/**
+	 * Return the value of the ID attribute of the given {@link EObject}, according to
+	 * {@link EcoreUtil#getID(EObject) EcoreUtil}.
+	 * If the object has no ID attribute or if is marked as <code>derived</code>, 
+	 * <code>null</code> will be returned.
+	 * 
+	 * @see 	EcoreUtil#getID(EObject)
+	 * @param 	eObject
+	 * 			The object to get the ID attribute value from
+	 * @return 	The ID attribute value of the given {@link EObject} or <code>null</code> 
+	 * 			if it has no ID attribute or if it is marked as <code>derived</code>.
+	 */
+	public static def String getID(EObject eObject) {
+		val idAttribute = eObject.eClass.EIDAttribute
+		if (idAttribute !== null && !idAttribute.derived) {
+			return EcoreUtil.getID(eObject);
+		}
+		return null;
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChangeFactory.xtend
@@ -16,7 +16,6 @@ import tools.vitruv.framework.util.datatypes.VURI
 import tools.vitruv.framework.change.preparation.ChangeDescription2EChangesTransformation
 import tools.vitruv.framework.change.description.impl.ConcreteApplicableChangeImpl
 import tools.vitruv.framework.change.description.impl.ConcreteChangeWithUriImpl
-import tools.vitruv.framework.change.echange.util.EChangeUtil
 
 class VitruviusChangeFactory {
 	private static val logger = Logger.getLogger(VitruviusChangeFactory);
@@ -112,7 +111,7 @@ class VitruviusChangeFactory {
             return null;
         }
         val CreateAndInsertRoot<EObject> createRootEObj =  TypeInferringCompoundEChangeFactory.
-        	instance.createCreateAndInsertRootChange(rootElement, resource, index, EChangeUtil.getID(rootElement));
+        	instance.createCreateAndInsertRootChange(rootElement, resource, index);
         return createRootEObj; 
 	}
 	
@@ -121,7 +120,7 @@ class VitruviusChangeFactory {
 			val index = 0
             val EObject rootElement = resource.getContents().get(index);
             val RemoveAndDeleteRoot<EObject> deleteRootObj = TypeInferringCompoundEChangeFactory.
-            	instance.createRemoveAndDeleteRootChange(rootElement, resource, index, EChangeUtil.getID(rootElement));
+            	instance.createRemoveAndDeleteRootChange(rootElement, resource, index);
             return deleteRootObj;
         }
         logger.info("Deleted resource " + VURI.getInstance(resource) + " did not contain any EObject");

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChangeFactory.xtend
@@ -16,7 +16,7 @@ import tools.vitruv.framework.util.datatypes.VURI
 import tools.vitruv.framework.change.preparation.ChangeDescription2EChangesTransformation
 import tools.vitruv.framework.change.description.impl.ConcreteApplicableChangeImpl
 import tools.vitruv.framework.change.description.impl.ConcreteChangeWithUriImpl
-import org.eclipse.emf.ecore.util.EcoreUtil
+import tools.vitruv.framework.change.echange.util.EChangeUtil
 
 class VitruviusChangeFactory {
 	private static val logger = Logger.getLogger(VitruviusChangeFactory);
@@ -112,7 +112,7 @@ class VitruviusChangeFactory {
             return null;
         }
         val CreateAndInsertRoot<EObject> createRootEObj =  TypeInferringCompoundEChangeFactory.
-        	instance.createCreateAndInsertRootChange(rootElement, resource, index, EcoreUtil.getID(rootElement));
+        	instance.createCreateAndInsertRootChange(rootElement, resource, index, EChangeUtil.getID(rootElement));
         return createRootEObj; 
 	}
 	
@@ -121,7 +121,7 @@ class VitruviusChangeFactory {
 			val index = 0
             val EObject rootElement = resource.getContents().get(index);
             val RemoveAndDeleteRoot<EObject> deleteRootObj = TypeInferringCompoundEChangeFactory.
-            	instance.createRemoveAndDeleteRootChange(rootElement, resource, index, EcoreUtil.getID(rootElement));
+            	instance.createRemoveAndDeleteRootChange(rootElement, resource, index, EChangeUtil.getID(rootElement));
             return deleteRootObj;
         }
         logger.info("Deleted resource " + VURI.getInstance(resource) + " did not contain any EObject");

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/EMFModelChangeTransformationUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/EMFModelChangeTransformationUtil.xtend
@@ -17,7 +17,7 @@ import tools.vitruv.framework.change.echange.feature.attribute.ReplaceSingleValu
 import tools.vitruv.framework.change.echange.feature.attribute.SubtractiveAttributeEChange
 
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.EObjectUtil.*
-import org.eclipse.emf.ecore.util.EcoreUtil
+import tools.vitruv.framework.change.echange.util.EChangeUtil
 
 /**
  * A utility class providing extension methods for transforming change descriptions to change models.
@@ -165,7 +165,7 @@ package class EMFModelChangeTransformationUtil {
 	def static EChange createInsertRootChange(EObject rootToInsert, EObject oldRootContainer, Resource oldRootResource, Resource newResource, int index) {
 		val isCreate = isCreate(oldRootContainer, oldRootResource)
 		if (isCreate) {
-			return TypeInferringCompoundEChangeFactory.instance.createCreateAndInsertRootChange(rootToInsert, newResource, index, EcoreUtil.getID(rootToInsert));
+			return TypeInferringCompoundEChangeFactory.instance.createCreateAndInsertRootChange(rootToInsert, newResource, index, EChangeUtil.getID(rootToInsert));
 		} else {
 
 			return TypeInferringAtomicEChangeFactory.instance.createInsertRootChange(rootToInsert, newResource, index)
@@ -184,7 +184,7 @@ package class EMFModelChangeTransformationUtil {
 		val isDelete = isDelete(newRootContainer, newRootResource)
 		if (isDelete) {
 
-			return TypeInferringCompoundEChangeFactory.instance.createRemoveAndDeleteRootChange(rootToRemove, oldResource, index, EcoreUtil.getID(rootToRemove));
+			return TypeInferringCompoundEChangeFactory.instance.createRemoveAndDeleteRootChange(rootToRemove, oldResource, index, EChangeUtil.getID(rootToRemove));
 		} else {
 
 			return TypeInferringAtomicEChangeFactory.instance.createRemoveRootChange(rootToRemove, oldResource, index);
@@ -199,7 +199,7 @@ package class EMFModelChangeTransformationUtil {
 		val isCreate = forceCreate || (isContainment && oldResource === null)
 		if (isCreate) {
 
-			return TypeInferringCompoundEChangeFactory.instance.createCreateAndInsertNonRootChange(affectedEObject, affectedReference, referenceValue, index, EcoreUtil.getID(referenceValue));
+			return TypeInferringCompoundEChangeFactory.instance.createCreateAndInsertNonRootChange(affectedEObject, affectedReference, referenceValue, index, EChangeUtil.getID(referenceValue));
 		} else {
 
 			return TypeInferringAtomicEChangeFactory.instance.createInsertReferenceChange(affectedEObject, affectedReference, referenceValue, index);
@@ -212,7 +212,7 @@ package class EMFModelChangeTransformationUtil {
 		val isDelete = forceDelete || (isContainment && isDelete(newContainer, newResource))
 		if (isDelete) {
 
-			return TypeInferringCompoundEChangeFactory.instance.createRemoveAndDeleteNonRootChange(affectedEObject, affectedReference, referenceValue, index, EcoreUtil.getID(referenceValue));
+			return TypeInferringCompoundEChangeFactory.instance.createRemoveAndDeleteNonRootChange(affectedEObject, affectedReference, referenceValue, index, EChangeUtil.getID(referenceValue));
 		} else {
 
 			return TypeInferringAtomicEChangeFactory.instance.createRemoveReferenceChange(affectedEObject, affectedReference, referenceValue, index);
@@ -224,11 +224,11 @@ package class EMFModelChangeTransformationUtil {
 
 		if (forceCreate || isContainment) {
 			if (oldReferenceValue === null) {
-				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceNonRootChange(affectedEObject, affectedReference, newReferenceValue, EcoreUtil.getID(newReferenceValue))
+				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceNonRootChange(affectedEObject, affectedReference, newReferenceValue, EChangeUtil.getID(newReferenceValue))
 			} else if (newReferenceValue === null) {
-				return TypeInferringCompoundEChangeFactory.instance.createReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue, EcoreUtil.getID(oldReferenceValue))
+				return TypeInferringCompoundEChangeFactory.instance.createReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue, EChangeUtil.getID(oldReferenceValue))
 			} else {
-				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue, newReferenceValue, EcoreUtil.getID(oldReferenceValue), EcoreUtil.getID(newReferenceValue));				
+				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue, newReferenceValue, EChangeUtil.getID(oldReferenceValue), EChangeUtil.getID(newReferenceValue));				
 			}
 		} else {
 

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/EMFModelChangeTransformationUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/EMFModelChangeTransformationUtil.xtend
@@ -17,7 +17,6 @@ import tools.vitruv.framework.change.echange.feature.attribute.ReplaceSingleValu
 import tools.vitruv.framework.change.echange.feature.attribute.SubtractiveAttributeEChange
 
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.EObjectUtil.*
-import tools.vitruv.framework.change.echange.util.EChangeUtil
 
 /**
  * A utility class providing extension methods for transforming change descriptions to change models.
@@ -165,7 +164,7 @@ package class EMFModelChangeTransformationUtil {
 	def static EChange createInsertRootChange(EObject rootToInsert, EObject oldRootContainer, Resource oldRootResource, Resource newResource, int index) {
 		val isCreate = isCreate(oldRootContainer, oldRootResource)
 		if (isCreate) {
-			return TypeInferringCompoundEChangeFactory.instance.createCreateAndInsertRootChange(rootToInsert, newResource, index, EChangeUtil.getID(rootToInsert));
+			return TypeInferringCompoundEChangeFactory.instance.createCreateAndInsertRootChange(rootToInsert, newResource, index);
 		} else {
 
 			return TypeInferringAtomicEChangeFactory.instance.createInsertRootChange(rootToInsert, newResource, index)
@@ -184,7 +183,7 @@ package class EMFModelChangeTransformationUtil {
 		val isDelete = isDelete(newRootContainer, newRootResource)
 		if (isDelete) {
 
-			return TypeInferringCompoundEChangeFactory.instance.createRemoveAndDeleteRootChange(rootToRemove, oldResource, index, EChangeUtil.getID(rootToRemove));
+			return TypeInferringCompoundEChangeFactory.instance.createRemoveAndDeleteRootChange(rootToRemove, oldResource, index);
 		} else {
 
 			return TypeInferringAtomicEChangeFactory.instance.createRemoveRootChange(rootToRemove, oldResource, index);
@@ -199,7 +198,7 @@ package class EMFModelChangeTransformationUtil {
 		val isCreate = forceCreate || (isContainment && oldResource === null)
 		if (isCreate) {
 
-			return TypeInferringCompoundEChangeFactory.instance.createCreateAndInsertNonRootChange(affectedEObject, affectedReference, referenceValue, index, EChangeUtil.getID(referenceValue));
+			return TypeInferringCompoundEChangeFactory.instance.createCreateAndInsertNonRootChange(affectedEObject, affectedReference, referenceValue, index);
 		} else {
 
 			return TypeInferringAtomicEChangeFactory.instance.createInsertReferenceChange(affectedEObject, affectedReference, referenceValue, index);
@@ -212,7 +211,7 @@ package class EMFModelChangeTransformationUtil {
 		val isDelete = forceDelete || (isContainment && isDelete(newContainer, newResource))
 		if (isDelete) {
 
-			return TypeInferringCompoundEChangeFactory.instance.createRemoveAndDeleteNonRootChange(affectedEObject, affectedReference, referenceValue, index, EChangeUtil.getID(referenceValue));
+			return TypeInferringCompoundEChangeFactory.instance.createRemoveAndDeleteNonRootChange(affectedEObject, affectedReference, referenceValue, index);
 		} else {
 
 			return TypeInferringAtomicEChangeFactory.instance.createRemoveReferenceChange(affectedEObject, affectedReference, referenceValue, index);
@@ -224,11 +223,11 @@ package class EMFModelChangeTransformationUtil {
 
 		if (forceCreate || isContainment) {
 			if (oldReferenceValue === null) {
-				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceNonRootChange(affectedEObject, affectedReference, newReferenceValue, EChangeUtil.getID(newReferenceValue))
+				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceNonRootChange(affectedEObject, affectedReference, newReferenceValue)
 			} else if (newReferenceValue === null) {
-				return TypeInferringCompoundEChangeFactory.instance.createReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue, EChangeUtil.getID(oldReferenceValue))
+				return TypeInferringCompoundEChangeFactory.instance.createReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue)
 			} else {
-				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue, newReferenceValue, EChangeUtil.getID(oldReferenceValue), EChangeUtil.getID(newReferenceValue));				
+				return TypeInferringCompoundEChangeFactory.instance.createCreateAndReplaceAndDeleteNonRootChange(affectedEObject, affectedReference, oldReferenceValue, newReferenceValue);				
 			}
 		} else {
 

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndInsertNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndInsertNonRootTest.xtend
@@ -198,6 +198,6 @@ public class CreateAndInsertNonRootTest extends ReferenceEChangeTest {
 	 * Creates new unresolved change.
 	 */
 	def private CreateAndInsertNonRoot<Root, NonRoot> createUnresolvedChange(Root affectedRootObject, NonRoot newNonRoot, int index) {
-		return compoundFactory.createCreateAndInsertNonRootChange(affectedRootObject, affectedFeature, newNonRoot, index, null)
+		return compoundFactory.createCreateAndInsertNonRootChange(affectedRootObject, affectedFeature, newNonRoot, index)
 	}
 }

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndInsertRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndInsertRootTest.xtend
@@ -201,6 +201,6 @@ class CreateAndInsertRootTest extends EChangeTest {
 	 * Creates new unresolved change.
 	 */
 	def private CreateAndInsertRoot<Root> createUnresolvedChange(Root newObject, int index) {
-		return compoundFactory.createCreateAndInsertRootChange(newObject, resource, index, null)	
+		return compoundFactory.createCreateAndInsertRootChange(newObject, resource, index)	
 	}
 }

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndReplaceAndDeleteNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndReplaceAndDeleteNonRootTest.xtend
@@ -200,6 +200,6 @@ class CreateAndReplaceAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * Creates new unresolved change.
 	 */
 	def private CreateAndReplaceAndDeleteNonRoot<Root, NonRoot> createUnresolvedChange(NonRoot newNonRootValue) {
-		return compoundFactory.createCreateAndReplaceAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue, newNonRootValue, null, null)	
+		return compoundFactory.createCreateAndReplaceAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue, newNonRootValue)	
 	}
 }

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndReplaceNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndReplaceNonRootTest.xtend
@@ -184,6 +184,6 @@ class CreateAndReplaceNonRootTest extends EChangeTest {
 	 * Creates new unresolved change.
 	 */	
 	def private CreateAndReplaceNonRoot<Root, NonRoot> createUnresolvedChange(NonRoot newNonRoot) {
-		return compoundFactory.createCreateAndReplaceNonRootChange(affectedEObject, affectedFeature, newNonRoot, null)
+		return compoundFactory.createCreateAndReplaceNonRootChange(affectedEObject, affectedFeature, newNonRoot)
 	}
 }

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ExplicitUnsetEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ExplicitUnsetEReferenceTest.xtend
@@ -480,11 +480,11 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 			}
 		} else {
 			if (!affectedFeature.many) {
-				changes.add(compoundFactory.createReplaceAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue, null))
+				changes.add(compoundFactory.createReplaceAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue))
 			} else {
-				changes.add(compoundFactory.createRemoveAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue3, 2, null))
-				changes.add(compoundFactory.createRemoveAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue2, 1, null))
-				changes.add(compoundFactory.createRemoveAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue, 0, null))
+				changes.add(compoundFactory.createRemoveAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue3, 2))
+				changes.add(compoundFactory.createRemoveAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue2, 1))
+				changes.add(compoundFactory.createRemoveAndDeleteNonRootChange(affectedEObject, affectedFeature, oldValue, 0))
 			}
 		}
 		return compoundFactory.<Root, NonRoot>createExplicitUnsetEReferenceChange(affectedEObject, affectedFeature, changes)

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/RemoveAndDeleteNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/RemoveAndDeleteNonRootTest.xtend
@@ -210,7 +210,7 @@ public class RemoveAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * Creates new unresolved change.
 	 */
 	def private RemoveAndDeleteNonRoot<Root, NonRoot> createUnresolvedChange(Root affectedRootObject, NonRoot newNonRoot, int index) {
-		return compoundFactory.createRemoveAndDeleteNonRootChange(affectedRootObject, affectedFeature, newNonRoot, index, null)	
+		return compoundFactory.createRemoveAndDeleteNonRootChange(affectedRootObject, affectedFeature, newNonRoot, index)	
 	}	
 		
 }

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/RemoveAndDeleteRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/RemoveAndDeleteRootTest.xtend
@@ -207,6 +207,6 @@ class RemoveAndDeleteRootTest extends EChangeTest {
 	 * Creates new unresolved change.
 	 */
 	def private RemoveAndDeleteRoot<Root> createUnresolvedChange(Root newObject, int index) {
-		return compoundFactory.createRemoveAndDeleteRootChange(newObject, resource, index, null)	
+		return compoundFactory.createRemoveAndDeleteRootChange(newObject, resource, index)	
 	}	
 }

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ReplaceAndDeleteNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ReplaceAndDeleteNonRootTest.xtend
@@ -186,6 +186,6 @@ class ReplaceAndDeleteNonRootTest extends EChangeTest {
 	 * Creates new unresolved change.
 	 */
 	def private ReplaceAndDeleteNonRoot<Root, NonRoot> createUnresolvedChange(NonRoot oldNonRoot) {
-		return compoundFactory.createReplaceAndDeleteNonRootChange(affectedEObject, affectedFeature, oldNonRoot, null)
+		return compoundFactory.createReplaceAndDeleteNonRootChange(affectedEObject, affectedFeature, oldNonRoot)
 	}
 }

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/CreateEObjectTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/CreateEObjectTest.xtend
@@ -110,7 +110,7 @@ class CreateEObjectTest extends EObjectTest {
 	 * Creates new unresolved change.
 	 */
 	def private CreateEObject<Root> createUnresolvedChange(Root newObject) {
-		return atomicFactory.createCreateEObjectChange(newObject, resource, null)
+		return atomicFactory.createCreateEObjectChange(newObject, resource)
 	}
 		
 }

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/DeleteEObjectTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/DeleteEObjectTest.xtend
@@ -126,7 +126,7 @@ class DeleteEObjectTest extends EObjectTest {
 	 * Creates new unresolved change.
 	 */
 	def private DeleteEObject<Root> createUnresolvedChange(Root oldObject) {
-		return atomicFactory.createDeleteEObjectChange(oldObject, resource, null)
+		return atomicFactory.createDeleteEObjectChange(oldObject, resource)
 	}
 	
 }

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/EObjectExistenceEChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/EObjectExistenceEChangeTest.xtend
@@ -111,6 +111,6 @@ class EObjectExistenceEChangeTest extends EObjectTest {
 	 */
 	def private EObjectExistenceEChange<Root> createUnresolvedChange(Root createdObject) {
 		// The concrete change type CreateEObject will be used for the tests.
-		return atomicFactory.createCreateEObjectChange(createdObject, resource, null)
+		return atomicFactory.createCreateEObjectChange(createdObject, resource)
 	}
 }


### PR DESCRIPTION
This is an optimized solution for the problem mentioned in #150 and initially solved in #146.

With this PR, changes do not store IDs for ID attributes that are derived, as it makes no sense to store derived information and to (try to) apply them on model elements when applying the change.

This PR fixes #150.