### PR TITLE
Single model recording and bugfixes

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/EChangeIdManager.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/EChangeIdManager.xtend
@@ -47,6 +47,9 @@ class EChangeIdManager {
 	}
 
 	public def boolean isCreateChange(EObjectAddedEChange<?> addedEChange) {
+		// We do not check the containment of the reference, because an element may be inserted into a non-containment
+		// reference before inserting it into a containment reference so that the create change has to be added
+		// for the inserting into the non-containment reference
 		var create = addedEChange.newValue !== null && !(uuidGeneratorAndResolver.hasUuid(addedEChange.newValue))
 		// Look if the new value has no resource or if it is a reference change, if the resource of the affected
 		// object is the same. Otherwise, the create has to be handled by an insertion/reference in that resource, as

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChange.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChange.xtend
@@ -30,28 +30,17 @@ interface VitruviusChange extends URIHaving {
 	def List<EChange> getEChanges();
 
 	/**
-	 * Applies this change backward so that the model is in the state before the change afterwards.
-	 * It has to be ensured that the model is in the state right after the change before calling this method.
-	 * If the method has already been called without calling {@link #applyForward applyForward} in the meantime, an 
-	 * {@link IllegalStateException} will be thrown.
-	 * 
-	 * @throws IllegalStateException if this method was already called without calling {@link applyForward} in the meantime
+	 * Resolves the change and applies it forward so that the model is in the state after the change afterwards.
+	 * It has to be ensured that the model is in a state the change can be applied to before calling this method.
+	 * If the change cannot be resolved or is already resolved, an Exception is thrown.
 	 */
-	def void applyBackward() throws IllegalStateException;
-	
-	/**
-	 * Applies this change forward so that the model is in the state after the change afterwards.
-	 * It has to be ensured that the model is in the state right before the change before calling this method.
-	 * This especially means that {@link #applyBackward applyBackward} has to be called before.
-	 * Otherwise or if the method has been called without calling {@link #applyBackward applyBackward} in the meantime, an 
-	 * {@link IllegalStateException} will be thrown.
-	 * 
-	 * @throws IllegalStateException if this method was called before without calling {@link applyBackward} in the meantime
-	 */
-	def void applyForward() throws IllegalStateException;
-	
 	def void resolveBeforeAndApplyForward(UuidResolver uuidResolver);
 	
+	/**
+	 * Resolves the change and applies it backward so that the model is in the state before the change afterwards.
+	 * It has to be ensured that the model is in a state the change can be applied to before calling this method.
+	 * If the change cannot be resolved or is already resolved, an Exception is thrown.
+	 */
 	def void resolveAfterAndApplyBackward(UuidResolver uuidResolver);
 	
 	def void unresolveIfApplicable();

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractCompositeChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractCompositeChangeImpl.xtend
@@ -74,18 +74,6 @@ abstract class AbstractCompositeChangeImpl<C extends VitruviusChange> implements
 		);
 	}
 
