### PR TITLE
Reverse resolved propagated changes

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/PropagatedChange.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/PropagatedChange.xtend
@@ -15,8 +15,10 @@ class PropagatedChange {
 	'''
 	
 	def applyBackward(UuidResolver uuidResolver) {
+		consequentialChanges.unresolveIfApplicable;
+		originalChange.unresolveIfApplicable;
 		consequentialChanges.resolveAfterAndApplyBackward(uuidResolver);
-		originalChange.applyBackward;
+		originalChange.resolveAfterAndApplyBackward(uuidResolver);
 	}
 	
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.java
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.java
@@ -323,17 +323,6 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
         return this.metamodelRepository.getDomain(fileExtension);
     }
 
-    // private void loadAndMapCorrepondenceInstances() {
-    // for (Metamodel metamodel : this.metamodelManaging) {
-    // for (Metamodel metamodel2 : this.metamodelManaging) {
-    // if (metamodel != metamodel2
-    // && getCorrespondenceModel(metamodel.getURI(), metamodel2.getURI()) == null) {
-    // createCorrespondenceModel(new MetamodelPair(metamodel, metamodel2));
-    // }
-    // }
-    // }
-    // }
-
     @Override
     public void startRecording() {
         this.changeRecorder.beginRecording();

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.java
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.java
@@ -353,9 +353,6 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
         result.addAll(relevantChanges.stream().filter(
                 change -> change.getURI() == null || !change.getURI().getEMFUri().toString().endsWith("correspondence"))
                 .collect(Collectors.toList()));
-        for (TransactionalChange change : relevantChanges) {
-            change.unresolveIfApplicable();
-        }
         logger.debug("End recording virtual model");
         return result;
     }


### PR DESCRIPTION
This PR allows to use both resolved and unresolved changes within a `PropagatedChange` and to be able to apply that change backward. A `PropagatedChange` simply unresovles all original and consequential changes before resolving and applying them backwards.

Per default, a `PropagatedChange` contains only resolved changes after this PR, whereas it contained resolved original and unresolved consequential changes before.

Fixes #128.