### PR TITLE
Optimized Reactions retrieval

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/GenerateReactionsLanguage.mwe2
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/GenerateReactionsLanguage.mwe2
@@ -53,10 +53,4 @@ Workflow {
 		generateCustomClasses = false
 	}
 	
-	// Execute EMF model code generator again, as otherwise some feature ID references are broken
-	component = EcoreGenerator {
-		srcPath = "platform:/resource/tools.vitruv.dsls.reactions/src-gen"
-		genModel = "platform:/resource/tools.vitruv.dsls.reactions/model/generated/ReactionsLanguage.genmodel"
-		generateCustomClasses = false
-	}
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/GenerateReactionsLanguage.mwe2
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/GenerateReactionsLanguage.mwe2
@@ -48,8 +48,15 @@ Workflow {
 	}
 	
 	component = EcoreGenerator {
-		srcPath = "platform:/resource/tools.vitruv.dsls.commonalities/src"
+		srcPath = "platform:/resource/tools.vitruv.dsls.reactions/model-gen"
 		genModel = "platform:/resource/tools.vitruv.dsls.reactions/model/InputTypes.genmodel"
+		generateCustomClasses = false
+	}
+	
+	// Execute EMF model code generator again, as otherwise some feature ID references are broken
+	component = EcoreGenerator {
+		srcPath = "platform:/resource/tools.vitruv.dsls.reactions/src-gen"
+		genModel = "platform:/resource/tools.vitruv.dsls.reactions/model/generated/ReactionsLanguage.genmodel"
 		generateCustomClasses = false
 	}
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
@@ -165,19 +165,16 @@ RetrieveModelElement:
 
 
 RetrieveModelElementTypeStatement returns RetrieveModelElementType:
-	{RetrieveOneModelElement} 'one' type=RetrieveOneElementType |
+	{RetrieveOneModelElement} (optional?='optional' | asserted?='asserted')? |
 	{RetrieveManyModelElements} 'many';
 
 enum RetrieveOneElementType:
-	optional='optional' | matching='matching' | asserted='asserted' ;
+	optional='optional' | asserted='asserted' ;
 
 MatcherCheckStatement:
 	{MatcherCheckStatement}
-	'check' checkType=CheckType CodeBlock;
+	'check' (asserted?='asserted')? CodeBlock;
 	
-enum CheckType:
-	asserted='asserted' | matching='matching';
-
 // *********** EFFECTS ***********
 
 ActionBlock returns Action:

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
@@ -173,7 +173,10 @@ enum RetrieveOneElementType:
 
 MatcherCheckStatement:
 	{MatcherCheckStatement}
-	'check' CodeBlock;
+	'check' checkType=CheckType CodeBlock;
+	
+enum CheckType:
+	asserted='asserted' | matching='matching';
 
 // *********** EFFECTS ***********
 

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
@@ -149,14 +149,27 @@ MatcherBlock returns Matcher:
 	'}';
 
 MatcherStatement:
-	RetrieveModelElementStatement | MatcherCheckStatement;
+	RetrieveOrRequireAbscenceOfModelElement | MatcherCheckStatement;
 
-RetrieveModelElementStatement returns RetrieveModelElement:
-	{RetrieveModelElement}
-	// TODO remove uses of required property or set it to something like required?=!optional
-	((('val' name=ValidID '=')? 'retrieve' optional?='optional'?) | abscence?='require absence of') 
-	MetaclassReference 'corresponding to' correspondenceSource=CorrespondingObjectCodeBlock
-	('tagged with' Taggable)? ('with' precondition=PreconditionCodeBlock)?;
+RetrieveOrRequireAbscenceOfModelElement:
+	(RequireAbscenceOfModelElement | RetrieveModelElement) MetaclassReference 
+	'corresponding to' correspondenceSource=CorrespondingObjectCodeBlock ('tagged with' Taggable)? 
+	('with' precondition=PreconditionCodeBlock)?; 
+
+RequireAbscenceOfModelElement returns RequireAbscenceOfModelElement:
+	{RequireAbscenceOfModelElement}
+	'require absence of';
+	
+RetrieveModelElement:
+	('val' name=ValidID '=')? 'retrieve' retrievalType=RetrieveModelElementTypeStatement;
+
+
+RetrieveModelElementTypeStatement returns RetrieveModelElementType:
+	{RetrieveOneModelElement} 'one' type=RetrieveOneElementType |
+	{RetrieveManyModelElements} 'many';
+
+enum RetrieveOneElementType:
+	optional='optional' | matching='matching' | asserted='asserted' ;
 
 MatcherCheckStatement:
 	{MatcherCheckStatement}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/api/generator/IReactionsGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/api/generator/IReactionsGenerator.xtend
