### PR TITLE
UUID view update

### DIFF
--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/EmptyUuidResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/EmptyUuidResolver.xtend
@@ -58,4 +58,8 @@ class EmptyUuidResolver implements UuidResolver {
 		return false;
 	}
 	
+	override loadUuidsToChild(UuidResolver childResolver, URI uri) {
+		// Do nothing, as there are no entries
+	}
+	
 }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/ResourceRegistrationAdapter.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/ResourceRegistrationAdapter.xtend
@@ -1,0 +1,48 @@
+package tools.vitruv.framework.uuid
+
+import org.eclipse.emf.common.notify.Adapter
+import org.eclipse.emf.ecore.resource.ResourceSet
+import java.util.function.Consumer
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.common.notify.Notification
+import org.eclipse.emf.common.notify.Notifier
+
+/**
+ * An adapter that reacts to additions of resources in a {@link ResourceSet} to call the
+ * callback function for that resource given to the constructor. 
+ */
+package class ResourceRegistrationAdapter implements Adapter {
+	ResourceSet monitoredResourceSet;
+	val Consumer<Resource> resourceRegistrationFunction;
+
+	new(Consumer<Resource> resourceRegistrationFunction) {
+		this.resourceRegistrationFunction = resourceRegistrationFunction;
+	}
+
+	override getTarget() {
+		return null;
+	}
+
+	override isAdapterForType(Object type) {
+		return false;
+	}
+
+	override notifyChanged(Notification notification) {
+		if (notification.eventType == Notification.ADD) {
+			if (notification.notifier instanceof ResourceSet) {
+				if (notification.newValue instanceof Resource) {
+					val resource = notification.newValue as Resource
+					resourceRegistrationFunction.accept(resource);
+				}
+			}
+		}
+	}
+
+	override setTarget(Notifier newTarget) {
+		if (!(newTarget instanceof ResourceSet)) {
+			throw new IllegalArgumentException();
+		}
+		this.monitoredResourceSet = newTarget as ResourceSet;
+	}
+
+}

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -248,7 +248,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		// lead to errors if the ResourceSet is also modified by the test, as these modifications
 		// would also have to be made on the TransactionalEditingDomain once it was created.
 		val domain = transactionalEditingDomain;
-		if (domain !== null && eObject.eResource?.resourceSet === resourceSet) {
+		if (domain !== null && (eObject.eResource?.resourceSet === resourceSet || eObject instanceof EClass)) {
 			EMFCommandBridge.createAndExecuteVitruviusRecordingCommand(registerEObjectCall, domain);
 		} else {
 			registerEObjectCall.call;

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -14,6 +14,7 @@ import tools.vitruv.framework.util.command.EMFCommandBridge
 import java.util.concurrent.Callable
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EClass
+import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil.*
 
 class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	static val logger = Logger.getLogger(UuidGeneratorAndResolverImpl)
@@ -109,6 +110,9 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 			UuidResolver.EMPTY;
 		}
 		loadAndRegisterUuidProviderAndResolver(uuidResource);
+		this.resourceSet.eAdapters.add(new ResourceRegistrationAdapter(
+			[resource | this.loadUuidsFromParent(resource)]
+		));
 	}
 
 	def private loadAndRegisterUuidProviderAndResolver(Resource uuidResource) {
@@ -318,6 +322,35 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		cache.EObjectToUuid.put(eObject, uuid);
 		cache.uuidToEObject.put(uuid, eObject);
 		return uuid;
+	}
+	
+	override void loadUuidsToChild(UuidResolver childResolver, URI uri) {
+		// Only load UUIDs if resource exists (a pathmap resource always exists)
+		if (!(((uri.file || uri.platform) && uri.existsResourceAtUri) || uri.isPathmap)) {
+			return;
+		}
+		for (element : childResolver.resourceSet.getResource(uri, true).allContents.toList) {
+			// Not having a UUID is only supported for pathmap resources and currently Java root elements
+			if (hasUuid(element)) {
+				childResolver.registerEObject(getUuid(element), element);
+			} else {
+				if (uri.isPathmap || uri.fileExtension.equals("java")) {
+					val resolvedObject = resourceSet.getEObject(EcoreUtil.getURI(element), true);
+					if (resolvedObject !== null) {
+						childResolver.registerEObject(generateUuid(resolvedObject), element);
+						// LayoutInformation in Java elements may not be equal in different UuidResolvers (VirtualModel and view), so ignore it	
+					} else if (!element.eClass.name.contains("LayoutInformation")) {
+						throw new IllegalStateException("Object could not be resolved in this UuidResolver's resource set: " + element);
+					}
+				} else {
+					throw new IllegalStateException("Element does not have a UUID but should have one: " + element);
+				}
+			}
+		}
+	}
+	
+	def void loadUuidsFromParent(Resource resource) {
+		parentUuidResolver.loadUuidsToChild(this, resource.URI);
 	}
 
 }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidResolver.xtend
