### PR TITLE
Test Helpers Improvements

### DIFF
--- a/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusApplicationTest.java
+++ b/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusApplicationTest.java
@@ -158,4 +158,10 @@ public abstract class VitruviusApplicationTest extends VitruviusUnmonitoredAppli
 			throw e;
 		}
 	}
-}
+	
+	protected <T> T from(Class<T> clazz, String modelPathInProject) {
+		final Resource requestedResource = getModelResource(modelPathInProject);
+		startRecordingChanges(requestedResource);
+		return clazz.cast(requestedResource.getContents().get(0));
+	}
+ }

--- a/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/matchers/AbstractFeatureMatcher.xtend
+++ b/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/matchers/AbstractFeatureMatcher.xtend
@@ -1,0 +1,52 @@
+package tools.vitruv.framework.tests.matchers
+
+import java.lang.reflect.Method
+import java.util.function.Consumer
+import org.hamcrest.Description
+
+abstract class AbstractFeatureMatcher<FeatureType> implements FeatureMatcher {
+
+	val Class<?> expectedFeatureType
+	protected var Consumer<Description> mismatch
+
+	protected new() {
+		expectedFeatureType = findExpectedType()
+	}
+
+	def private findExpectedType() {
+		for (var Class<?> fromClass = this.class; fromClass != AbstractFeatureMatcher; fromClass = fromClass.
+			superclass) {
+			for (method : fromClass.declaredMethods) {
+				val expectedType = method.findExpectedFeatureType
+				if (expectedType !== null) {
+					return expectedType
+				}
+			}
+		}
+		throw new Error("Cannot determine correct type for checkFeatureValuesSavely method.")
+	}
+
+	def private findExpectedFeatureType(Method method) {
+		if (method.name == 'checkFeatureValuesSavely' && method.parameterCount == 2 && !method.isSynthetic) {
+			return method.parameterTypes.get(0)
+		}
+	}
+
+	override getMismatch(Object expectedValue, Object itemValue) {
+		if (!expectedFeatureType.isInstance(expectedValue)) {
+			throw new IllegalStateException("The expected value is not an instance of " + expectedFeatureType)
+		}
+		if (expectedFeatureType.isInstance(itemValue)) {
+			return [
+				appendText("has the wrong type ").appendValue(itemValue.class.name).appendText(", expected ").
+					appendValue(expectedFeatureType.name).appendText(".")
+			]
+		}
+		if (expectedFeatureType.isInstance(expectedValue) && expectedFeatureType.isInstance(itemValue)) {
+			return getMismatchSafely(expectedValue as FeatureType, itemValue as FeatureType)
+		}
+
+	}
+
+	def protected Consumer<Description> getMismatchSafely(FeatureType expectedValue, FeatureType itemValue)
+}

--- a/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/matchers/FeatureMatcher.xtend
+++ b/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/matchers/FeatureMatcher.xtend
@@ -1,0 +1,12 @@
+package tools.vitruv.framework.tests.matchers
+
+import org.eclipse.emf.ecore.EClass
+import org.eclipse.emf.ecore.EStructuralFeature
+import org.hamcrest.Description
+import java.util.function.Consumer
+
+interface FeatureMatcher {
+	def boolean isForFeature(EClass checkedClass, EStructuralFeature feature)
+
+	def Consumer<Description> getMismatch(Object expectedValue, Object itemValue)
+}


### PR DESCRIPTION
Adds a generic API to specify how certain features should be compared when using the model matchers (only implementation at the moment is one ignoring certain features by name).

Additionally adds a method to retrieve existing roots in `VitruviusApplicationTest`