### PR TITLE
Revert accessor generation in routines facades

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
@@ -55,7 +55,7 @@ class RoutineFacadeClassGenerator extends ClassGenerator {
 				val includedRoutinesFacadeClassName = includedReactionsSegment.routinesFacadeClassNameGenerator.qualifiedName;
 				reactionsSegment.toField(includedRoutinesFacadeFieldName, typeRef(includedRoutinesFacadeClassName)) [
 					final = true;
-					visibility = JvmVisibility.PRIVATE;
+					visibility = JvmVisibility.PUBLIC;
 				]
 			]
 

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
@@ -19,7 +19,6 @@ import tools.vitruv.dsls.common.helper.ClassNameGenerator
 import tools.vitruv.extensions.dslsruntime.reactions.ReactionExecutionState
 import tools.vitruv.extensions.dslsruntime.reactions.structure.CallHierarchyHaving
 import tools.vitruv.extensions.dslsruntime.reactions.RoutinesFacadeExecutionState
-import org.eclipse.xtext.common.types.JvmMember
 
 class RoutineFacadeClassGenerator extends ClassGenerator {
 	val ReactionsSegment reactionsSegment
@@ -51,19 +50,14 @@ class RoutineFacadeClassGenerator extends ClassGenerator {
 			// fields for all routines facades of reactions segments imported with qualified names,
 			// including transitively included routines facades for imports without qualified names:
 			members += includedRoutinesFacades.entrySet.map [
-				val newMembers = <JvmMember>newArrayList;
 				val includedReactionsSegment = it.key;
 				val includedRoutinesFacadeFieldName = includedReactionsSegment.name;
 				val includedRoutinesFacadeClassName = includedReactionsSegment.routinesFacadeClassNameGenerator.qualifiedName;
-				newMembers += reactionsSegment.toField(includedRoutinesFacadeFieldName, typeRef(includedRoutinesFacadeClassName)) [
+				reactionsSegment.toField(includedRoutinesFacadeFieldName, typeRef(includedRoutinesFacadeClassName)) [
 					final = true;
 					visibility = JvmVisibility.PRIVATE;
 				]
-				newMembers += reactionsSegment.toMethod("get" + includedRoutinesFacadeFieldName.toFirstUpper, typeRef(includedRoutinesFacadeClassName)) [
-					body = '''return «includedRoutinesFacadeFieldName»;'''
-				]
-				return newMembers;
-			].flatten;
+			]
 
 			// included original routines: own routines and routines imported without qualified names, including transitively included routines,
 			// without any override routines


### PR DESCRIPTION
Avoid name clashes due to equally named accessors and routine call methods. Just make the generated local field final to avoid modifications.