### PR TITLE
Issue #212: TUID update cache overwrite

### DIFF
--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidManager.xtend
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidManager.xtend
@@ -76,7 +76,7 @@ final class TuidManager {
 	}
 	
 	def public registerObjectUnderModification(EObject objectUnderModification) {
-		if (objectUnderModification.hasTuidCalculator) {
+		if (objectUnderModification.hasTuidCalculator && !tuidUpdateCache.containsKey(objectUnderModification)) {
 			tuidUpdateCache.put(objectUnderModification, objectUnderModification.calculateTuid);
 		}
 	}


### PR DESCRIPTION
This PR adds a check in the TUID update cache to not overwrite already added objects.

Fixes #212 
