### PR TITLE
Test Helpers to Deal with Resources

### DIFF
--- a/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusApplicationTest.java
+++ b/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusApplicationTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 
 import edu.kit.ipd.sdq.commons.util.java.lang.StringUtil;
 import tools.vitruv.framework.change.description.CompositeContainerChange;
@@ -150,7 +152,8 @@ public abstract class VitruviusApplicationTest extends VitruviusUnmonitoredAppli
 	
 	protected Resource resourceAt(String modelPathInProject) {
 		try {
-			return getModelResource(modelPathInProject);
+			final ResourceSet resourceSet = new ResourceSetImpl();
+			return getModelResource(modelPathInProject, resourceSet);
 		} catch (RuntimeException e) {
 			if (e.getCause() instanceof FileNotFoundException) {
 				return createModelResource(modelPathInProject);

--- a/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusUnmonitoredApplicationTest.java
+++ b/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/VitruviusUnmonitoredApplicationTest.java
@@ -108,7 +108,7 @@ public abstract class VitruviusUnmonitoredApplicationTest extends VitruviusTest 
 		return resourceSet.createResource(getModelVuri(modelPathWithinProject).getEMFUri());
 	}
 
-	private Resource getModelResource(String modelPathWithinProject, ResourceSet resourceSet) {
+	protected Resource getModelResource(String modelPathWithinProject, ResourceSet resourceSet) {
 		return resourceSet.getResource(getModelVuri(modelPathWithinProject).getEMFUri(), true);
 	}
 
@@ -210,5 +210,4 @@ public abstract class VitruviusUnmonitoredApplicationTest extends VitruviusTest 
 	protected UuidGeneratorAndResolver getLocalUuidGeneratorAndResolver() {
 		return uuidGeneratorAndResolver;
 	}
-
 }

--- a/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/matchers/ModelMatchers.xtend
+++ b/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/matchers/ModelMatchers.xtend
@@ -23,7 +23,7 @@ class ModelMatchers {
 	}
 	
 	def static Matcher<Resource> doesNotExist() {
-		new ResourceInexistencMatcher()
+		new ResourceInexistenceMatcher()
 	}
 
 	def static Matcher<EObject> equalsDeeply(EObject object, FeatureMatcher... featureMatchers) {
@@ -74,7 +74,7 @@ package class ResourceContainmentMatcher extends TypeSafeMatcher<Resource> {
 }
 
 
-package class ResourceInexistencMatcher extends TypeSafeMatcher<Resource> {
+package class ResourceInexistenceMatcher extends TypeSafeMatcher<Resource> {
 	boolean exists
 
 	override protected describeMismatchSafely(Resource item, Description mismatchDescription) {

--- a/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/matchers/ModelMatchers.xtend
+++ b/bundles/framework/tools.vitruv.framework.tests.util/src/tools/vitruv/framework/tests/matchers/ModelMatchers.xtend
@@ -21,6 +21,10 @@ class ModelMatchers {
 	def static Matcher<Resource> contains(EObject root, FeatureMatcher... featureMatchers) {
 		new ResourceContainmentMatcher(root, featureMatchers)
 	}
+	
+	def static Matcher<Resource> doesNotExist() {
+		new ResourceInexistencMatcher()
+	}
 
 	def static Matcher<EObject> equalsDeeply(EObject object, FeatureMatcher... featureMatchers) {
 		new ModelTreeEqualityMatcher(object, featureMatchers)
@@ -65,6 +69,25 @@ package class ResourceContainmentMatcher extends TypeSafeMatcher<Resource> {
 		contentsSize = item.contents.size
 		if (contentsSize != 1) return false
 		return delegateMatcher.matches(item.contents.get(0))
+	}
+
+}
+
+
+package class ResourceInexistencMatcher extends TypeSafeMatcher<Resource> {
+	boolean exists
+
+	override protected describeMismatchSafely(Resource item, Description mismatchDescription) {
+		mismatchDescription.appendText("there was a resource at ").appendValue(item.URI)
+	}
+
+	override describeTo(Description description) {
+		description.appendText("the resource not to exist");
+	}
+
+	override protected matchesSafely(Resource item) {
+		exists = item.resourceSet.URIConverter.exists(item.URI, Collections.emptyMap)
+		return !exists
 	}
 
 }


### PR DESCRIPTION
#177 made me realise that the test helper modifications I have in my branch could also be useful to others.

* `resourceAt` loads the resource from disk instead of using the cached one
* Added matcher to check that a resource does *not* exist