### PR TITLE
Extend TUID mechanism to be able to reference metaclasses (EClass)

### DIFF
--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/Tuid.xtend
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/Tuid.xtend
@@ -42,7 +42,8 @@ import org.eclipse.emf.ecore.EObject
  * @author kramerm
  */
 final class Tuid implements Serializable {
-
+	public static final String META_ELEMENT_PREFIX = "MetaElement"
+	 
 	protected static final long serialVersionUID = 5018494116382201707L
 
 	static var SEGMENTS = generateForwardHashedBackwardLinkedTree()
@@ -251,4 +252,7 @@ lastSegment2TuidMap:
 				return true
 			}
 
+	def boolean isMetaElementTuid() {
+		return this.toString().startsWith(META_ELEMENT_PREFIX);
+	}
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/TuidResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/TuidResolverImpl.xtend
@@ -23,6 +23,10 @@ class TuidResolverImpl implements tools.vitruv.framework.tuid.TuidResolver{
 	}
 
 	override EObject resolveEObjectFromTuid(Tuid tuid) {
+		if (tuid.isMetaElementTuid) {
+			// Meta element Tuids cannot be resolved
+			return null;
+		}
 		val TuidAwareVitruvDomain domain = getMetamodelHavingTuid(tuid)
 		var VURI vuri = domain.getModelVURIContainingIdentifiedEObject(tuid)
 		var ModelInstance modelInstance = null


### PR DESCRIPTION
This PR allows to define correspondences between metaclasses (EClasses) and model elements (EObjects). This can be useful to define static correspondences (e.g. for a UML model corresponding to the complete Java model). 

Fixes #39 