@@ -93,4 +93,10 @@ interface UuidResolver {
 	 * cache to the ordinary resolution mechanism.
 	 */
 	def String registerCachedEObject(EObject eObject);
+	
+	/**
+	 * Loads the UUIDs for the resource of the given {@link URI} into the given
+	 * child {@link UuidResolver}.
+	 */
+	def void loadUuidsToChild(UuidResolver childResolver, URI uri);
 }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidResolver.xtend
@@ -51,15 +51,46 @@ interface UuidResolver {
 	 */
 	def boolean registerUuidForGlobalUri(String uuid, URI uri);
 	
+	/**
+	 * Returns the {@link ResourceSet} used in this UUID resolver.
+	 */
 	def ResourceSet getResourceSet();
 	
+	/**
+	 * Returns the {@link EObject} for the given UUID from the repository, or from the cache
+	 * if it was added using {@link #registerCachedEObject(EObject}.
+	 * If no object is found, an {@link IllegalStateException} is thrown.
+	 */
 	def EObject getPotentiallyCachedEObject(String uuid);
 	
+	/**
+	 * Returns whether an {@link EObject} was registered for the given UUID in the repository,
+	 * or in the cache if it was added using {@link #registerCachedEObject(EObject}.
+	 */
 	def boolean hasPotentiallyCachedEObject(String uuid);
 	
+	/**
+	 * Returns the UUID for the given {@link EObject} from the repository, or from the cache
+	 * if it was added using {@link #registerCachedEObject(EObject}.
+	 * If no UUID is found, an {@link IllegalStateException} is thrown.
+	 */
 	def String getPotentiallyCachedUuid(EObject eObject);
 	
+	/**
+	 * Returns whether a UUID was generated and registered for the given {@link EObject} in the repository,
+	 * or in the cache if it was added using {@link #registerCachedEObject(EObject}.
+	 */
 	def boolean hasPotentiallyCachedUuid(EObject eObject);
 	
+	/**
+	 * Registers the given {@link EObject} as cached object.
+	 * This means that is not resolved by the ordinary {@link #getEObject} and {@link #getUuid} methods.
+	 * This can be useful, if having a UUID assigned to an object is used as an indicator.
+	 * For example, objects having a UUID may be treated as also created and those having none are newly created.
+	 * Nevertheless, UUIDs must sometimes be referenced (e.g. in correspondences created before the element was
+	 * inserted into a monitored model) before checking for creating. So long, the object can be placed in the cache.
+	 * When {@link UuidGeneratorAndResolver#generateUuid(EObject)} is called, the object will be moved from the
+	 * cache to the ordinary resolution mechanism.
+	 */
 	def String registerCachedEObject(EObject eObject);
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruviusUnmonitoredApplicationTest.java
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruviusUnmonitoredApplicationTest.java
@@ -43,8 +43,8 @@ import static org.junit.Assert.assertTrue;
  *
  */
 public abstract class VitruviusUnmonitoredApplicationTest extends VitruviusTest {
-
-	protected ResourceSet resourceSet;
+	// Do not manipulate this resource set, as it reacts to resource additions with UUID loading
+	private ResourceSet resourceSet;
 	private UuidGeneratorAndResolver uuidGeneratorAndResolver;
 	
 	private TestUserInteraction testUserInteractor;


### PR DESCRIPTION
This PR improves the `UuidGeneratorAndResolver`, such that it updates the UUIDs managed by a child resolver (in a view) when an resource is loaded into the resource set of the resolver (i.e., of the view).
This enables the creation of new views from a `VirtualModel` and also supports the resolution of proxy elements (such as primitive types) from external resources.