### PR TITLE
Dialog user interactor fixes

### DIFF
--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/MultipleChoiceSelectionInteractionBuilderBaseImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/MultipleChoiceSelectionInteractionBuilderBaseImpl.xtend
@@ -3,7 +3,6 @@ package tools.vitruv.framework.userinteraction.builder.impl
 import tools.vitruv.framework.userinteraction.builder.MultipleChoiceSelectionInteractionBuilder
 import tools.vitruv.framework.userinteraction.builder.MultipleChoiceSelectionInteractionBuilder.ChoicesStep
 import tools.vitruv.framework.userinteraction.builder.MultipleChoiceSelectionInteractionBuilder.OptionalSteps
-import org.eclipse.xtend.lib.annotations.Accessors
 import tools.vitruv.framework.userinteraction.UserInteractionListener
 import tools.vitruv.framework.userinteraction.types.MultipleChoiceSelectionInteraction
 import tools.vitruv.framework.userinteraction.types.InteractionFactory
@@ -18,8 +17,6 @@ import tools.vitruv.framework.userinteraction.types.InteractionFactory
  * @author Heiko Klare
  */
 public abstract class MultipleChoiceSelectionInteractionBuilderBaseImpl<T, I extends MultipleChoiceSelectionInteraction<?>> extends BaseInteractionBuilder<T, I, OptionalSteps<T>> implements MultipleChoiceSelectionInteractionBuilder<T>, ChoicesStep<T>, OptionalSteps<T> {
-	@Accessors private Iterable<String> choices = #["unspecified"]
-
 	new(InteractionFactory interactionFactory, Iterable<UserInteractionListener> userInteractionListener) {
 		super(interactionFactory, userInteractionListener)
 	}
@@ -33,7 +30,7 @@ public abstract class MultipleChoiceSelectionInteractionBuilderBaseImpl<T, I ext
 		if (choices === null || choices.length < 2) {
 			throw new IllegalArgumentException("Provide at least two choices to pick from.")
 		}
-		this.choices = choices
+		choices.forEach[this.interactionToBuild.addChoice(it)]
 		return this
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/MultipleChoiceSelectionDialogWindow.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/MultipleChoiceSelectionDialogWindow.xtend
@@ -14,6 +14,7 @@ import java.util.List
 import java.util.ArrayList
 import org.eclipse.swt.layout.RowLayout
 import org.eclipse.swt.widgets.Group
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 
 /**
  * @author Dominik Klooz
@@ -25,6 +26,7 @@ class MultipleChoiceSelectionDialogWindow extends BaseDialogWindow {
 	private List<Button> choiceButtons
 	private final String positiveButtonText;
 	private final String cancelButtonText;
+	private Iterable<Integer> selectedChoices;
 
 	new(Shell parent, WindowModality windowModality, String title, String message, String positiveButtonText,
 		String cancelButtonText, boolean multiple, Iterable<String> choices) {
@@ -33,6 +35,7 @@ class MultipleChoiceSelectionDialogWindow extends BaseDialogWindow {
 		this.choices = choices;
 		this.positiveButtonText = positiveButtonText;
 		this.cancelButtonText = cancelButtonText;
+		this.selectedChoices = new ArrayList<Integer>();
 	}
 
 	protected override Control createDialogArea(Composite parent) {
@@ -82,6 +85,7 @@ class MultipleChoiceSelectionDialogWindow extends BaseDialogWindow {
 	}
 
 	override okPressed() {
+		selectedChoices = choiceButtons.indexed().filter(pair|pair.value.selection).mapFixed(pair|pair.key);
 		close()
 	}
 
@@ -90,6 +94,6 @@ class MultipleChoiceSelectionDialogWindow extends BaseDialogWindow {
 	}
 
 	public def Iterable<Integer> getSelectedChoices() {
-		return choiceButtons.indexed().filter(pair|pair.value.selection).map(pair|pair.key);
+		return selectedChoices
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/TextInputDialogWindow.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/TextInputDialogWindow.xtend
@@ -29,7 +29,8 @@ class TextInputDialogWindow extends BaseDialogWindow {
 	private final InputValidator inputValidator;
 	private final String positiveButtonText;
 	private final String cancelButtonText;
-
+	private String input = "";
+	
 	new(Shell parent, WindowModality windowModality, String title, String message, String positiveButtonText,
 		String cancelButtonText, InputValidator inputValidator) {
 		super(parent, windowModality, title, message)
@@ -106,14 +107,16 @@ class TextInputDialogWindow extends BaseDialogWindow {
 			inputDecorator.showHoverText(inputDecorator.getDescriptionText())
 			return
 		}
+		this.input = inputField.text
 		close()
 	}
 
 	override void cancelPressed() {
+		this.input = null
 		close()
 	}
 
 	public def String getInputText() {
-		return inputField.text;
+		return input
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/DialogInteractionResultProviderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/DialogInteractionResultProviderImpl.xtend
@@ -31,6 +31,7 @@ class DialogInteractionResultProviderImpl implements InteractionResultProvider {
 	private def void showDialog(BaseDialogWindow dialog) {
 		display.syncExec(new Runnable() {
 			override void run() {
+				dialog.blockOnOpen = true;
 				dialog.show();
 			}
 		});

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/MultipleChoiceSelectionInteraction.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/MultipleChoiceSelectionInteraction.xtend
@@ -5,6 +5,7 @@ import java.util.ArrayList
 import org.eclipse.xtend.lib.annotations.Accessors
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 import tools.vitruv.framework.userinteraction.InteractionResultProvider
+import java.util.List
 
 /**
  * Implementation of an interaction providing a list of choices for the user to select a single or multiple ones.
@@ -17,7 +18,7 @@ abstract class MultipleChoiceSelectionInteraction<I extends MultipleChoiceSelect
 	private static val DEFAULT_MESSAGE = "";
 
 	@Accessors(PROTECTED_GETTER)
-	private final Iterable<String> choices
+	private final List<String> choices
 
 	protected new(InteractionResultProvider interactionResultProvider, WindowModality windowModality) {
 		super(interactionResultProvider, windowModality, DEFAULT_TITLE, DEFAULT_MESSAGE)
@@ -25,4 +26,7 @@ abstract class MultipleChoiceSelectionInteraction<I extends MultipleChoiceSelect
 		this.choices = new ArrayList<String>();
 	}
 
+	public def void addChoice(String choice) {
+		this.choices += choice;
+	}
 }


### PR DESCRIPTION
This PR fixes bugs in or related to the `DialogUserInteractionResultProviderImpl`.
It ensures that change propagation does not proceed until a user decision is performed. Additionally, result retrieval is corrected, so that results can also be returned from the dialog after it has been disposed.