### PR TITLE
Reaction executor processing order

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageConstants.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageConstants.xtend
@@ -3,15 +3,9 @@ package tools.vitruv.dsls.reactions.codegen.helper
 import edu.kit.ipd.sdq.activextendannotations.Utility
 
 @Utility class ReactionsLanguageConstants {
-	private static val BLACKBOARD_NAME = "blackboard";
-	public static val BLACKBOARD_PARAMETER_NAME = BLACKBOARD_NAME;
-	public static val BLACKBOARD_FIELD_NAME = BLACKBOARD_NAME;
 	private static val USER_INTERACTING_NAME = "userInteracting";
 	public static val USER_INTERACTING_PARAMETER_NAME = USER_INTERACTING_NAME;
 	public static val USER_INTERACTING_FIELD_NAME = USER_INTERACTING_NAME;
-	private static val TRANSFORMATION_RESULT_NAME = "transformationResult";
-	public static val TRANSFORMATION_RESULT_PARAMETER_NAME = TRANSFORMATION_RESULT_NAME;
-	public static val TRANSFORMATION_RESULT_FIELD_NAME = TRANSFORMATION_RESULT_NAME;
 	private static val REACTION_EXECUTION_STATE_NAME = "reactionExecutionState";
 	public static val REACTION_EXECUTION_STATE_PARAMETER_NAME = REACTION_EXECUTION_STATE_NAME;
 	public static val REACTION_EXECUTION_STATE_FIELD_NAME = REACTION_EXECUTION_STATE_NAME;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
@@ -18,14 +18,9 @@ import tools.vitruv.dsls.mirbase.mirBase.NamedMetaclassReference
 import tools.vitruv.dsls.reactions.reactionsLanguage.ConcreteModelChange
 import static extension tools.vitruv.dsls.reactions.codegen.changetyperepresentation.ChangeTypeRepresentationExtractor.*
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
+import static tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageConstants.*;
 
 class ParameterGenerator {
-	package static val CHANGE_PARAMETER_NAME = "change";
-	package static val BLACKBOARD_PARAMETER_NAME = "blackboard";
-	package static val TRANSFORMATION_RESULT_PARAMETER_NAME = "transformationResult";
-	package static val USER_INTERACTING_PARAMETER_NAME = "userInteracting";
-	package static val REACTION_EXECUTION_STATE_PARAMETER_NAME = "reactionExecutionState";
-	
 	protected final extension JvmTypeReferenceBuilder _typeReferenceBuilder;
 	protected final extension JvmTypesBuilderWithoutAssociations _typesBuilder;	
 	

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/generator/ReactionsEnvironmentGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/generator/ReactionsEnvironmentGenerator.xtend
@@ -7,7 +7,6 @@ import org.eclipse.xtext.generator.IFileSystemAccess2
 import edu.kit.ipd.sdq.commons.util.java.Pair
 import static extension tools.vitruv.dsls.reactions.codegen.helper.ClassNamesGenerators.*
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
-import tools.vitruv.framework.change.processing.impl.CompositeChangePropagationSpecification
 import tools.vitruv.dsls.reactions.helper.XtendImportHelper
 import org.eclipse.emf.ecore.resource.ResourceSet
 import tools.vitruv.dsls.reactions.reactionsLanguage.ReactionsSegment
@@ -25,6 +24,7 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.Callable
 import java.util.Arrays
 import tools.vitruv.dsls.reactions.codegen.helper.ClassNamesGenerators
+import tools.vitruv.framework.change.processing.impl.CompositeDecomposingChangePropagationSpecification
 
 class ReactionsEnvironmentGenerator {
 
@@ -96,14 +96,14 @@ class ReactionsEnvironmentGenerator {
 		val changePropagationSpecificationNameGenerator = modelPair.changePropagationSpecificationClassNameGenerator
 		'''
 			/**
-			 * The {@link «CompositeChangePropagationSpecification»} for transformations between the metamodels «modelPair.first.name» and «modelPair.second.name».
+			 * The {@link «CompositeDecomposingChangePropagationSpecification»} for transformations between the metamodels «modelPair.first.name» and «modelPair.second.name».
 			 * To add further change processors override the setup method.
 			 *
 			 * <p> This file is generated! Do not edit it but extend it by inheriting from it!
 			 * 
 			 * <p> «VERSION_MARKER» «TEMPLATE_VERSION»
 			 */
-			public class «changePropagationSpecificationNameGenerator.simpleName» extends «CompositeChangePropagationSpecification.typeRef» {
+			public class «changePropagationSpecificationNameGenerator.simpleName» extends «CompositeDecomposingChangePropagationSpecification.typeRef» {
 				
 				private final «List.typeRef»<«Supplier.typeRef»<? extends «ChangePropagationSpecification.typeRef»>> executors = «Arrays.typeRef».asList(
 					«EXECUTORS_MARKER_START»

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeChangePropagationSpecification.xtend
@@ -11,11 +11,14 @@ import tools.vitruv.framework.domains.VitruvDomain
 import tools.vitruv.framework.change.processing.ChangePropagationObserver
 import org.eclipse.emf.ecore.EObject
 import tools.vitruv.framework.util.command.ResourceAccess
+import org.eclipse.xtend.lib.annotations.Accessors
 
 abstract class CompositeChangePropagationSpecification extends AbstractChangePropagationSpecification implements ChangePropagationObserver {
 	private static val logger = Logger.getLogger(CompositeChangePropagationSpecification);
 
+	@Accessors(PROTECTED_GETTER)
 	private val List<ChangePropagationSpecification> changePreprocessors;
+	@Accessors(PROTECTED_GETTER)
 	private val List<ChangePropagationSpecification> changeMainprocessors;
 
 	new(VitruvDomain sourceDomain, VitruvDomain targetDomain) {
@@ -55,8 +58,22 @@ abstract class CompositeChangePropagationSpecification extends AbstractChangePro
 
 	override propagateChange(TransactionalChange change, CorrespondenceModel correspondenceModel,
 		ResourceAccess resourceAccess) {
-		for (changeProcessor : allProcessors) {
-			logger.debug('''Calling change processor «changeProcessor» for change event «change»''');
+		propagateChangeViaPreprocessors(change, correspondenceModel, resourceAccess);
+		propagateChangeViaMainprocessors(change, correspondenceModel, resourceAccess);
+	}
+	
+	protected def propagateChangeViaPreprocessors(TransactionalChange change, CorrespondenceModel correspondenceModel,
+		ResourceAccess resourceAccess) {
+		for (changeProcessor : changePreprocessors) {
+			logger.debug('''Calling change preprocessor «changeProcessor» for change event «change»''');
+			changeProcessor.propagateChange(change, correspondenceModel, resourceAccess);
+		}
+	}
+	
+	protected def propagateChangeViaMainprocessors(TransactionalChange change, CorrespondenceModel correspondenceModel,
+		ResourceAccess resourceAccess) {
+		for (changeProcessor : changeMainprocessors) {
+			logger.debug('''Calling change mainprocessor «changeProcessor» for change event «change»''');
 			changeProcessor.propagateChange(change, correspondenceModel, resourceAccess);
 		}
 	}

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeDecomposingChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeDecomposingChangePropagationSpecification.xtend
@@ -1,0 +1,43 @@
+package tools.vitruv.framework.change.processing.impl
+
+import tools.vitruv.framework.change.processing.impl.CompositeChangePropagationSpecification
+import tools.vitruv.framework.domains.VitruvDomain
+import tools.vitruv.framework.change.description.TransactionalChange
+import tools.vitruv.framework.correspondence.CorrespondenceModel
+import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.description.CompositeTransactionalChange
+import org.apache.log4j.Logger
+
+/**
+ * This {@link ChangePropagationSpecification} acts just like the generic {@link CompositeChangePropagationSpecification}
+ * but disassembles {@link CompositeTransactionalChanges} into their inner changes and applies the main change processors to each of them
+ * instead of applying the main change processors to the complete {@link CompositeTransactionalChange}.
+ * 
+ */
+class CompositeDecomposingChangePropagationSpecification extends CompositeChangePropagationSpecification {
+	private static val logger = Logger.getLogger(CompositeDecomposingChangePropagationSpecification);
+
+	new(VitruvDomain sourceDomain, VitruvDomain targetDomain) {
+		super(sourceDomain, targetDomain)
+	}
+
+	override propagateChangeViaMainprocessors(TransactionalChange change, CorrespondenceModel correspondenceModel,
+		ResourceAccess resourceAccess) {
+		propagateDecomposedChange(change, correspondenceModel, resourceAccess);
+	}
+
+	private def dispatch void propagateDecomposedChange(TransactionalChange change,
+		CorrespondenceModel correspondenceModel, ResourceAccess resourceAccess) {
+		for (changeProcessor : changeMainprocessors) {
+			logger.debug('''Calling change mainprocessor «changeProcessor» for change event «change»''');
+			changeProcessor.propagateChange(change, correspondenceModel, resourceAccess);
+		}
+	}
+
+	private def dispatch void propagateDecomposedChange(CompositeTransactionalChange change,
+		CorrespondenceModel correspondenceModel, ResourceAccess resourceAccess) {
+		for (innerChange : change.changes) {
+			propagateDecomposedChange(innerChange, correspondenceModel, resourceAccess);
+		}
+	}
+}


### PR DESCRIPTION
Reactions generate a `CompositeChangePropagationSpecification` and register one `ReactionsExecutor` for each Reactions file in that specification. During runtime, that specification executes one `ReactionsExecutor` after another on the given `TransactionalChange`.
In general, that `TransactionalChange` is a `CompositeTransactionalChange` consisting of other `TransactionalChange`s. Executing the `ReactionsExecutor`s one after another on the composed change resulted in unwanted behavior, e.g., element creation and ID modification were put into one `CompositeTransactionalChange` but the ID modification was processed before element creation because its `ReactionsExecutor` was executed first.

This PR introduces a `CompositeDecomposingChangePropagationSpecification`, which decomposed `CompositeTransactionChanges` during change propagation and executes all `ReactionsExecutor`s on an atomic change before processing the next.

This PR fixes #62.