### PR TITLE
Tag handling fix

### DIFF
--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelImpl.xtend
@@ -192,7 +192,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	}
 
 	override Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects) {
-		this.getCorrespondingEObjects(eObjects, "");
+		this.getCorrespondingEObjects(eObjects, null);
 	}
 	
 	override Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects, String tag) {
@@ -200,7 +200,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	}
 
 	def private <T extends Correspondence> Iterable<T> filterCorrespondences(Iterable<? extends Correspondence> correspondences, Class<T> correspondenceType, String tag) {
-		return correspondences.filter(correspondenceType).filter[tag.nullOrEmpty || tag == it.tag]
+		return correspondences.filter(correspondenceType).filter[tag === null || tag == it.tag]
 	}
 	
 	def private Set<List<String>> getCorrespondingUuids(Class<? extends Correspondence> correspondenceType, List<String> uuids, String tag) {

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/GenericCorrespondenceModel.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/GenericCorrespondenceModel.java
@@ -62,10 +62,31 @@ public interface GenericCorrespondenceModel<T extends Correspondence> extends UR
      */
     public Set<T> getCorrespondencesForTuids(List<Tuid> tuids);
 
+    /**
+     * Returns all elements corresponding to the given one.
+     * 
+     * @param eObjects - the objects to get the corresponding ones for
+     * @return the elements corresponding to the given ones
+     */
     public Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects);
     
+    /**
+     * Returns the elements corresponding to the given one, if the correspondence contains the given tag.
+     * 
+     * @param eObjects - the objects to get the corresponding ones for
+     * @param tag - the tag to filter correspondences for. If the tag is <code>null</code>, all correspondences will be returned
+     * @return the elements corresponding to the given ones
+     */
     public Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects, String tag);
     
+    /**
+     * Returns the elements corresponding to the given one, if the correspondence is of the given type and contains the given tag.
+     * 
+     * @param correspondenceType - the type of correspondence to filter
+     * @param eObjects - the objects to get the corresponding ones for
+     * @param tag - the tag to filter correspondences for. If the tag is <code>null</code>, all correspondences will be returned
+     * @return the elements corresponding to the given ones
+     */
     public Set<List<EObject>> getCorrespondingEObjects(Class<? extends Correspondence> correspondenceType, List<EObject> eObjects, String tag);
 
     public T claimUniqueCorrespondence(final List<EObject> aEObjects, final List<EObject> bEObjects);


### PR DESCRIPTION
This PR improves the handling of tag in correspondences, such that empty tags are correctly matched and only `null` tags are used to retrieve elements independent of the tag used in the correspondence.