@@ -6,8 +6,6 @@ import tools.vitruv.dsls.reactions.reactionsLanguage.Reaction
 import tools.vitruv.dsls.reactions.generator.ReactionBuilder
 import org.eclipse.xtext.resource.XtextResourceSet
 import tools.vitruv.dsls.reactions.builder.FluentReactionsFileBuilder
-import java.nio.file.Path
-import org.eclipse.emf.common.util.URI
 import tools.vitruv.dsls.reactions.generator.ExternalReactionsGenerator
 import org.eclipse.emf.ecore.resource.ResourceSet
 import java.io.IOException

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
@@ -313,11 +313,13 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 		}
 
 		def check(Function<RoutineTypeProvider, XExpression> expressionBuilder) {
-			routine.matcher.matcherStatements ReactionsLanguageFactory.eINSTANCE.createMatcherCheckStatement => [
+			val statement = ReactionsLanguageFactory.eINSTANCE.createMatcherCheckStatement => [
 				code = XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
 					expressions += extractExpressions(expressionBuilder.apply(typeProvider))
 				]
 			]
+			routine.matcher.matcherStatements += statement
+			return statement
 		}
 		
 		def checkAsserted(Function<RoutineTypeProvider, XExpression> expressionBuilder) {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
@@ -26,6 +26,8 @@ import static tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageConsta
 import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveOneModelElement
 import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveOneElementType
 import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveOrRequireAbscenceOfModelElement
+import tools.vitruv.dsls.reactions.reactionsLanguage.MatcherCheckStatement
+import tools.vitruv.dsls.reactions.reactionsLanguage.CheckType
 
 class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 
@@ -324,12 +326,32 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 			return new RetrieveModelElementMatcherStatementCorrespondenceBuilder(builder, statement)
 		}
 
