### PR TITLE
Reactions Trigger Scoping Fix

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.reactions.ui/src/tools/vitruv/dsls/reactions/ui/outline/ReactionsLanguageOutlineTreeProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions.ui/src/tools/vitruv/dsls/reactions/ui/outline/ReactionsLanguageOutlineTreeProvider.xtend
@@ -16,7 +16,7 @@ import tools.vitruv.dsls.reactions.reactionsLanguage.ReactionsSegment
 import tools.vitruv.dsls.reactions.reactionsLanguage.Reaction
 import tools.vitruv.dsls.reactions.reactionsLanguage.Action
 import tools.vitruv.dsls.reactions.reactionsLanguage.ConcreteModelChange
-import static extension tools.vitruv.dsls.reactions.codegen.changetyperepresentation.ChangeTypeRepresentationExtractor.*
+// import static extension tools.vitruv.dsls.reactions.codegen.changetyperepresentation.ChangeTypeRepresentationExtractor.*
 import static extension tools.vitruv.dsls.reactions.util.ReactionsLanguageUtil.*
 import tools.vitruv.dsls.reactions.reactionsLanguage.Matcher
 import tools.vitruv.dsls.reactions.reactionsLanguage.RoutineInput
@@ -133,7 +133,8 @@ class ReactionsLanguageOutlineTreeProvider extends DefaultOutlineTreeProvider {
 	}
 	
 	protected def Object _text(ConcreteModelChange event) {
-		return '''«FOR change : event.extractChangeSequenceRepresentation.atomicChanges SEPARATOR ", "»«change.name»«ENDFOR»''';
+		return "change"; 
+		//''«FOR change : event.extractChangeSequenceRepresentation.atomicChanges SEPARATOR ", "»«change.name»«ENDFOR»''';
 	}
 	
 	protected def boolean _isLeaf(Trigger element) {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/scoping/ReactionsLanguageScopeProviderDelegate.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/scoping/ReactionsLanguageScopeProviderDelegate.xtend
@@ -33,7 +33,7 @@ import tools.vitruv.dsls.reactions.reactionsLanguage.ReactionsImport
 import tools.vitruv.dsls.reactions.reactionsLanguage.RoutineOverrideImportPath
 import static extension tools.vitruv.dsls.reactions.util.ReactionsLanguageUtil.*
 import static extension tools.vitruv.dsls.reactions.codegen.helper.ReactionsImportsHelper.*
-
+import tools.vitruv.dsls.reactions.reactionsLanguage.ModelElementChange
 
 class ReactionsLanguageScopeProviderDelegate extends MirBaseScopeProviderDelegate {
 
@@ -47,7 +47,11 @@ class ReactionsLanguageScopeProviderDelegate extends MirBaseScopeProviderDelegat
 			return createEStructuralFeatureScope(context as MetaclassFeatureReference)
 		else if (reference.equals(METACLASS_REFERENCE__METACLASS)) {
 			val contextContainer = context.eContainer();
-			if (context instanceof CreateModelElement) {
+			if (context instanceof ModelElementChange) {
+				return createQualifiedEClassScopeWithEObject(context.elementType?.metamodel);
+			} else if (contextContainer instanceof ModelElementChange) {
+				return createQualifiedEClassScopeWithoutAbstract(contextContainer.elementType?.metamodel);
+			} else if (context instanceof CreateModelElement) {
 				return createQualifiedEClassScopeWithoutAbstract(context.metamodel);
 			} else if (contextContainer instanceof CreateModelElement) {
 				return createQualifiedEClassScopeWithoutAbstract(contextContainer.metamodel);


### PR DESCRIPTION
This PR fixes a bug that cased the scoping in Reactions triggers to fail during editing.
It was caused by a missing scoping specification for triggers, which is added by this PR.
Additionally, it removes a faulty outline representation of triggers causing NullpointerExceptions.