### PR TITLE
Model recording fixes and optimizations

### DIFF
--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutineRealization.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutineRealization.xtend
@@ -120,11 +120,13 @@ abstract class AbstractRepairRoutineRealization extends CallHierarchyHaving impl
 			val _resourceURI = PersistenceHelper.getURIFromSourceProjectFolder(alreadyPersistedObject, persistencePath);
 			logger.debug("Registered to persist root " + elementToPersist + " in: " + VURI.getInstance(_resourceURI));
 			
-			// Update TUID after removal, as persistence will also change it and rely on an up-to-date value			
-			TuidManager.getInstance().registerObjectUnderModification(elementToPersist);
-			EcoreUtil.remove(elementToPersist);
-			TuidManager.getInstance().updateTuidsOfRegisteredObjects();
-			resourceAccess.persistAsRoot(elementToPersist, VURI.getInstance(_resourceURI));
+			if (elementToPersist.eResource?.URI !== _resourceURI) {
+				// Update TUID after removal, as persistence will also change it and rely on an up-to-date value			
+				TuidManager.getInstance().registerObjectUnderModification(elementToPersist);
+				EcoreUtil.remove(elementToPersist);
+				TuidManager.getInstance().updateTuidsOfRegisteredObjects();
+				resourceAccess.persistAsRoot(elementToPersist, VURI.getInstance(_resourceURI));
+			}
 		}
 
 		/**

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
@@ -8,6 +8,11 @@ import org.eclipse.emf.common.command.BasicCommandStack
 import org.eclipse.emf.ecore.EReference
 import java.util.List
 import org.eclipse.emf.ecore.util.EcoreUtil
+import tools.vitruv.framework.change.echange.EChange
+import tools.vitruv.framework.change.echange.feature.reference.ReplaceSingleValuedEReference
+import tools.vitruv.framework.change.echange.feature.reference.RemoveEReference
+import tools.vitruv.framework.change.echange.root.RemoveRootEObject
+import tools.vitruv.framework.change.echange.feature.reference.AdditiveReferenceEChange
 
 /**
  * Static utility class for the EChange package and subpackages.
@@ -62,5 +67,34 @@ class EChangeUtil {
 			return EcoreUtil.getID(eObject);
 		}
 		return null;
+	}
+	
+	
+	public static def dispatch isContainmentRemoval(EChange change) {
+		return false;
+	}
+	
+	public static def dispatch isContainmentRemoval(ReplaceSingleValuedEReference<?,?> change) {
+		return change.affectedFeature.containment && change.oldValue !== null && change.oldValue !== change.newValue;
+	}
+	
+	public static def dispatch isContainmentRemoval(RemoveEReference<?,?> change) {
+		return change.affectedFeature.containment;
+	}
+	
+	public static def dispatch isContainmentRemoval(RemoveRootEObject<?> change) {
+		return true;
+	}
+	
+	public static def dispatch isContainmentInsertion(EChange change) {
+		return false;
+	}
+	
+	public static def dispatch isContainmentInsertion(AdditiveReferenceEChange<?,?> change) {
+		return change.affectedFeature.containment && change.newValue !== null;
+	}
+	
+	public static def dispatch isContainmentInsertion(RemoveRootEObject<?> change) {
+		return true;
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationRecorder.xtend
@@ -19,6 +19,12 @@ import static extension tools.vitruv.framework.change.echange.util.EChangeUtil.*
 import tools.vitruv.framework.change.echange.eobject.EObjectSubtractedEChange
 import org.eclipse.xtend.lib.annotations.Data
 
+/**
+ * This {@link Adapter} records changes to the given model elements as {@link CompositeTransactionalChanges}.
+ * Recording can be started with {@link #beginRecording} and ended with {@link #endRecording}. It is assumed 
+ * that all elements that do not have a container when ending the recording have been deleted, resulting in
+ * an appropriate delete change.
+ */
 class NotificationRecorder implements Adapter {
 	private Set<Notifier> rootObjects;
 	private boolean isRecording = false
@@ -68,16 +74,28 @@ class NotificationRecorder implements Adapter {
 		recursivelyAddAdapter(newTarget);
 	}
 	
+	/**
+	 * Add the given elements and all its contained elements ({@link Resource}s, {@link EObject}s) to the recorder.
+	 * 
+	 * @param notifier - the {@link Notifier} to add the recorder to
+	 */
 	def void addToRecording(Notifier notifier) {
 		rootObjects += notifier;
 		recursivelyAddAdapter(notifier);
 	}
 	
+	/**
+	 * Removes the given elements and all its contained elements (resources, EObjects) from the recorder.
+	 * @param notifier - the {@link Notifier} to remove the recorder from
+	 */
 	def void removeFromRecording(Notifier notifier) {
 		rootObjects -= notifier;
 		recursivelyRemoveAdapter(notifier);
 	}
 	
+	/**
+	 * Starts recording changes on the registered elements.
+	 */
 	def beginRecording() {
 		if (!isRecording) {
 			changes = newArrayList();
@@ -88,6 +106,12 @@ class NotificationRecorder implements Adapter {
 		}
 	}
 
+	/**
+	 * Ends recording changes on the registered elements.
+	 * All elements that were removed from their container and not inserted into another one
+	 * are treated as deleted and a delete change is created for them, inserted right after
+	 * the change describing the removal from the container.
+	 */
 	def endRecording() {
 		isRecording = false;
 		postprocessRemovals();

--- a/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/AbstractVitruvDomain.xtend
+++ b/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/AbstractVitruvDomain.xtend
@@ -23,7 +23,7 @@ abstract class AbstractVitruvDomain extends AbstractURIHaving implements TuidCal
 	TuidCalculatorAndResolver tuidCalculatorAndResolver
 	Set<String> nsURIs
 	EPackage metamodelRootPackage;
-	Collection<EPackage> furtherRootPackages;
+	Set<EPackage> furtherRootPackages;
 	Map<Object, Object> defaultLoadOptions
 	Map<Object, Object> defaultSaveOptions
 	String name;

--- a/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruvDomain.xtend
+++ b/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruvDomain.xtend
@@ -1,7 +1,6 @@
 package tools.vitruv.framework.domains
 
 import org.eclipse.emf.ecore.EPackage
-import java.util.Collection
 import java.util.Map
 import java.util.Set
 import org.eclipse.emf.ecore.EObject
@@ -10,7 +9,7 @@ interface VitruvDomain extends TuidAwareVitruvDomain {
 	def String getName();
 
 	def EPackage getMetamodelRootPackage();
-	def Collection<EPackage> getFurtherRootPackages();
+	def Set<EPackage> getFurtherRootPackages();
 	def Set<String> getNsUris();
 	def boolean isInstanceOfDomainMetamodel(EObject object);	
 	

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/integration/ChangeDescriptionComplexSequencesTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/integration/ChangeDescriptionComplexSequencesTest.xtend
@@ -25,10 +25,10 @@ class ChangeDescriptionComplexSequencesTest extends ChangeDescription2ChangeTran
 		this.rootElement.singleValuedContainmentEReference = nonRoot;
 				
 		// assert
-		changes.assertChangeCount(6)
+		changes.assertChangeCount(5)
 		changes.assertSetSingleValuedEReference(this.rootElement, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, nonRoot, true, true, false)
 			.assertReplaceSingleValuedEAttribute(nonRoot, IDENTIFIED__ID, null, nonRoot.id, false, false)
-			.assertUnsetSingleValuedEReference(this.rootElement, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, nonRoot, true, true, false)
+			.assertUnsetSingleValuedEReference(this.rootElement, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, nonRoot, true, false, false)
 			.assertSetSingleValuedEReference(this.rootElement, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, nonRoot, true, false, false)
 			.assertEmpty;
 		// There is no 5th change setting the ID again, because the element is stored in a ChangeDescription in between, which means 


### PR DESCRIPTION
This PR makes several improvements on and fixes several bugs in the model recording mechanism.
Delete changes are now correctly inserted after recording a complete sequence of changes instead of generating them on the fly (which is not possible, cf. #202).  This fixes #202.

Some identity changes are not recorded anymore (newly persisting a model at the same URI).

Additionally, changes are now recorded per domain instead of per model, to keep the ordering of changes within all models of one domain. This fixes #203.