### PR TITLE
Add org.eclipse.rcp to DSL Tests’ Target Platform

### DIFF
--- a/tests/dsls/pom.xml
+++ b/tests/dsls/pom.xml
@@ -22,7 +22,7 @@
 		<module>tools.vitruv.dsls.reactions.tests</module>
 		<!--<module>tools.vitruv.dsls.reactions.ui.tests</module>-->
 	</modules>
-	
+
 	<build>
 		<plugins>
 			<plugin>
@@ -38,6 +38,26 @@
 					<excludes>
 						<exclude>**/Abstract*</exclude>
 					</excludes>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<configuration>
+					<dependency-resolution>
+						<optionalDependencies>require</optionalDependencies>
+						<extraRequirements>
+							<!-- to get the org.eclipse.osgi.compatibility.state plugin if the 
+								target platform is Luna or later. (backward compatible with kepler and previous 
+								versions) see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492149 -->
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>org.eclipse.rcp</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
This is part of the default configuration when setting up new Xtext projects. The commonalities tests are the only once requiring this piece of configuration at the moment. However, other UI tests could require it at some point. So having it in the common configuration makes more sense to me.