### PR TITLE
Improve Fluent Builders

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionBuilder.xtend
@@ -21,7 +21,6 @@ import tools.vitruv.dsls.reactions.reactionsLanguage.ReactionsLanguageFactory
 import static com.google.common.base.Preconditions.*
 import static tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageConstants.*
 import org.eclipse.emf.ecore.EcorePackage
-import org.eclipse.emf.ecore.EcoreFactory
 
 class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 
@@ -79,7 +78,7 @@ class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 		
 		def afterAttributeInsertIn(EClass eClass, EAttribute attribute) {
 			valueType = attribute.EType
-			affectedElementType = attribute.EContainingClass
+			affectedElementType = eClass
 			reaction.trigger = ReactionsLanguageFactory.eINSTANCE.createModelAttributeInsertedChange => [
 				feature = MirBaseFactory.eINSTANCE.createMetaclassEAttributeReference.reference(eClass, attribute)
 			]
@@ -92,7 +91,7 @@ class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 		
 		def afterAttributeReplacedAt(EClass eClass, EAttribute attribute) {
 			valueType = attribute.EType
-			affectedElementType = attribute.EContainingClass
+			affectedElementType = eClass
 			reaction.trigger = ReactionsLanguageFactory.eINSTANCE.createModelAttributeReplacedChange => [
 				feature = MirBaseFactory.eINSTANCE.createMetaclassEAttributeReference.reference(eClass, attribute)
 			]
@@ -105,7 +104,7 @@ class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 
 		def afterAttributeRemoveFrom(EClass eClass, EAttribute attribute) {
 			valueType = attribute.EType
-			affectedElementType = attribute.EContainingClass
+			affectedElementType = eClass
 			reaction.trigger = ReactionsLanguageFactory.eINSTANCE.createModelAttributeRemovedChange => [
 				feature = MirBaseFactory.eINSTANCE.createMetaclassEAttributeReference.reference(eClass, attribute)
 			]
@@ -145,6 +144,7 @@ class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 		
 		def insertedIn(EClass eClass, EReference reference) {
 			valueType = element ?: reference.EReferenceType
+			affectedElementType = eClass
 			continueWithChangeType(ReactionsLanguageFactory.eINSTANCE.createElementInsertionInListChangeType => [
 				feature = MirBaseFactory.eINSTANCE.createMetaclassEReferenceReference.reference(eClass, reference)
 			])
@@ -156,6 +156,7 @@ class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 		
 		def removedFrom(EClass eClass, EReference reference) {
 			valueType = element ?: reference.EReferenceType
+			affectedElementType = eClass
 			continueWithChangeType(ReactionsLanguageFactory.eINSTANCE.createElementRemovalFromListChangeType => [
 				feature = MirBaseFactory.eINSTANCE.createMetaclassEReferenceReference.reference(eClass, reference)
 			])
@@ -167,6 +168,7 @@ class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 		
 		def replacedAt(EClass eClass, EReference reference) {
 			valueType = element ?: reference.EReferenceType
+			affectedElementType = eClass
 			continueWithChangeType(ReactionsLanguageFactory.eINSTANCE.createElementReplacementChangeType => [
 				feature = MirBaseFactory.eINSTANCE.createMetaclassEReferenceReference.reference(eClass, reference)
 			])

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionElementBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionElementBuilder.xtend
@@ -236,21 +236,21 @@ abstract package class FluentReactionElementBuilder {
 		]
 	}
 
-	def protected <T extends MetaclassEReferenceReference> reference(T referenceReference, EReference reference) {
+	def protected <T extends MetaclassEReferenceReference> reference(T referenceReference, EClass eClass, EReference reference) {
 		(referenceReference => [
 			feature = reference
-			metaclass = reference.EContainingClass
+			metaclass = eClass
 		]).beforeAttached [
-			metamodel = reference.EContainingClass.EPackage.metamodelImport
+			metamodel = eClass.EPackage.metamodelImport
 		]
 	}
 
-	def protected <T extends MetaclassEAttributeReference> reference(T attributeReference, EAttribute attribute) {
+	def protected <T extends MetaclassEAttributeReference> reference(T attributeReference, EClass eClass, EAttribute attribute) {
 		(attributeReference => [
 			feature = attribute
-			metaclass = attribute.EContainingClass
+			metaclass = eClass
 		]).beforeAttached [
-			metamodel = attribute.EContainingClass.EPackage.metamodelImport
+			metamodel = eClass.EPackage.metamodelImport
 		]
 	}
 

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
@@ -290,6 +290,12 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 			statement.correspondenceSource = correspondingElement(CHANGE_NEW_VALUE_ATTRIBUTE)
 			new TaggedWithBuilder(builder, statement)
 		}
+		
+		def oldValue() {
+			requireOldValue = true
+			statement.correspondenceSource = correspondingElement(CHANGE_OLD_VALUE_ATTRIBUTE)
+			new TaggedWithBuilder(builder, statement)
+		}
 	}
 
 	static class UndecidedMatcherStatementBuilder {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
@@ -73,9 +73,9 @@ class UserExecutionClassGenerator extends ClassGenerator {
 
 	protected def JvmOperation generateUpdateElementMethod(String elementName, CodeBlock codeBlock,
 		Iterable<AccessibleElement> accessibleElements) {
-		return codeBlock.getOrGenerateMethod("update" + elementName.toFirstUpper + "Element", typeRef(Void.TYPE)) [
+		val code = codeBlock.code;
+		return code.getOrGenerateMethod("update" + elementName.toFirstUpper + "Element", typeRef(Void.TYPE)) [
 			parameters += generateAccessibleElementsParameters(accessibleElements);
-			val code = codeBlock.code;
 			if (code instanceof SimpleTextXBlockExpression) {
 				body = code.text;
 			} else {


### PR DESCRIPTION
 * Allow to specify a which metaclass should be listened on when listening for a feature change
 * Allow to call `call` on a `FluentReactionBuilder` muiltiple times
 * Fix issues with type settings
 * Add missing `correspondingTo.oldValue` to `FluentReactionBuilder`