-	override applyBackward() throws IllegalStateException {
-		for (change : changes.reverseView) {
-			change.applyBackward();
-		}
-	}
-
-	override applyForward() throws IllegalStateException {
-		for (change : changes.reverseView) {
-			change.applyForward();
-		}
-	}
-
 	override resolveBeforeAndApplyForward(UuidResolver uuidResolver) {
 		for (c : changes) {
 			c.resolveBeforeAndApplyForward(uuidResolver)

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractCompositeChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractCompositeChangeImpl.xtend
@@ -111,7 +111,7 @@ abstract class AbstractCompositeChangeImpl<C extends VitruviusChange> implements
 	}
 	
 	override toString() '''
-	«this.class.simpleName»:
+	«this.class.simpleName», VURI: «URI»
 		«FOR change : changes»
 			«change»
 		«ENDFOR»

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractConcreteChange.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractConcreteChange.xtend
@@ -56,14 +56,6 @@ abstract class AbstractConcreteChange implements ConcreteChange {
 		this.eChange = eChange;
 	}
 	
-	override applyBackward() {
-		logger.warn("The applyBackward method is not implemented for " + this.class.simpleName + " yet.");
-	}
-	
-	override applyForward() {
-		logger.warn("The applyForward method is not implemented for " + this.class.simpleName + " yet.");
-	}
-	
 	override resolveBeforeAndApplyForward(UuidResolver uuidResolver) {
 		logger.warn("The resolveBeforeAndapplyForward method is not implemented for " + this.class.simpleName + " yet.");
 	}

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteApplicableChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteApplicableChangeImpl.xtend
@@ -11,31 +11,29 @@ import org.eclipse.emf.ecore.InternalEObject
 import tools.vitruv.framework.change.echange.root.RootEChange
 
 class ConcreteApplicableChangeImpl extends ConcreteChangeImpl {
-	private var boolean canBeBackwardsApplied;
 	private var VURI vuri;
 	
     public new(EChange eChange) {
     	super(eChange);
     	tryToSetUri;
-    	this.canBeBackwardsApplied = true;
     }
 
 	override resolveBeforeAndApplyForward(UuidResolver uuidResolver) {
+		// TODO HK Make a copy of the complete change instead of replacing it internally
 		this.EChange = this.EChange.resolveBefore(uuidResolver)
 		tryToSetUri;
 		this.registerOldObjectTuidsForUpdate(getObjectsWithPotentiallyModifiedTuids)
-		this.canBeBackwardsApplied = false;
-		applyForward()
+		this.EChange.applyForward;
 		tryToSetUri;
 		this.updateTuids
 	}
 	
 	override resolveAfterAndApplyBackward(UuidResolver uuidResolver) {
+		// TODO HK Make a copy of the complete change instead of replacing it internally
 		this.EChange = this.EChange.resolveAfter(uuidResolver)
 		tryToSetUri;
 		this.registerOldObjectTuidsForUpdate(getObjectsWithPotentiallyModifiedTuids)
-		this.canBeBackwardsApplied = true;
-		applyBackward()
+		this.EChange.applyBackward;
 		tryToSetUri;
 		this.updateTuids
 	}
@@ -66,22 +64,6 @@ class ConcreteApplicableChangeImpl extends ConcreteChangeImpl {
 		// e.g. for Operations whose TUIDs depend on the values of their parameter type references.
 		// This number of layers may still be too few, this is just a random number.
 		this.affectedEObjects.map[#{it, it.eContainer, it.eContainer?.eContainer, it.eContainer?.eContainer?.eContainer}].flatten.filterNull.toSet
-	}
-	
-	def applyForward() {
-		if (this.canBeBackwardsApplied) {
-			throw new IllegalStateException("Change " + this + " cannot be applied forwards as was not backwards applied before.");	
-		}
-		this.EChange.applyForward
-		this.canBeBackwardsApplied = true;
-	}
-
-	def applyBackward() {
-		if (!this.canBeBackwardsApplied) {
-			throw new IllegalStateException("Change " + this + " cannot be applied backwards as was not forward applied before.");	
-		}
-		this.EChange.applyBackward
-		this.canBeBackwardsApplied = false;
 	}
 	
 	private def void registerOldObjectTuidsForUpdate(Iterable<EObject> objects) {

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteApplicableChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteApplicableChangeImpl.xtend
@@ -38,7 +38,7 @@ class ConcreteApplicableChangeImpl extends ConcreteChangeImpl {
 		this.affectedEObjects.map[#{it, it.eContainer, it.eContainer?.eContainer, it.eContainer?.eContainer?.eContainer}].flatten.filterNull.toSet
 	}
 	
-	override applyForward() {
+	def applyForward() {
 		if (this.canBeBackwardsApplied) {
 			throw new IllegalStateException("Change " + this + " cannot be applied forwards as was not backwards applied before.");	
 		}
@@ -46,7 +46,7 @@ class ConcreteApplicableChangeImpl extends ConcreteChangeImpl {
 		this.canBeBackwardsApplied = true;
 	}
 
-	override applyBackward() {
+	def applyBackward() {
 		if (!this.canBeBackwardsApplied) {
 			throw new IllegalStateException("Change " + this + " cannot be applied backwards as was not forward applied before.");	
 		}

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteApplicableChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteApplicableChangeImpl.xtend
@@ -6,29 +6,59 @@ import tools.vitruv.framework.tuid.TuidManager
 import static extension tools.vitruv.framework.change.echange.resolve.EChangeResolverAndApplicator.*
 import tools.vitruv.framework.uuid.UuidResolver
 import tools.vitruv.framework.change.echange.resolve.EChangeUnresolver
+import tools.vitruv.framework.util.datatypes.VURI
+import org.eclipse.emf.ecore.InternalEObject
+import tools.vitruv.framework.change.echange.root.RootEChange
 
 class ConcreteApplicableChangeImpl extends ConcreteChangeImpl {
 	private var boolean canBeBackwardsApplied;
+	private var VURI vuri;
 	
     public new(EChange eChange) {
     	super(eChange);
+    	tryToSetUri;
     	this.canBeBackwardsApplied = true;
     }
 
 	override resolveBeforeAndApplyForward(UuidResolver uuidResolver) {
 		this.EChange = this.EChange.resolveBefore(uuidResolver)
+		tryToSetUri;
 		this.registerOldObjectTuidsForUpdate(getObjectsWithPotentiallyModifiedTuids)
 		this.canBeBackwardsApplied = false;
 		applyForward()
+		tryToSetUri;
 		this.updateTuids
 	}
 	
 	override resolveAfterAndApplyBackward(UuidResolver uuidResolver) {
 		this.EChange = this.EChange.resolveAfter(uuidResolver)
+		tryToSetUri;
 		this.registerOldObjectTuidsForUpdate(getObjectsWithPotentiallyModifiedTuids)
 		this.canBeBackwardsApplied = true;
 		applyBackward()
+		tryToSetUri;
 		this.updateTuids
+	}
+	
+	private def void tryToSetUri() {
+		val eChange = EChange;
+		var resolvedResources = affectedNotReferencedEObjects.map[eResource].filterNull.toList;
+		if (eChange instanceof RootEChange) {
+			resolvedResources += eChange.resource;
+		}
+		if (resolvedResources.size > 0) {
+			this.vuri = VURI.getInstance(resolvedResources.get(0));
+			return;
+		}
+		val proxyUris = affectedNotReferencedEObjects.filter(InternalEObject).map[eProxyURI].filterNull.filter[segmentCount > 0]
+		if (proxyUris.size > 0) {
+			this.vuri = VURI.getInstance(proxyUris.get(0).trimFragment);
+			return;
+		}
+	}
+	
+	override getURI() {
+		return vuri;
 	}
 	
 	private def getObjectsWithPotentiallyModifiedTuids() {

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteChangeImpl.xtend
@@ -8,7 +8,7 @@ class ConcreteChangeImpl extends AbstractConcreteChange {
     }
 
     public override String toString() {
-        return this.class.getSimpleName() + ": VURI: " + this.URI + "\n	EChange: " + this.EChange;
+        return this.class.getSimpleName() + ", VURI: " + this.URI + "\n	EChange: " + this.EChange;
     }
 
 }

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/EmptyChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/EmptyChangeImpl.xtend
@@ -27,14 +27,6 @@ class EmptyChangeImpl implements TransactionalChange {
 		return vuri;
 	}
 	
-	override applyBackward() throws IllegalStateException {
-		// Nothing to be done
-	}
-	
-	override applyForward() throws IllegalStateException {
-		// Nothing to be done
-	}
-	
 	override resolveBeforeAndApplyForward(UuidResolver uuidResolver) {
 		
 	}

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
@@ -44,6 +44,9 @@ class AtomicEmfChangeRecorder {
 	}
 
 	def void addToRecording(Notifier elementToObserve) {
+		if (elementToObserve === null) {
+			throw new IllegalArgumentException("Element to observe must not be null");
+		}
 		this.elementsToObserve += elementToObserve;
 		elementsToObserve.forEach[changeRecorder.addToRecording(it)];
 		elementToObserve.registerContentsAtUuidResolver

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
@@ -96,12 +96,7 @@ class AtomicEmfChangeRecorder {
 		}
 		changeRecorder.endRecording();
 		val changes = changeRecorder.changes;
-		
 		removeCreateFollowedByDelete(changes);
-		// Allow null provider and resolver for test purposes
-		if(uuidGeneratorAndResolver !== null) {
-			changes.forEach[EChanges.forEach[eChangeIdManager.setOrGenerateIds(it)]]
-		}
 		this.changes = changes;
 	}
 	

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
@@ -97,9 +97,7 @@ class AtomicEmfChangeRecorder {
 		changeRecorder.endRecording();
 		val changes = changeRecorder.changes;
 		
-		removeDuplicateCreates(changes);
 		removeCreateFollowedByDelete(changes);
-		reorderChanges(changes);
 		// Allow null provider and resolver for test purposes
 		if(uuidGeneratorAndResolver !== null) {
 			changes.forEach[EChanges.forEach[eChangeIdManager.setOrGenerateIds(it)]]
@@ -149,29 +147,6 @@ class AtomicEmfChangeRecorder {
 		return result
 	}
 	
-	/**
-	 * Removes duplicate create operations, which can occur, if an element is created and inserted into 
-	 * a resource (CreateAndInsertRoot) and afterwards also inserted into a containment relation
-	 * (CreateAndInsertNonRoot), because the resource creation is performed lazy and thus the containment
-	 * insertion operation is interpreted as a creation as well.
-	 */
-	 // TODO In fact, we have the same problem with remove changes. We have to monitor the concrete models instead
-	 // of the resources to get rid of that
-	private def void removeDuplicateCreates(List<TransactionalChange> changes) {
-		val createdObjects = changes.generateCreateChangesMultimap
-		for (var i = 0; i < changes.size; i++) {
-			val currentCreatedObjects = createdObjects.get(changes.get(i))
-			for (var k = i + 1; k < changes.size; k++) {
-				for (var object = 0; object < currentCreatedObjects.size; object++) {
-					if (createdObjects.get(changes.get(k)).contains(currentCreatedObjects.get(object))) {
-						val affectedChange = changes.get(k)
-						removeCreateOrDelete(affectedChange as CompositeTransactionalChange, currentCreatedObjects.get(object), true);
-					}
-				}			
-			}
-		}
-	}
-	
 	private def void removeCreateOrDelete(CompositeTransactionalChange change, EObject createdObject, boolean create) {
 		for (var i = 0; i < change.changes.size; i++) {
 			val currentChange = change.changes.get(i);
@@ -196,38 +171,6 @@ class AtomicEmfChangeRecorder {
 		} 
 	}
 	
-	/** 
-	 * Reorders changes so that create changes are always present before insertion changes of the same element.
-	 * Some metamodels produce insertions of elements before inserting them into a containment, resulting in a
-	 * create change after an insertion, which would not be resolvable.
-	 */
-	private def void reorderChanges(List<TransactionalChange> changes) {
-		val createdObjects = changes.generateCreateChangesMultimap
-		var boolean reordered = true;
-		var counter = 0;
-		while(reordered) {
-			reordered = false;
-			for (var i = 0; i < changes.size && !reordered; i++) {	
-				val affectedEObjects = changes.get(i).affectedEObjects;
-				for (var k = i + 1; k < changes.size && !reordered; k++) {
-					for (var object = 0; object < affectedEObjects.size && !reordered; object++) {
-						if (createdObjects.get(changes.get(k)).contains(affectedEObjects.get(object))) {
-							changes.add(i, changes.remove(k));
-							reordered = true;
-						}
-					}
-				}			
-			}
-			// We are playing ping-pong: There must be duplicate create changes so changes are repeatedly reordered
-			if (counter > changes.size * changes.size) {
-				throw new IllegalStateException("Reordering is in endless loop")
-			}
-			counter++;
-		}
-		
-		
- 	}
- 	
  	private def generateDeleteChangesMultimap(List<TransactionalChange> changes) {
 		val Multimap<TransactionalChange, EObject> deletedObjects = ArrayListMultimap.create;
 		for (change : changes) {

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationRecorder.xtend
@@ -33,6 +33,9 @@ class NotificationRecorder implements Adapter {
 	}
 
 	override notifyChanged(Notification notification) {
+		if (!isRecording) {
+			return;
+		}
 		if (notification.newValue instanceof Notifier) {
 			addToRecording(notification.newValue as Notifier);
 		}

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationToEChangeConverter.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationToEChangeConverter.xtend
@@ -345,7 +345,9 @@ final class NotificationToEChangeConverter {
 		if (!n.getAttribute().isMany()) {
 			op = handleSetAttribute(n)
 		} else {
-			op = #[TypeInferringAtomicEChangeFactory.instance.createUnsetFeatureChange(n.notifierModelElement, n.feature as EStructuralFeature)];
+			val change = TypeInferringAtomicEChangeFactory.instance.createUnsetFeatureChange(n.notifierModelElement, n.feature as EStructuralFeature);
+			eChangeIdManager.setOrGenerateIds(change);
+			op = #[change];
 		}
 		return op
 	}
@@ -355,7 +357,9 @@ final class NotificationToEChangeConverter {
 		if (!n.getReference().isMany()) {
 			op = handleSetReference(n);
 		} else {
-			op = #[TypeInferringAtomicEChangeFactory.instance.createUnsetFeatureChange(n.notifierModelElement, n.feature as EStructuralFeature)];
+			val change = TypeInferringAtomicEChangeFactory.instance.createUnsetFeatureChange(n.notifierModelElement, n.feature as EStructuralFeature);
+			eChangeIdManager.setOrGenerateIds(change);
+			op = #[change];
 		}
 		return op;
 	}

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationToEChangeConverter.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationToEChangeConverter.xtend
@@ -254,7 +254,9 @@ final class NotificationToEChangeConverter {
 		val resource = notification.notifier as Resource
 		switch (notification.getEventType()) {
 			case Notification.ADD: {
-				changes += handleInsertRootChange(resource, notification.newModelElementValue, notification.position)
+				if (notification.newValue instanceof EObject) {
+					changes += handleInsertRootChange(resource, notification.newModelElementValue, notification.position)
+				}
 			}
 			case Notification.ADD_MANY: {
 				var List<EObject> list = (notification.getNewValue() as List<EObject>)

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -21,7 +21,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	final UuidResolver parentUuidResolver;
 	final boolean strictMode;
 	UuidToEObjectRepository repository;
-	
+
 	/**
 	 * Instantiates a UUID generator and resolver with no parent resolver, 
 	 * the given {@link ResourceSet} for resolving objects
@@ -76,7 +76,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	new(ResourceSet resourceSet, Resource uuidResource, boolean strictMode) {
 		this(null, resourceSet, uuidResource, strictMode);
 	}
-	
+
 	/**
 	 * Instantiates a UUID generator and resolver with the given parent resolver, used when
 	 * this resolver cannot resolve a UUID, the given {@link ResourceSet} for resolving objects
@@ -110,12 +110,12 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	}
 
 	def private loadAndRegisterUuidProviderAndResolver(Resource uuidResource) {
-		var UuidToEObjectRepository repository = if(uuidResource !== null)
+		var UuidToEObjectRepository repository = if (uuidResource !== null)
 				EcoreResourceBridge::getResourceContentRootIfUnique(uuidResource)?.dynamicCast(UuidToEObjectRepository,
 					"uuid provider and resolver model")
-		if(repository === null) {
+		if (repository === null) {
 			repository = UuidFactory.eINSTANCE.createUuidToEObjectRepository;
-			if(uuidResource !== null) {
+			if (uuidResource !== null) {
 				uuidResource.getContents().add(repository)
 			}
 		}
@@ -124,7 +124,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 
 	override getUuid(EObject eObject) {
 		val result = internalGetUuid(eObject);
-		if(result === null) {
+		if (result === null) {
 			throw new IllegalStateException("No UUID registered for EObject: " + eObject);
 		}
 		return result;
@@ -132,33 +132,33 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 
 	private def internalGetUuid(EObject eObject) {
 		val localResult = repository.EObjectToUuid.get(eObject);
-		if(localResult !== null) {
+		if (localResult !== null) {
 			return localResult;
 		}
 		val uri = EcoreUtil.getURI(eObject)
-		if(uri !== null) {
+		if (uri !== null) {
 			try {
 				val resolvedObject = resourceSet.getEObject(uri, false);
 				// The EClass check avoids that an objects of another type with the same URI is resolved
 				// This is, for example, the case if a modifier in a UML model is changed, as it is only a
 				// marker class that is replaced, having always the same URI on the same model element.
-				if(resolvedObject !== null && resolvedObject.eClass == eObject.eClass) {
+				if (resolvedObject !== null && resolvedObject.eClass == eObject.eClass) {
 					val resolvedKey = repository.EObjectToUuid.get(resolvedObject);
-					if(resolvedKey !== null) {
+					if (resolvedKey !== null) {
 						return resolvedKey;
 					}
 				} else {
 					// Finally look for a proxy in the repository (due to a deleted object) and match the URI
-					for (proxyObject : repository.EObjectToUuid.keySet.filter[eIsProxy]){
+					for (proxyObject : repository.EObjectToUuid.keySet.filter[eIsProxy]) {
 						if (EcoreUtil.getURI(proxyObject).equals(EcoreUtil.getURI(eObject))) {
 							return repository.EObjectToUuid.get(proxyObject);
 						}
 					}
 				}
-			} catch(RuntimeException e) {
+			} catch (RuntimeException e) {
 			}
 		}
-		
+
 		return null;
 	}
 
@@ -175,11 +175,9 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		if (eObject === null) {
 			return null;
 		}
-		if(eObject.eIsProxy) {
+		if (eObject.eIsProxy) {
+			// Try to resolve the proxy. This can still lead to a valid proxy element if it is a proxy on purpose
 			val resolvedObject = EcoreUtil.resolve(eObject, resourceSet);
-			if(resolvedObject === null || resolvedObject.eIsProxy) {
-				return null;
-			}
 			return resolvedObject;
 		} else {
 			return eObject;
@@ -191,7 +189,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		registerEObject(uuid, eObject);
 		return uuid;
 	}
-	
+
 	public override String generateUuidWithoutCreate(EObject eObject) {
 		val uuid = generateUuid(eObject);
 		// Register UUID globally for third party elements that are statically accessible and are never created.
@@ -239,7 +237,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	override hasUuid(EObject object) {
 		return internalGetUuid(object) !== null;
 	}
-	
+
 	override hasEObject(String uuid) {
 		return internalGetEObject(uuid) !== null;
 	}
@@ -247,7 +245,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	override getResourceSet() {
 		return resourceSet;
 	}
-	
+
 	override registerUuidForGlobalUri(String uuid, URI uri) {
 		try {
 			val localObject = resourceSet.getEObject(uri, true)
@@ -260,14 +258,14 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		}
 		return false;
 	}
-	
+
 	override registerEObject(EObject eObject) {
 		if (parentUuidResolver.hasUuid(eObject)) {
 			registerEObject(parentUuidResolver.getUuid(eObject), eObject);
 		} else if (hasUuid(eObject)) {
 			registerEObject(getUuid(eObject), eObject);
 		} else {
-			//throw new IllegalStateException("Given EObject has no UUID yet: " + eObject);
+			// throw new IllegalStateException("Given EObject has no UUID yet: " + eObject);
 		}
 	}
 

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
@@ -37,7 +37,7 @@ class VirtualModelImpl implements InternalVirtualModel {
 			metamodel.registerAtTuidManagement();
 		}
 		this.resourceRepository = new ResourceRepositoryImpl(folder, metamodelRepository);
-		this.modelRepository = new ModelRepositoryImpl();
+		this.modelRepository = new ModelRepositoryImpl(resourceRepository.uuidGeneratorAndResolver);
 		val changePropagationSpecificationRepository = new ChangePropagationSpecificationRepository();
 		for (changePropagationSpecification : modelConfiguration.changePropagationSpecifications) {
 			changePropagationSpecification.userInteracting = userInteracting;

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
@@ -87,6 +87,7 @@ class VirtualModelImpl implements InternalVirtualModel {
 		])
 		resourceRepository.executeRecordingCommandOnTransactionalDomain(command);
 
+		// TODO HK Instead of this make the changes set the modified flag of the resource when applied
 		val changedEObjects = changes.map[originalChange.affectedEObjects + consequentialChanges.affectedEObjects].flatten
 		changedEObjects.map[eResource].filterNull.forEach[modified = true];
 		save();

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -134,11 +134,13 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 		ChangedResourcesTracker changedResourcesTracker
 	) {
 		val consequentialChanges = newArrayList();
+		//modelRepository.startRecording;
 		resourceRepository.startRecording;
 		for (propagationSpecification : changePropagationProvider.
 			getChangePropagationSpecifications(change.changeDomain)) {
 			propagateChangeForChangePropagationSpecification(change, propagationSpecification, changedResourcesTracker);
 		}
+		//consequentialChanges += modelRepository.endRecording();
 		consequentialChanges += resourceRepository.endRecording();
 		consequentialChanges.forEach[logger.debug(it)];
 

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -115,10 +115,10 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 			change.resolveBeforeAndApplyForward(uuidResolver)
             // If change has a URI, add the model to the repository
             if (change.URI !== null) resourceRepository.getModel(change.getURI());
+            change.affectedEObjects.forEach[modelRepository.addRootElement(it)];
             return;
     	];
 		this.resourceRepository.executeOnUuidResolver(changeApplicationFunction);
-		change.affectedEObjects.forEach[modelRepository.addRootElement(it)];
 		modelRepository.cleanupRootElements;
 
 		val changedObjects = change.affectedEObjects;

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -202,6 +202,7 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 		// Add affected objects if change is resolved
 		resolvedObjects += change.affectedEObjects;
 		// Resolve IDs to get actual objects
+		// TODO HK Should only be called when change is resolved, so this should be omittable
 		change.affectedEObjectIds.forEach[id | resourceRepository.executeOnUuidResolver[resolvedObjects += it.getEObject(id)]]
 		metamodelRepository.getDomain(resolvedObjects.filterNull.head)
 	}

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -200,13 +200,8 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 	}
 
 	def private getChangeDomain(VitruviusChange change) {
-		val resolvedObjects = <EObject>newArrayList();
-		// Add affected objects if change is resolved
-		resolvedObjects += change.affectedEObjects;
-		// Resolve IDs to get actual objects
-		// TODO HK Should only be called when change is resolved, so this should be omittable
-		change.affectedEObjectIds.forEach[id | resourceRepository.executeOnUuidResolver[resolvedObjects += it.getEObject(id)]]
-		metamodelRepository.getDomain(resolvedObjects.filterNull.head)
+		val resolvedObjects = change.affectedEObjects.filter[!eIsProxy];
+		metamodelRepository.getDomain(resolvedObjects.head)
 	}
 
 	private def void handleObjectsWithoutResource() {

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.java
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.java
@@ -349,7 +349,9 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
 
     @Override
     public void startRecording() {
-        removeRecorderForDeletedModels();
+        // TODO HK Reactive: We have to disable this as long as intermediate models (from the commonalities
+        // language) are not persisted, as otherwise the recorder is removed from them
+        // removeRecorderForDeletedModels();
         for (AtomicEmfChangeRecorder recorder : this.uriToRecorder.values()) {
             recorder.beginRecording();
         }
@@ -376,6 +378,7 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
         return result;
     }
 
+    @SuppressWarnings("unused")
     private void removeRecorderForDeletedModels() {
         List<VURI> nonExistentUris = new ArrayList<>();
         for (VURI recordedVuri : this.uriToRecorder.keySet()) {

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
@@ -15,6 +15,8 @@ import tools.vitruv.framework.change.echange.eobject.DeleteEObject
 import tools.vitruv.framework.change.echange.root.RemoveRootEObject
 import tools.vitruv.framework.change.echange.eobject.CreateEObject
 import tools.vitruv.framework.change.echange.feature.reference.ReplaceSingleValuedEReference
+import tools.vitruv.framework.change.description.PropagatedChange
+import tools.vitruv.framework.change.description.VitruviusChange
 
 class BidirectionalExecutionTests extends AbstractAllElementTypesReactionsTests {
 	private static val TEST_SOURCE_MODEL_NAME = "EachTestModelSource";
@@ -59,6 +61,10 @@ class BidirectionalExecutionTests extends AbstractAllElementTypesReactionsTests 
 		saveAndSynchronizeChanges(rootElement);
 	}
 	
+	private def VitruviusChange getSourceModelChanges(PropagatedChange propagatedChange) {
+		return (propagatedChange.consequentialChanges as CompositeContainerChange).changes.findFirst[URI.toString.endsWith(TEST_SOURCE_MODEL_NAME.projectModelPath)];
+	}
+	
 	@Test
 	public def void testBasicBidirectionalApplication() {
 		val targetRoot = TEST_TARGET_MODEL_NAME.projectModelPath.firstRootElement as Root;
@@ -68,9 +74,9 @@ class BidirectionalExecutionTests extends AbstractAllElementTypesReactionsTests 
 		targetRoot.singleValuedContainmentEReference = newNonRoot;
 		val propagatedChanges = saveAndSynchronizeChanges(targetRoot);
 		assertEquals(1, propagatedChanges.size);
-		val compositePropagatedChange = propagatedChanges.get(0).consequentialChanges as CompositeContainerChange
-		assertTrue(compositePropagatedChange.EChanges.get(0) instanceof CreateEObject<?>)
-		assertTrue(compositePropagatedChange.EChanges.get(1) instanceof ReplaceSingleValuedEReference<?,?>)
+		val consequentialSourceModelChange = propagatedChanges.get(0).sourceModelChanges;
+		assertTrue(consequentialSourceModelChange.EChanges.get(0) instanceof CreateEObject<?>)
+		assertTrue(consequentialSourceModelChange.EChanges.get(1) instanceof ReplaceSingleValuedEReference<?,?>)
 		assertPersistedModelsEqual(TEST_SOURCE_MODEL_NAME.projectModelPath, TEST_TARGET_MODEL_NAME.projectModelPath);
 		val testResourceSet = new ResourceSetImpl();
 		testResourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("*", new XMIResourceFactoryImpl());
@@ -92,9 +98,9 @@ class BidirectionalExecutionTests extends AbstractAllElementTypesReactionsTests 
 		targetRoot.nonRootObjectContainerHelper.nonRootObjectsContainment.remove(0);
 		val propagatedChanges = saveAndSynchronizeChanges(targetRoot);
 		assertEquals(1, propagatedChanges.size);
-		val compositePropagatedChange = propagatedChanges.get(0).consequentialChanges as CompositeContainerChange
-		assertTrue(compositePropagatedChange.EChanges.get(3) instanceof RemoveEReference<?,?>)
-		assertTrue(compositePropagatedChange.EChanges.get(4) instanceof DeleteEObject<?>)
+		val consequentialSourceModelChange = propagatedChanges.get(0).sourceModelChanges;
+		assertTrue(consequentialSourceModelChange.EChanges.get(0) instanceof RemoveEReference<?,?>)
+		assertTrue(consequentialSourceModelChange.EChanges.get(1) instanceof DeleteEObject<?>)
 		assertPersistedModelsEqual(TEST_SOURCE_MODEL_NAME.projectModelPath, TEST_TARGET_MODEL_NAME.projectModelPath);
 		val testResourceSet = new ResourceSetImpl();
 		testResourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("*", new XMIResourceFactoryImpl());
@@ -115,9 +121,9 @@ class BidirectionalExecutionTests extends AbstractAllElementTypesReactionsTests 
 		startRecordingChanges(targetRoot);
 		val propagatedChanges = deleteAndSynchronizeModel(TEST_TARGET_MODEL_NAME.projectModelPath);
 		assertEquals(1, propagatedChanges.size);
-		val compositePropagatedChange = propagatedChanges.get(0).consequentialChanges as CompositeContainerChange
-		assertTrue(compositePropagatedChange.EChanges.get(3) instanceof RemoveRootEObject<?>)
-		assertTrue(compositePropagatedChange.EChanges.get(4) instanceof DeleteEObject<?>)
+		val consequentialSourceModelChange = propagatedChanges.get(0).sourceModelChanges;
+		assertTrue(consequentialSourceModelChange.EChanges.get(0) instanceof RemoveRootEObject<?>)
+		assertTrue(consequentialSourceModelChange.EChanges.get(1) instanceof DeleteEObject<?>)
 		assertModelNotExists(TEST_SOURCE_MODEL_NAME.projectModelPath)
 		assertModelNotExists(TEST_TARGET_MODEL_NAME.projectModelPath)
 	}

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -49,6 +49,7 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2EReferenc
 
 	def private testInsertInEReference(int expectedIndex) {
 		// prepare 
+		startRecording
 		val nonRoot = createAndAddNonRootToRootMultiReference(expectedIndex)
 		startRecording
 		// test


### PR DESCRIPTION
The PR restructures the recording mechanism within the virtual model, so that one recorder per resource is started instead of one for the complete resource set. This especially leads to a recorded consequential change that contains one transactional change per recorded resource. In consequence, one transactional change contains only changes related to one specific domain, which fixes #159.

Additionally, this PR performs several minor bugfixes in the notification processing, notification recording and in the changes implementation. Is also removes obsolete code and methods from changes and the change recorder.