-		def void check(Function<RoutineTypeProvider, XExpression> expressionBuilder) {
-			routine.matcher.matcherStatements += ReactionsLanguageFactory.eINSTANCE.createMatcherCheckStatement => [
+		def check(Function<RoutineTypeProvider, XExpression> expressionBuilder) {
+			val statement = ReactionsLanguageFactory.eINSTANCE.createMatcherCheckStatement => [
 				code = XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
 					expressions += extractExpressions(expressionBuilder.apply(typeProvider))
 				]
 			]
+			routine.matcher.matcherStatements += statement
+			return new MatcherCheckTypeBuilder(builder, statement);
+		}
+	}
+	
+	static class MatcherCheckTypeBuilder {
+		val extension FluentRoutineBuilder builder
+		val MatcherCheckStatement statement
+
+		private new(FluentRoutineBuilder builder, MatcherCheckStatement statement) {
+			this.builder = builder
+			this.statement = statement
+		}
+
+		def void asserted() {
+			statement.checkType = CheckType.ASSERTED
+		}
+
+		def void matching() {
+			statement.checkType = CheckType.MATCHING
 		}
 	}
 	

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ClassGenerator.xtend
@@ -25,7 +25,7 @@ abstract class ClassGenerator extends TypesBuilderExtensionProvider implements I
 
 	protected def generateAccessibleElementsParameters(EObject sourceObject,
 		Iterable<AccessibleElement> accessibleElements) {
-		accessibleElements.map[sourceObject.toParameter(name, typeRef(fullyQualifiedType))];
+			sourceObject.generateMethodInputParameters(accessibleElements)
 	}
 
 	public new(TypesBuilderExtensionProvider typesBuilderExtensionProvider) {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
@@ -39,6 +39,7 @@ import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveOneElementType
 import tools.vitruv.dsls.reactions.reactionsLanguage.RequireAbscenceOfModelElement
 import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveOrRequireAbscenceOfModelElement
 import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveManyModelElements
+import tools.vitruv.dsls.reactions.reactionsLanguage.CheckType
 
 class RoutineClassGenerator extends ClassGenerator {
 	protected final Routine routine;
@@ -213,7 +214,11 @@ class RoutineClassGenerator extends ClassGenerator {
 		val checkMethodCall = checkMethod.userExecutionMethodCallString;
 		return '''
 		if (!«checkMethodCall») {
-			return false;
+			«IF checkStatement.checkType == CheckType.ASSERTED»
+				throw new «IllegalStateException»();
+			«ELSE»
+				return false;
+			«ENDIF»
 		}''';
 	}
 

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/AccessibleElement.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/AccessibleElement.xtend
@@ -1,24 +1,29 @@
 package tools.vitruv.dsls.reactions.codegen.helper
 
+import java.util.List
+import org.eclipse.xtend.lib.annotations.Accessors
+
 class AccessibleElement {
+	@Accessors(PUBLIC_GETTER)
 	private val String name;
+	@Accessors(PUBLIC_GETTER)
 	private val String fullyQualifiedTypeName;
+	@Accessors(PUBLIC_GETTER)
+	private val List<String> typeParameters;
 	
 	public new(String name, String fullyQualifiedTypeName) {
 		this.name = name;
 		this.fullyQualifiedTypeName = fullyQualifiedTypeName;
+		this.typeParameters = newArrayList
+	}
+	
+	public new(String name, String fullyQualifiedTypeName, String... typeParameters) {
+		this(name, fullyQualifiedTypeName);
+		this.typeParameters += typeParameters;
 	}
 	
 	public new(String name, Class<?> type) {
-		this.name = name;
-		this.fullyQualifiedTypeName = type.name;
+		this(name, type.name)
 	}
 	
-	public def String getName() {
-		return name;
-	}
-	
-	public def String getFullyQualifiedType() {
-		return fullyQualifiedTypeName;
-	}
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageConstants.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageConstants.xtend
@@ -3,6 +3,7 @@ package tools.vitruv.dsls.reactions.codegen.helper
 import edu.kit.ipd.sdq.activextendannotations.Utility
 
 @Utility class ReactionsLanguageConstants {
+	public static val RETRIEVAL_PRECONDITION_METHOD_TARGET = "potentialTarget"
 	private static val USER_INTERACTING_NAME = "userInteracting";
 	public static val USER_INTERACTING_PARAMETER_NAME = USER_INTERACTING_NAME;
 	public static val USER_INTERACTING_FIELD_NAME = USER_INTERACTING_NAME;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
@@ -74,9 +74,11 @@ class ParameterGenerator {
 	}
 	
 	public def Iterable<JvmFormalParameter> generateMethodInputParameters(EObject contextObject, Iterable<NamedMetaclassReference> metaclassReferences, Iterable<NamedJavaElement> javaElements) {
-		return contextObject.getInputElements(metaclassReferences, javaElements).map[
-			toParameter(contextObject, it.name, typeRef(it.fullyQualifiedType))
-		];
+		return contextObject.generateMethodInputParameters(contextObject.getInputElements(metaclassReferences, javaElements));
+	}
+	
+	public def Iterable<JvmFormalParameter> generateMethodInputParameters(EObject contextObject, Iterable<AccessibleElement> elements) {
+		elements.map[toParameter(contextObject, it.name, typeRef(it.fullyQualifiedTypeName, it.typeParameters.map[typeRef]))]
 	}
 	
 	private def getMappedInstanceClassCanonicalName(EClass eClass) {

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
@@ -80,7 +80,7 @@ class FluentReactionsLanguageBuilderTests {
 					.afterElement(Root).deleted
 					.call [
 						match [
-							vall('toDelete').retrieveOne(Root).matching.correspondingTo.affectedEObject
+							vall('toDelete').retrieve(Root).correspondingTo.affectedEObject
 						].action [
 							delete('toDelete')
 						]
@@ -100,7 +100,7 @@ class FluentReactionsLanguageBuilderTests {
 			
 			routine deleteRootTestRepair(allElementTypes::Root affectedEObject) {
 				match {
-					val toDelete = retrieve one matching allElementTypes::Root corresponding to affectedEObject
+					val toDelete = retrieve allElementTypes::Root corresponding to affectedEObject
 				}
 				action {
 					delete toDelete

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
@@ -80,7 +80,7 @@ class FluentReactionsLanguageBuilderTests {
 					.afterElement(Root).deleted
 					.call [
 						match [
-							vall('toDelete').retrieve(Root).correspondingTo.affectedEObject
+							vall('toDelete').retrieveOne(Root).matching.correspondingTo.affectedEObject
 						].action [
 							delete('toDelete')
 						]
@@ -100,7 +100,7 @@ class FluentReactionsLanguageBuilderTests {
 			
 			routine deleteRootTestRepair(allElementTypes::Root affectedEObject) {
 				match {
-					val toDelete = retrieve allElementTypes::Root corresponding to affectedEObject
+					val toDelete = retrieve one matching allElementTypes::Root corresponding to affectedEObject
 				}
 				action {
 					delete toDelete

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesRootTests.reactions
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesRootTests.reactions
@@ -18,7 +18,7 @@ routine createRoot(minimal::Root rootElement) {
 
 routine deleteRoot(minimal::Root rootElement) {
 	match {
-		val oldModel = retrieve one asserted minimal::Root corresponding to rootElement
+		val oldModel = retrieve asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		delete oldModel

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesRootTests.reactions
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesRootTests.reactions
@@ -18,7 +18,7 @@ routine createRoot(minimal::Root rootElement) {
 
 routine deleteRoot(minimal::Root rootElement) {
 	match {
-		val oldModel = retrieve minimal::Root corresponding to rootElement
+		val oldModel = retrieve one asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		delete oldModel

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.reactions
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.reactions
@@ -19,7 +19,7 @@ reaction ReplacedSingleValuedPrimitiveTypeEAttribute {
 
 routine replaceSingleValuedPrimitiveTypeEAttribute(minimal::Root rootElement, Integer value) {
 	match {
-		val targetElement = retrieve minimal::Root corresponding to rootElement
+		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetElement {
@@ -43,7 +43,7 @@ routine replaceSingleValuedEAttribute(minimal::Root rootElement, Integer value) 
 	match {
 		// The check statements do only test that multiple check statements work
 		check { rootElement !== null }
-		val targetElement = retrieve minimal::Root corresponding to rootElement
+		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
 		check { value !== null }
 	}
 	action {
@@ -66,7 +66,7 @@ reaction ReplacedIdentifiedId {
 
 routine replaceIdentifiedId(minimal::Identified identified, String value) {
 	match {
-		val targetElement = retrieve minimal::Identified corresponding to identified
+		val targetElement = retrieve one asserted minimal::Identified corresponding to identified
 	}
 	action {
 		update targetElement {
@@ -85,7 +85,7 @@ reaction CreatedNonRootEObjectInList {
 
 routine insertNonRoot(minimal::Root rootElement, minimal::NonRoot insertedNonRoot) {
 	match {
-		val targetElement = retrieve minimal::Root corresponding to rootElement
+		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		val newNonRoot = create minimal::NonRoot and initialize {
@@ -111,7 +111,7 @@ reaction DeletedNonRootEObjectInList {
 
 routine removeNonRoot(minimal::NonRoot removedNonRoot) {
 	match {
-		val targetElement = retrieve minimal::NonRoot corresponding to removedNonRoot
+		val targetElement = retrieve one asserted minimal::NonRoot corresponding to removedNonRoot
 	}
 	action {
 		call {
@@ -138,7 +138,7 @@ reaction ReplacedNonRootEObjectSingleReaction {
 
 routine deleteNonRootEObjectSingle(minimal::NonRoot containedObject) {
 	match {
-		val targetElement = retrieve minimal::NonRoot corresponding to containedObject
+		val targetElement = retrieve one asserted minimal::NonRoot corresponding to containedObject
 	}
 	action {
 		delete targetElement
@@ -150,7 +150,7 @@ routine deleteNonRootEObjectSingle(minimal::NonRoot containedObject) {
 
 routine createNonRootEObjectSingle(minimal::Root sourceRoot, minimal::NonRoot containedObject) {
 	match {
-		val targetElement = retrieve minimal::Root corresponding to sourceRoot
+		val targetElement = retrieve one asserted minimal::Root corresponding to sourceRoot
 	}
 	action {
 		val newNonRoot = create minimal::NonRoot and initialize {
@@ -177,8 +177,8 @@ reaction ReplacedSingleValuedNonContainmentEReference {
 routine replaceSingleValuedNonContainmentReference(minimal::Root rootElement, minimal::NonRoot newReferencedElement
 ) {
 	match {
-		val targetContainer = retrieve minimal::Root corresponding to rootElement
-		val targetElement = retrieve minimal::NonRoot corresponding to newReferencedElement
+		val targetContainer = retrieve one asserted minimal::Root corresponding to rootElement
+		val targetElement = retrieve one asserted minimal::NonRoot corresponding to newReferencedElement
 	}
 	action {
 		update targetContainer {
@@ -200,7 +200,7 @@ reaction InsertedEAttributeValue {
 
 routine insertEAttribute(minimal::Root rootElement, Integer attributeValue) {
 	match {
-		val targetElement = retrieve minimal::Root corresponding to rootElement
+		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetElement {
@@ -222,7 +222,7 @@ reaction RemovedEAttributeValue {
 
 routine removeEAttribute(minimal::Root rootElement, Integer removedAttributeValue) {
 	match {
-		val targetElement = retrieve minimal::Root corresponding to rootElement
+		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetElement {
@@ -245,7 +245,7 @@ reaction InsertedNonContainmentEReference {
 
 routine insertNonContainmentReference(minimal::Root rootElement, minimal::NonRoot insertedNonRoot) {
 	match {
-		val targetElement = retrieve minimal::Root corresponding to rootElement
+		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetElement {
@@ -269,7 +269,7 @@ reaction RemovedNonContainmentEReference {
 
 routine removeNonContainmentReference(minimal::Root rootElement, minimal::NonRoot removedNonRoot) {
 	match {
-		val targetRoot = retrieve minimal::Root corresponding to rootElement
+		val targetRoot = retrieve one asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetRoot {
@@ -294,7 +294,7 @@ reaction HelperReactionForNonRootObjectContainerInitialization {
 
 routine createNonRootObjectContainer(minimal::Root rootElement, minimal::NonRootObjectContainerHelper nonRootObjectContainer) {
 	match {
-		val targetElement = retrieve minimal::Root corresponding to rootElement
+		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		val newNonRootContainer = create minimal::NonRootObjectContainerHelper and initialize {
@@ -317,7 +317,7 @@ reaction HelperReactionForNonRootObjectContainerContentsInitialization {
 
 routine createNonRootInContainer(minimal::NonRootObjectContainerHelper container, minimal::NonRoot insertedNonRoot) {
 	match {
-		val nonRootContainer = retrieve minimal::NonRootObjectContainerHelper corresponding to container
+		val nonRootContainer = retrieve one asserted minimal::NonRootObjectContainerHelper corresponding to container
 	}
 	action {
 		val newNonRoot = create minimal::NonRoot and initialize {
@@ -373,3 +373,19 @@ routine testJavaTypes(plain SimpleChangesTestsExecutionMonitor as monitor) {
 		execute {}
 	}
 }
+
+reaction CheckManyCorrespondenceRetrievalWorks {
+	after attribute replaced at minimal::Root[singleValuedEAttribute]
+	call checkManyCorrespondenceRetrievalWorks(affectedEObject)
+}
+
+routine checkManyCorrespondenceRetrievalWorks(minimal::Root rootElement) {
+	match {
+		val targetElements = retrieve many minimal::Root corresponding to rootElement
+		check { return targetElements !== null && !targetElements.empty }
+	}
+	action {
+		call { }
+	}
+}
+

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.reactions
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.reactions
@@ -42,9 +42,9 @@ reaction ReplacedSingleValuedEAttribute {
 routine replaceSingleValuedEAttribute(minimal::Root rootElement, Integer value) {
 	match {
 		// The check statements do only test that multiple check statements work
-		check { rootElement !== null }
+		check asserted { rootElement !== null }
 		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
-		check { value !== null }
+		check matching { value !== null }
 	}
 	action {
 		update targetElement {
@@ -382,7 +382,7 @@ reaction CheckManyCorrespondenceRetrievalWorks {
 routine checkManyCorrespondenceRetrievalWorks(minimal::Root rootElement) {
 	match {
 		val targetElements = retrieve many minimal::Root corresponding to rootElement
-		check { return targetElements !== null && !targetElements.empty }
+		check asserted { return targetElements !== null && !targetElements.empty }
 	}
 	action {
 		call { }

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.reactions
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.reactions
@@ -19,7 +19,7 @@ reaction ReplacedSingleValuedPrimitiveTypeEAttribute {
 
 routine replaceSingleValuedPrimitiveTypeEAttribute(minimal::Root rootElement, Integer value) {
 	match {
-		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
+		val targetElement = retrieve asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetElement {
@@ -43,8 +43,8 @@ routine replaceSingleValuedEAttribute(minimal::Root rootElement, Integer value) 
 	match {
 		// The check statements do only test that multiple check statements work
 		check asserted { rootElement !== null }
-		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
-		check matching { value !== null }
+		val targetElement = retrieve asserted minimal::Root corresponding to rootElement
+		check { value !== null }
 	}
 	action {
 		update targetElement {
@@ -66,7 +66,7 @@ reaction ReplacedIdentifiedId {
 
 routine replaceIdentifiedId(minimal::Identified identified, String value) {
 	match {
-		val targetElement = retrieve one asserted minimal::Identified corresponding to identified
+		val targetElement = retrieve asserted minimal::Identified corresponding to identified
 	}
 	action {
 		update targetElement {
@@ -85,7 +85,7 @@ reaction CreatedNonRootEObjectInList {
 
 routine insertNonRoot(minimal::Root rootElement, minimal::NonRoot insertedNonRoot) {
 	match {
-		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
+		val targetElement = retrieve asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		val newNonRoot = create minimal::NonRoot and initialize {
@@ -111,7 +111,7 @@ reaction DeletedNonRootEObjectInList {
 
 routine removeNonRoot(minimal::NonRoot removedNonRoot) {
 	match {
-		val targetElement = retrieve one asserted minimal::NonRoot corresponding to removedNonRoot
+		val targetElement = retrieve asserted minimal::NonRoot corresponding to removedNonRoot
 	}
 	action {
 		call {
@@ -138,7 +138,7 @@ reaction ReplacedNonRootEObjectSingleReaction {
 
 routine deleteNonRootEObjectSingle(minimal::NonRoot containedObject) {
 	match {
-		val targetElement = retrieve one asserted minimal::NonRoot corresponding to containedObject
+		val targetElement = retrieve asserted minimal::NonRoot corresponding to containedObject
 	}
 	action {
 		delete targetElement
@@ -150,7 +150,7 @@ routine deleteNonRootEObjectSingle(minimal::NonRoot containedObject) {
 
 routine createNonRootEObjectSingle(minimal::Root sourceRoot, minimal::NonRoot containedObject) {
 	match {
-		val targetElement = retrieve one asserted minimal::Root corresponding to sourceRoot
+		val targetElement = retrieve asserted minimal::Root corresponding to sourceRoot
 	}
 	action {
 		val newNonRoot = create minimal::NonRoot and initialize {
@@ -177,8 +177,8 @@ reaction ReplacedSingleValuedNonContainmentEReference {
 routine replaceSingleValuedNonContainmentReference(minimal::Root rootElement, minimal::NonRoot newReferencedElement
 ) {
 	match {
-		val targetContainer = retrieve one asserted minimal::Root corresponding to rootElement
-		val targetElement = retrieve one asserted minimal::NonRoot corresponding to newReferencedElement
+		val targetContainer = retrieve asserted minimal::Root corresponding to rootElement
+		val targetElement = retrieve asserted minimal::NonRoot corresponding to newReferencedElement
 	}
 	action {
 		update targetContainer {
@@ -200,7 +200,7 @@ reaction InsertedEAttributeValue {
 
 routine insertEAttribute(minimal::Root rootElement, Integer attributeValue) {
 	match {
-		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
+		val targetElement = retrieve asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetElement {
@@ -222,7 +222,7 @@ reaction RemovedEAttributeValue {
 
 routine removeEAttribute(minimal::Root rootElement, Integer removedAttributeValue) {
 	match {
-		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
+		val targetElement = retrieve asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetElement {
@@ -245,7 +245,7 @@ reaction InsertedNonContainmentEReference {
 
 routine insertNonContainmentReference(minimal::Root rootElement, minimal::NonRoot insertedNonRoot) {
 	match {
-		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
+		val targetElement = retrieve asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetElement {
@@ -269,7 +269,7 @@ reaction RemovedNonContainmentEReference {
 
 routine removeNonContainmentReference(minimal::Root rootElement, minimal::NonRoot removedNonRoot) {
 	match {
-		val targetRoot = retrieve one asserted minimal::Root corresponding to rootElement
+		val targetRoot = retrieve asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		update targetRoot {
@@ -294,7 +294,7 @@ reaction HelperReactionForNonRootObjectContainerInitialization {
 
 routine createNonRootObjectContainer(minimal::Root rootElement, minimal::NonRootObjectContainerHelper nonRootObjectContainer) {
 	match {
-		val targetElement = retrieve one asserted minimal::Root corresponding to rootElement
+		val targetElement = retrieve asserted minimal::Root corresponding to rootElement
 	}
 	action {
 		val newNonRootContainer = create minimal::NonRootObjectContainerHelper and initialize {
@@ -317,7 +317,7 @@ reaction HelperReactionForNonRootObjectContainerContentsInitialization {
 
 routine createNonRootInContainer(minimal::NonRootObjectContainerHelper container, minimal::NonRoot insertedNonRoot) {
 	match {
-		val nonRootContainer = retrieve one asserted minimal::NonRootObjectContainerHelper corresponding to container
+		val nonRootContainer = retrieve asserted minimal::NonRootObjectContainerHelper corresponding to container
 	}
 	action {
 		val newNonRoot = create minimal::NonRoot and initialize {


### PR DESCRIPTION
This PR improves the retrieval operations in Reactions. It is now possible to define _many_ retrievals for retrieving collections of elements. Furthermore, extending `retrieve` with `asserted` defines that the correspondences is asserted to exist, resulting in an exception if it cannot be resolved. The latter extension is also added for `check` statements.

Fixes #36, fixes #143 and contributes to #131
