### PR TITLE
Java 9 preparation

### DIFF
--- a/bundles/demo/addressesrecipients/tools.vitruv.demo.applications.addressesrecipients/META-INF/MANIFEST.MF
+++ b/bundles/demo/addressesrecipients/tools.vitruv.demo.applications.addressesrecipients/META-INF/MANIFEST.MF
@@ -2,8 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Addresses Recipients Application
 Bundle-SymbolicName: tools.vitruv.demo.applications.addressesrecipients;singleton:=true
-Bundle-Version: 1.0.0.qualifier
-Bundle-Vendor: SDQ
+Automatic-Module-Name: tools.vitruv.demo.applications.addressesrecipients
+Bundle-Version: 0.3.0.qualifier
+Bundle-Vendor: vitruv.tools
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,
@@ -12,4 +13,3 @@ Require-Bundle: com.google.guava,
  tools.vitruv.framework.applications,
  tools.vitruv.extensions.dslsruntime.reactions,
  tools.vitruv.dsls.mappings.tests.addressesXrecipients
-

--- a/bundles/demo/addressesrecipients/tools.vitruv.demo.domains.addresses/META-INF/MANIFEST.MF
+++ b/bundles/demo/addressesrecipients/tools.vitruv.demo.domains.addresses/META-INF/MANIFEST.MF
@@ -1,7 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Vitruvius Domain ASEM Metamodel
+Bundle-Name: Vitruvius Demo Domain Addresses
 Bundle-SymbolicName: tools.vitruv.demo.domains.addresses;singleton:=true
+Automatic-Module-Name: tools.vitruv.demo.domains.addresses
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit, 

--- a/bundles/demo/addressesrecipients/tools.vitruv.demo.domains.recipients/META-INF/MANIFEST.MF
+++ b/bundles/demo/addressesrecipients/tools.vitruv.demo.domains.recipients/META-INF/MANIFEST.MF
@@ -1,7 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Vitruvius Domain ASEM Metamodel
+Bundle-Name: Vitruvius Demo Domain Recipients
 Bundle-SymbolicName: tools.vitruv.demo.domains.recipients;singleton:=true
+Automatic-Module-Name: tools.vitruv.demo.domains.recipients
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit, 

--- a/bundles/demo/familiespersons/tools.vitruv.demo.applications.familiespersons.families2persons/META-INF/MANIFEST.MF
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.applications.familiespersons.families2persons/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Demo Families -> Persons
 Bundle-SymbolicName: tools.vitruv.demo.applications.familiespersons.families2persons;singleton:=true
+Automatic-Module-Name: tools.vitruv.demo.applications.familiespersons.families2persons
 Bundle-Version: 0.3.0.qualifier
 Export-Package: tools.vitruv.applications.familiespersons.families2persons
 Require-Bundle: org.apache.log4j,
@@ -23,3 +24,4 @@ Require-Bundle: org.apache.log4j,
   edu.kit.ipd.sdq.metamodels.persons,
   edu.kit.ipd.sdq.metamodels.families
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Vendor: vitruv.tools

--- a/bundles/demo/familiespersons/tools.vitruv.demo.applications.familiespersons.persons2families/META-INF/MANIFEST.MF
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.applications.familiespersons.persons2families/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Demo Persons -> Families
 Bundle-SymbolicName: tools.vitruv.demo.applications.familiespersons.persons2families
+Automatic-Module-Name: tools.vitruv.demo.applications.familiespersons.families2Persons.test
 Bundle-Version: 0.3.0.qualifier
 Export-Package: tools.vitruv.applications.familiespersons.persons2families
 Require-Bundle: org.apache.log4j,
@@ -22,3 +23,4 @@ Require-Bundle: org.apache.log4j,
  edu.kit.ipd.sdq.metamodels.persons,
  edu.kit.ipd.sdq.metamodels.families
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Vendor: vitruv.tools

--- a/bundles/demo/familiespersons/tools.vitruv.demo.applications.familiespersons/META-INF/MANIFEST.MF
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.applications.familiespersons/META-INF/MANIFEST.MF
@@ -2,8 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Demo Families-Persons
 Bundle-SymbolicName: tools.vitruv.demo.applications.familiespersons;singleton:=true
+Automatic-Module-Name: tools.vitruv.demo.applications.familiespersons
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: tools.vitruv.demo.applications.familiespersons.families2persons,
  tools.vitruv.demo.applications.familiespersons.persons2families,
  tools.vitruv.framework.applications
+Bundle-Vendor: vitruv.tools

--- a/bundles/demo/familiespersons/tools.vitruv.demo.domains.families/META-INF/MANIFEST.MF
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.domains.families/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Demo Domain Families
 Bundle-SymbolicName: tools.vitruv.demo.domains.families;singleton:=true
+Automatic-Module-Name: tools.vitruv.demo.domains.families
 Bundle-Version: 0.3.0.qualifier
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,
@@ -15,3 +16,4 @@ Require-Bundle: com.google.guava,
  tools.vitruv.extensions.emf
 Export-Package: tools.vitruv.domains.families
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Vendor: vitruv.tools

--- a/bundles/demo/familiespersons/tools.vitruv.demo.domains.persons/META-INF/MANIFEST.MF
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.domains.persons/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Demo Domain Persons
 Bundle-SymbolicName: tools.vitruv.demo.domains.persons;singleton:=true
+Automatic-Module-Name: tools.vitruv.demo.domains.persons
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,
@@ -15,4 +16,4 @@ Require-Bundle: com.google.guava,
  org.apache.log4j,
  tools.vitruv.extensions.emf
 Export-Package: tools.vitruv.domains.persons
-
+Bundle-Vendor: vitruv.tools

--- a/bundles/dsls/tools.vitruv.dsls.common/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.common/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs Common
 Bundle-SymbolicName: tools.vitruv.dsls.common
+Automatic-Module-Name: tools.vitruv.dsls.common
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,
@@ -13,4 +14,3 @@ Require-Bundle: com.google.guava,
 Export-Package: tools.vitruv.dsls.common,
  tools.vitruv.dsls.common.helper
 Bundle-Vendor: vitruv.tools
-

--- a/bundles/dsls/tools.vitruv.dsls.commonalities.ide/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities.ide/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs Commonalities Language Shared IDE Integration
 Bundle-SymbolicName: tools.vitruv.dsls.commonalities.ide;singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.commonalities.ide
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
@@ -14,4 +15,3 @@ Require-Bundle: org.antlr.runtime,
  org.eclipse.xtext,
  tools.vitruv.dsls.commonalities
 Bundle-Vendor: vitruv.tools
-

--- a/bundles/dsls/tools.vitruv.dsls.commonalities.ui/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities.ui/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs Commonalities Language Eclipse Integration
 Bundle-SymbolicName: tools.vitruv.dsls.commonalities.ui;singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.commonalities.ui
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-Vendor: vitruv.tools
 Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-SymbolicName: tools.vitruv.dsls.commonalities;singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.common
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
@@ -19,7 +20,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.common.types,
  edu.kit.ipd.sdq.activextendannotations,
  tools.vitruv.framework.metamodel;bundle-version="0.2.0",
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional,
  tools.vitruv.dsls.reactions;bundle-version="0.2.0",
  org.eclipse.xtext.common.types;bundle-version="2.12.0",
  org.eclipse.emf.codegen.ecore;bundle-version="2.13.0",

--- a/bundles/dsls/tools.vitruv.dsls.mappings.ide/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.mappings.ide/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Vitruv DSLs Mappings Language Shared IDE Integration
 Bundle-Vendor: vitruv.tools
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.mappings.ide; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mappings.ide
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.mappings,
  org.eclipse.xtext.ide,
@@ -13,4 +14,3 @@ Require-Bundle: tools.vitruv.dsls.mappings,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: tools.vitruv.dsls.mappings.ide.contentassist.antlr.internal,
  tools.vitruv.dsls.mappings.ide.contentassist.antlr
-

--- a/bundles/dsls/tools.vitruv.dsls.mappings.ui/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.mappings.ui/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Vitruv DSLs Mappings Language Eclipse Integration
 Bundle-Vendor: vitruv.tools
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.mappings.ui; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mappings.ui
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.mappings,
  tools.vitruv.dsls.mappings.ide,

--- a/bundles/dsls/tools.vitruv.dsls.mappings/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: tools.vitruv.dsls.mappings; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mappings
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0",
@@ -13,7 +14,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.common.types,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.emf.ecore,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional,
  org.eclipse.xtext.util,
  org.eclipse.xtend.lib,
  org.eclipse.emf.common,

--- a/bundles/dsls/tools.vitruv.dsls.mirbase.ide/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase.ide/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs MIR Base Language Shared IDE Integration
 Bundle-SymbolicName: tools.vitruv.dsls.mirbase.ide;singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mirbase.ide
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
@@ -13,4 +14,3 @@ Require-Bundle: org.antlr.runtime,
  org.eclipse.xtext.xbase.ide,
  tools.vitruv.dsls.mirbase
 Bundle-Vendor: vitruv.tools
-

--- a/bundles/dsls/tools.vitruv.dsls.mirbase.ui/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase.ui/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs MIR Base Language Eclipse Integration
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.mirbase.ui; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mirbase.ui
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.mirbase,
  tools.vitruv.dsls.mirbase.ide,

--- a/bundles/dsls/tools.vitruv.dsls.mirbase/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs MIR Base Language
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.mirbase; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mirbase
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
@@ -11,7 +12,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.common.types,
  org.eclipse.xtext.xbase.lib,
  org.antlr.runtime,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional,
  org.eclipse.xtext.util,
  org.eclipse.xtend.lib,
  org.eclipse.emf.common,

--- a/bundles/dsls/tools.vitruv.dsls.reactions.ide/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.reactions.ide/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs Reactions Language Shared IDE Integration
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.reactions.ide;singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.reactions.ide
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.reactions,
  tools.vitruv.dsls.mirbase,
@@ -13,4 +14,3 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: tools.vitruv.dsls.reactions.ide.contentassist.antlr,
  tools.vitruv.dsls.reactions.ide.contentassist.antlr.internal
 Bundle-Vendor: vitruv.tools
-

--- a/bundles/dsls/tools.vitruv.dsls.reactions.ui/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.reactions.ui/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs Reactions Language Eclipse Integration
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.reactions.ui;singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.reactions.ui
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.reactions,
  tools.vitruv.dsls.reactions.ide;bundle-version="0.1.0",

--- a/bundles/dsls/tools.vitruv.dsls.reactions/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tools.vitruv.dsls.reactions;singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.reactions
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0",
@@ -14,7 +15,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.common.types,
  org.eclipse.xtext.xbase.lib,
  org.antlr.runtime,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional,
  org.eclipse.xtext.util,
  org.eclipse.xtend.lib,
  org.eclipse.emf.common,

--- a/bundles/extensions/changevisualization/tools.vitruv.extensions.changevisualization/META-INF/MANIFEST.MF
+++ b/bundles/extensions/changevisualization/tools.vitruv.extensions.changevisualization/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ChangeVisualization
 Bundle-SymbolicName: tools.vitruv.extensions.changevisualization;singleton:=true
+Automatic-Module-Name: tools.vitruv.extensions.changevisualization
 Bundle-Version: 0.3.0.qualifier
 Require-Bundle: org.eclipse.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/extensions/constructionsimulation/tools.vitruv.extensions.constructionsimulation.util/META-INF/MANIFEST.MF
+++ b/bundles/extensions/constructionsimulation/tools.vitruv.extensions.constructionsimulation.util/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Extension Construction Simulation Utilities
 Bundle-SymbolicName: tools.vitruv.extensions.constructionsimulation.util
+Automatic-Module-Name: tools.vitruv.extensions.constructionsimulation.util
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.ui,

--- a/bundles/extensions/constructionsimulation/tools.vitruv.extensions.constructionsimulation/META-INF/MANIFEST.MF
+++ b/bundles/extensions/constructionsimulation/tools.vitruv.extensions.constructionsimulation/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Extension Model Construction Simulation
 Bundle-SymbolicName: tools.vitruv.extensions.constructionsimulation;singleton:=true
+Automatic-Module-Name: tools.vitruv.extensions.constructionsimulation
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/META-INF/MANIFEST.MF
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.extensions.dslsruntime.commonalities;singleton:=true
+Automatic-Module-Name: tools.vitruv.extensions.dslsruntime.commonalities
 Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/resources/impl/IntermediateResourceBridgeI.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/resources/impl/IntermediateResourceBridgeI.xtend
@@ -15,8 +15,6 @@ import tools.vitruv.framework.util.datatypes.VURI
 
 import static com.google.common.base.Preconditions.*
 
-import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
-
 // TODO remove once resources are handled by domains
 class IntermediateResourceBridgeI extends IntermediateResourceBridgeImpl {
 

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/resources/impl/IntermediateResourceBridgeI.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/resources/impl/IntermediateResourceBridgeI.xtend
@@ -15,6 +15,8 @@ import tools.vitruv.framework.util.datatypes.VURI
 
 import static com.google.common.base.Preconditions.*
 
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
+
 // TODO remove once resources are handled by domains
 class IntermediateResourceBridgeI extends IntermediateResourceBridgeImpl {
 

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.mappings/META-INF/MANIFEST.MF
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.mappings/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.extensions.dslsruntime.mappings
+Automatic-Module-Name: tools.vitruv.extensions.dslsruntime.mappings
 Bundle-Version: 0.3.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -15,4 +16,3 @@ Require-Bundle: com.google.guava,
  edu.kit.ipd.sdq.commons.util.java
 Export-Package: tools.vitruv.extensions.dslsruntime.mappings,
  tools.vitruv.extensions.dslsruntime.mappings.interfaces
-

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/META-INF/MANIFEST.MF
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.extensions.dslsruntime.reactions;singleton:=true
+Automatic-Module-Name: tools.vitruv.extensions.dslsruntime.reactions
 Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
@@ -31,4 +32,3 @@ Export-Package: tools.vitruv.dsls.reactions.meta.correspondence.reactions,
  tools.vitruv.extensions.dslsruntime.reactions.helper,
  tools.vitruv.extensions.dslsruntime.reactions.structure
 Import-Package: org.apache.log4j
-

--- a/bundles/extensions/emfdomain/tools.vitruv.extensions.emf.monitorededitor/META-INF/MANIFEST.MF
+++ b/bundles/extensions/emfdomain/tools.vitruv.extensions.emf.monitorededitor/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain EMF Monitored Editor
 Bundle-SymbolicName: tools.vitruv.extensions.emf.monitorededitor;singleton:=true
+Automatic-Module-Name: tools.vitruv.extensions.emf.monitorededitor
 Bundle-Version: 0.3.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -25,5 +26,4 @@ Bundle-ActivationPolicy: lazy
 Export-Package: tools.vitruv.domains.emf.monitorededitor,
  tools.vitruv.domains.emf.monitorededitor.monitor,
  tools.vitruv.domains.emf.monitorededitor.tools
-Import-Package: tools.vitruv.framework.util.bridges
 Bundle-Vendor: vitruv.tools

--- a/bundles/extensions/emfdomain/tools.vitruv.extensions.emf/META-INF/MANIFEST.MF
+++ b/bundles/extensions/emfdomain/tools.vitruv.extensions.emf/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain EMF
 Bundle-SymbolicName: tools.vitruv.extensions.emf;singleton:=true
+Automatic-Module-Name: tools.vitruv.extensions.emf
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.resources,
@@ -25,4 +26,3 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.xtend.lib.macro
 Export-Package: tools.vitruv.domains.emf.builder
 Bundle-Vendor: vitruv.tools
-

--- a/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/META-INF/MANIFEST.MF
+++ b/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.extensions.integration.correspondence;singleton:=true
+Automatic-Module-Name: tools.vitruv.extensions.integration.correspondence
 Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
@@ -24,4 +25,3 @@ Export-Package: tools.vitruv.extensions.integration.correspondence.util,
  tools.vitruv.extensions.integration.correspondence.integration,
  tools.vitruv.extensions.integration.correspondence.integration.impl,
  tools.vitruv.extensions.integration.correspondence.integration.util
-

--- a/bundles/framework/tools.vitruv.framework.applications/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.applications/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework Applications Specification
 Bundle-SymbolicName: tools.vitruv.framework.applications;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.applications
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: tools.vitruv.framework.change.processing;visibility:=reexport,

--- a/bundles/framework/tools.vitruv.framework.change.echange/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.change.echange/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.framework.change.echange;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.change.echange
 Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
@@ -47,4 +48,3 @@ Require-Bundle: com.google.guava,
  tools.vitruv.framework.uuid;visibility:=reexport,
  edu.kit.ipd.sdq.activextendannotations
 Bundle-ActivationPolicy: lazy
-

--- a/bundles/framework/tools.vitruv.framework.change.interaction/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.change.interaction/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.framework.change.interaction;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.change.interaction
 Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName

--- a/bundles/framework/tools.vitruv.framework.change.processing/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.change.processing/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework Change Processing
 Bundle-SymbolicName: tools.vitruv.framework.change.processing;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.change.processing
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.apache.log4j,

--- a/bundles/framework/tools.vitruv.framework.change/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.change/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework Change Metamodel
 Bundle-SymbolicName: tools.vitruv.framework.change
+Automatic-Module-Name: tools.vitruv.framework.change
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.apache.log4j,

--- a/bundles/framework/tools.vitruv.framework.correspondence/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.correspondence/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.framework.correspondence;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.correspondence
 Bundle-ClassPath: .
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/framework/tools.vitruv.framework.metamodel/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.metamodel/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework Metamodel Representations
 Bundle-SymbolicName: tools.vitruv.framework.metamodel;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.metamodel
 Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/framework/tools.vitruv.framework.tuid/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.tuid/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework Temporary Unique Identifier Specification
 Bundle-SymbolicName: tools.vitruv.framework.tuid
+Automatic-Module-Name: tools.vitruv.framework.tuid
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.apache.log4j,
@@ -16,4 +17,3 @@ Require-Bundle: org.apache.log4j,
  tools.vitruv.framework.util;visibility:=reexport
 Export-Package: tools.vitruv.framework.tuid
 Bundle-Vendor: vitruv.tools
-

--- a/bundles/framework/tools.vitruv.framework.ui.monitorededitor/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.ui.monitorededitor/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework UI Monitored Editors
 Bundle-SymbolicName: tools.vitruv.framework.ui.monitorededitor;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.ui.monitorededitor
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
@@ -20,4 +21,3 @@ Require-Bundle: org.apache.log4j,
 Export-Package: tools.vitruv.framework.ui.monitorededitor,
  tools.vitruv.framework.ui.monitorededitor.registries
 Bundle-Vendor: vitruv.tools
-

--- a/bundles/framework/tools.vitruv.framework.ui.vsum/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.ui.vsum/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework UI Virtual Singl Underlying Model
 Bundle-SymbolicName: tools.vitruv.framework.ui.vsum;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.ui.monitorededitor
 Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: tools.vitruv.framework.ui.vsum.Activator
 Require-Bundle: org.eclipse.ui,
@@ -19,4 +20,3 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: vitruv.tools
-

--- a/bundles/framework/tools.vitruv.framework.userinteracting/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework User Interaction
 Bundle-SymbolicName: tools.vitruv.framework.userinteraction
+Automatic-Module-Name: tools.vitruv.framework.userinteraction
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/UserInteractor.java
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/UserInteractor.java
@@ -38,7 +38,7 @@ public interface UserInteractor {
 	TextInputInteractionBuilder getTextInputDialogBuilder();
 
 	/**
-	 * @return a {@link MultipleChoiceMultiSelectionInteractionBuilder} used to
+	 * @return a {@link MultipleChoiceSingleSelectionInteractionBuilder} used to
 	 *         configure, build and show multiple choice input dialogs to prompt the
 	 *         user to choose from a list of choices. This one allows the user to
 	 *         select one single item.

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/TextInputInteractionBuilderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/TextInputInteractionBuilderImpl.xtend
@@ -23,9 +23,6 @@ import tools.vitruv.framework.userinteraction.types.InteractionFactory
  * @author Heiko Klare
  */
 public class TextInputInteractionBuilderImpl extends BaseInteractionBuilder<String, TextInputInteraction, OptionalSteps> implements TextInputInteractionBuilder, OptionalSteps {
-	private InputFieldType inputFieldType = InputFieldType.SINGLE_LINE
-	private InputValidator inputValidator = TextInputInteraction.ACCEPT_ALL_INPUT_VALIDATOR
-
 	new(InteractionFactory interactionFactory, Iterable<UserInteractionListener> userInteractionListener) {
 		super(interactionFactory, userInteractionListener)
 	}
@@ -37,14 +34,14 @@ public class TextInputInteractionBuilderImpl extends BaseInteractionBuilder<Stri
 
 	override inputValidator(InputValidator inputValidator) {
 		if (inputValidator !== null) {
-			this.inputValidator = inputValidator
+			interactionToBuild.inputValidator = inputValidator
 		}
 		return this
 	}
 
 	override inputValidator(Function<String, Boolean> validatorFunction, String invalidInputMessage) {
 		if (validatorFunction !== null && invalidInputMessage !== null) {
-			this.inputValidator = new InputValidator() {
+			interactionToBuild.inputValidator = new InputValidator() {
 				override getInvalidInputMessage(String input) { invalidInputMessage }
 
 				override isInputValid(String input) { validatorFunction.apply(input) }
@@ -55,7 +52,7 @@ public class TextInputInteractionBuilderImpl extends BaseInteractionBuilder<Stri
 
 	override inputFieldType(InputFieldType inputFieldType) {
 		if (inputFieldType !== null) {
-			this.inputFieldType = inputFieldType
+			interactionToBuild.inputFieldType = inputFieldType
 		}
 		return this
 	}

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/ConfirmationDialogWindow.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/ConfirmationDialogWindow.xtend
@@ -67,7 +67,8 @@ class ConfirmationDialogWindow extends BaseDialogWindow {
 	}
 
 	protected override void createButtonsForButtonBar(Composite parent) {
-		createButton(parent, IDialogConstants.OK_ID, positiveButtonText, true)
+		createButton(parent, IDialogConstants.YES_ID, positiveButtonText, true)
+		createButton(parent, IDialogConstants.NO_ID, negativeButtonText, true)
 		createButton(parent, IDialogConstants.CANCEL_ID, cancelButtonText, true)
 	}
 
@@ -80,9 +81,18 @@ class ConfirmationDialogWindow extends BaseDialogWindow {
 		this.confirmed = false
 		close()
 	}
+	
+	override protected buttonPressed(int buttonId) {
+		if (buttonId == IDialogConstants.YES_ID) {
+			this.confirmed = true
+		} else if (buttonId == IDialogConstants.NO_ID) {
+			this.confirmed = false;
+		}
+		close();
+	}
 
 	def boolean getConfirmed() {
 		return confirmed
 	}
-
+	
 }

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/TextInputInteraction.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/TextInputInteraction.xtend
@@ -1,6 +1,5 @@
 package tools.vitruv.framework.userinteraction.types
 
-import java.util.function.Function
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.InputFieldType
 import tools.vitruv.framework.change.interaction.FreeTextUserInteraction
@@ -39,17 +38,8 @@ public class TextInputInteraction extends BaseInteraction<FreeTextUserInteractio
 		this.inputValidator = inputValidator
 	}
 
-	protected new(InteractionResultProvider interactionResultProvider, WindowModality windowModality,
-		InputFieldType fieldType, Function<String, Boolean> inputValidator, String invalidInputMessage) {
-		this(interactionResultProvider, windowModality, fieldType, new InputValidator() {
-			override getInvalidInputMessage(String input) { "" }
-
-			override isInputValid(String input) { inputValidator.apply(input) }
-		})
-	}
-
 	protected new(InteractionResultProvider interactionResultProvider, WindowModality windowModality) {
-		this(interactionResultProvider, windowModality, InputFieldType.SINGLE_LINE, [text|true], "")
+		this(interactionResultProvider, windowModality, InputFieldType.SINGLE_LINE, ACCEPT_ALL_INPUT_VALIDATOR)
 	}
 
 	def InputValidator getInputValidator() { inputValidator }

--- a/bundles/framework/tools.vitruv.framework.util/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.util/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework Utilities
 Bundle-SymbolicName: tools.vitruv.framework.util
+Automatic-Module-Name: tools.vitruv.framework.util
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: tools.vitruv.framework.util,

--- a/bundles/framework/tools.vitruv.framework.uuid/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.uuid/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.framework.uuid;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.uuid
 Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
@@ -20,4 +21,3 @@ Require-Bundle: org.eclipse.core.runtime,
  tools.vitruv.framework.util,
  org.eclipse.emf.transaction
 Bundle-ActivationPolicy: lazy
-

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/ResourceRegistrationAdapter.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/ResourceRegistrationAdapter.xtend
@@ -12,7 +12,6 @@ import org.eclipse.emf.common.notify.Notifier
  * callback function for that resource given to the constructor. 
  */
 package class ResourceRegistrationAdapter implements Adapter {
-	ResourceSet monitoredResourceSet;
 	val Consumer<Resource> resourceRegistrationFunction;
 
 	new(Consumer<Resource> resourceRegistrationFunction) {
@@ -39,10 +38,7 @@ package class ResourceRegistrationAdapter implements Adapter {
 	}
 
 	override setTarget(Notifier newTarget) {
-		if (!(newTarget instanceof ResourceSet)) {
-			throw new IllegalArgumentException();
-		}
-		this.monitoredResourceSet = newTarget as ResourceSet;
+		// Do nothing
 	}
 
 }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -19,7 +19,6 @@ import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util
 class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	static val logger = Logger.getLogger(UuidGeneratorAndResolverImpl)
 	final ResourceSet resourceSet;
-	final Resource uuidResource;
 	final UuidResolver parentUuidResolver;
 	final boolean strictMode;
 	UuidToEObjectRepository repository;
@@ -101,7 +100,6 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		if (resourceSet === null) {
 			throw new IllegalArgumentException("Resource set may not be null");
 		}
-		this.uuidResource = uuidResource;
 		this.resourceSet = resourceSet;
 		this.strictMode = strictMode;
 		this.parentUuidResolver = if (parentUuidResolver !== null) {

--- a/bundles/framework/tools.vitruv.framework.vsum/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.vsum/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework Virtual Single Underlying Model
 Bundle-SymbolicName: tools.vitruv.framework.vsum;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.vsum
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.apache.log4j,
@@ -24,4 +25,3 @@ Export-Package: tools.vitruv.framework.vsum,
  tools.vitruv.framework.vsum.helper,
  tools.vitruv.framework.vsum.modelsynchronization
 Bundle-Vendor: vitruv.tools
-

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
@@ -17,7 +17,6 @@ import tools.vitruv.framework.change.description.PropagatedChange
 import tools.vitruv.framework.util.command.EMFCommandBridge
 import tools.vitruv.framework.vsum.repositories.ResourceRepositoryImpl
 import tools.vitruv.framework.vsum.repositories.ModelRepositoryImpl
-import tools.vitruv.framework.change.echange.EChangeIdManager
 import java.util.Vector
 import tools.vitruv.framework.vsum.helper.ChangeDomainExtractor
 import tools.vitruv.framework.userinteraction.UserInteractor
@@ -32,7 +31,6 @@ class VirtualModelImpl implements InternalVirtualModel {
 	private val ChangePropagator changePropagator;
 	private val ChangePropagationSpecificationProvider changePropagationSpecificationProvider;
 	private val File folder;
-	private val EChangeIdManager eChangeIdManager;
 	private val extension ChangeDomainExtractor changeDomainExtractor;
 	
 	/**
@@ -61,7 +59,6 @@ class VirtualModelImpl implements InternalVirtualModel {
 		this.changePropagator = new ChangePropagatorImpl(resourceRepository, changePropagationSpecificationProvider,
 		    metamodelRepository, resourceRepository, modelRepository, userInteractor
 		);
-		this.eChangeIdManager = new EChangeIdManager(this.uuidGeneratorAndResolver);
 		VirtualModelManager.instance.putVirtualModel(this);
 		
 		this.propagatedChangeListeners = new Vector<PropagatedChangeListener>();

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -32,6 +32,8 @@ import tools.vitruv.framework.userinteraction.UserInteractionListener
 import tools.vitruv.framework.change.interaction.UserInteractionBase
 import tools.vitruv.framework.userinteraction.UserInteractionFactory
 
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
+
 class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserver, UserInteractionListener {
 	static Logger logger = Logger.getLogger(ChangePropagatorImpl.getSimpleName())
 	final VitruvDomainRepository metamodelRepository;

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -22,7 +22,6 @@ import tools.vitruv.framework.vsum.ModelRepository
 import tools.vitruv.framework.uuid.UuidResolver
 import tools.vitruv.framework.change.description.CompositeChange
 
-import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import tools.vitruv.framework.change.description.CompositeTransactionalChange
 import tools.vitruv.framework.correspondence.CorrespondencePackage
 import tools.vitruv.framework.change.description.ConcreteChange

--- a/bundles/testutils/tools.vitruv.testutils.domains/META-INF/MANIFEST.MF
+++ b/bundles/testutils/tools.vitruv.testutils.domains/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Test Utilities Domains
 Bundle-SymbolicName: tools.vitruv.testutils.domains;singleton:=true
+Automatic-Module-Name: tools.vitruv.testutils
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: tools.vitruv.framework.metamodel,

--- a/bundles/testutils/tools.vitruv.testutils.metamodels/META-INF/MANIFEST.MF
+++ b/bundles/testutils/tools.vitruv.testutils.metamodels/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.testutils.metamodels;singleton:=true
+Automatic-Module-Name: tools.vitruv.testutils
 Bundle-Version: 0.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/testutils/tools.vitruv.testutils/META-INF/MANIFEST.MF
+++ b/bundles/testutils/tools.vitruv.testutils/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Test Utilities
 Bundle-SymbolicName: tools.vitruv.testutils
+Automatic-Module-Name: tools.vitruv.testutils
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: tools.vitruv.framework.vsum;visibility:=reexport,
@@ -31,4 +32,3 @@ Export-Package: tools.vitruv.testutils,
  tools.vitruv.testutils.matchers,
  tools.vitruv.testutils.util
 Bundle-Vendor: vitruv.tools
-

--- a/features/tools.vitruv.demo.familiespersons.feature/feature.xml
+++ b/features/tools.vitruv.demo.familiespersons.feature/feature.xml
@@ -32,8 +32,8 @@
       <import feature="org.eclipse.xtend.sdk" version="2.12.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.xtext.xbase.lib" version="2.12.0" match="greaterOrEqual"/>
       <import feature="tools.vitruv.extensions.dslsruntime.feature" version="0.3.0.qualifier"/>
-      <import feature="edu.kit.ipd.sdq.metamodels.persons.feature" version="1.0.0.201711061638"/>
-      <import feature="edu.kit.ipd.sdq.metamodels.families.feature" version="1.0.0.201711061638"/>
+      <import feature="edu.kit.ipd.sdq.metamodels.persons.feature" version="1.0.0" match="greaterOrEqual"/>
+      <import feature="edu.kit.ipd.sdq.metamodels.families.feature" version="1.0.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/tests/demo/tools.vitruv.demo.applications.familiespersons.families2persons.tests/META-INF/MANIFEST.MF
+++ b/tests/demo/tools.vitruv.demo.applications.familiespersons.families2persons.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Demo Families -> Persons Tests
 Bundle-SymbolicName: tools.vitruv.demo.applications.familiespersons.families2Persons.test
+Automatic-Module-Name: tools.vitruv.demo.applications.familiespersons.families2Persons.test
 Bundle-Version: 0.3.0.qualifier
 Fragment-Host: tools.vitruv.demo.applications.familiespersons.families2persons
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -13,3 +14,4 @@ Require-Bundle: com.google.guava,
  org.junit;bundle-version="4.8.1",
  tools.vitruv.framework.change.processing,
  org.apache.log4j
+Bundle-Vendor: vitruv.tools

--- a/tests/demo/tools.vitruv.demo.applications.familiespersons.persons2families.tests/META-INF/MANIFEST.MF
+++ b/tests/demo/tools.vitruv.demo.applications.familiespersons.persons2families.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Demo Persons -> Families Tests
 Bundle-SymbolicName: tools.vitruv.demo.applications.familiespersons.persons2families.test
+Automatic-Module-Name: tools.vitruv.demo.applications.familiespersons.persons2families.test
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Fragment-Host: tools.vitruv.demo.applications.familiespersons.persons2families
@@ -12,5 +13,4 @@ Require-Bundle: com.google.guava,
  tools.vitruv.testutils;bundle-version="0.2.0",
  org.junit;bundle-version="4.8.1",
  tools.vitruv.framework.change.processing
-
-
+Bundle-Vendor: vitruv.tools

--- a/tests/dsls/tools.vitruv.dsls.commonalities.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.commonalities.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs Commonalities Language Core Tests
 Bundle-SymbolicName: tools.vitruv.dsls.commonalities.tests;singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.commonalities.tests
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/tests/dsls/tools.vitruv.dsls.commonalities.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.commonalities.ui.tests/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Vitruv DSLs Commonalities Language Eclipse Integration Tests
 Bundle-Vendor: vitruv.tools
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.commonalities.ui.tests; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.commonalities.ui.tests
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.commonalities.ui,
  org.junit;bundle-version="4.12.0",

--- a/tests/dsls/tools.vitruv.dsls.mappings.tests.addressesXrecipients/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.mappings.tests.addressesXrecipients/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs Mappings Tests AddressesXRecipients
 Bundle-SymbolicName: tools.vitruv.dsls.mappings.tests.addressesXrecipients
+Automatic-Module-Name: tools.vitruv.dsls.mappings.tests.addressesXrecipients
 Bundle-Version: 0.3.0.qualifier
 Bundle-Vendor: vitruv.tools
 Export-Package: mir.reactions.adXre_L2R,

--- a/tests/dsls/tools.vitruv.dsls.mappings.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.mappings.tests/META-INF/MANIFEST.MF
@@ -4,13 +4,14 @@ Bundle-Name: Vitruv DSLs Mapping Language Tests
 Bundle-Vendor: vitruv.tools
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.mappings.tests; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mappings.tests
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.mappings,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing,
  org.eclipse.xtext.xbase.lib,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: tools.vitruv.dsls.mappings.tests;x-internal=true
 Import-Package: org.hamcrest.core,

--- a/tests/dsls/tools.vitruv.dsls.mappings.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.mappings.ui.tests/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Vitruv DSLs Mappings Language UI Tests
 Bundle-Vendor: vitruv.tools
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.mappings.ui.tests; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mappings.ui
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.mappings.ui,
  org.junit;bundle-version="4.12.0",

--- a/tests/dsls/tools.vitruv.dsls.mirbase.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.mirbase.tests/META-INF/MANIFEST.MF
@@ -3,13 +3,14 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs MIR Base Language Tests
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.mirbase.tests; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mirbase.tests
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.mirbase,
  org.junit;bundle-version="4.7.0",
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.xtext.xbase.lib,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/dsls/tools.vitruv.dsls.mirbase.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.mirbase.ui.tests/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs MIR Base Language UI Tests
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.mirbase.ui.tests; singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.mirbase.ui.tests
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.mirbase.ui,
  org.junit;bundle-version="4.7.0",

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: tools.vitruv.dsls.reactions.tests;singleton:=true
 Bundle-Version: 0.3.0.qualifier
 Bundle-Vendor: vitruv.tools
 Export-Package: tools.vitruv.dsls.reactions.tests;x-internal=true
+Automatic-Module-Name: tools.vitruv.dsls.reactions.tests
 Require-Bundle: org.junit,
   org.apache.log4j,
   com.google.guava,
@@ -26,7 +27,7 @@ Require-Bundle: org.junit,
   tools.vitruv.framework.tuid,
   tools.vitruv.dsls.reactions,
   tools.vitruv.dsls.reactions.ui,
-  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+  org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional,
   tools.vitruv.testutils.domains,
   org.eclipse.xtext.testing;bundle-version="2.12.0",
   org.eclipse.xtext.xbase.testing,

--- a/tests/dsls/tools.vitruv.dsls.reactions.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.reactions.ui.tests/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv DSLs Reactions Language UI Tests
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: tools.vitruv.dsls.reactions.ui.tests;singleton:=true
+Automatic-Module-Name: tools.vitruv.dsls.reactions.ui.tests
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.reactions.ui,
  org.junit;bundle-version="4.7.0",

--- a/tests/extensions/emfdomain/tools.vitruv.extensions.emf.monitorededitor.tests/META-INF/MANIFEST.MF
+++ b/tests/extensions/emfdomain/tools.vitruv.extensions.emf.monitorededitor.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain EMF Monitored Editor Tests
 Bundle-SymbolicName: tools.vitruv.extensions.emf.monitorededitor.tests;singleton:=true
+Automatic-Module-Name: tools.vitruv.extensions.emf.monitorededitor.tests
 Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: tools.vitruv.domains.emf.monitorededitor.Activator
 Bundle-ClassPath: ., lib/cglib-nodep-3.1.jar, lib/easymock-3.1.jar, lib/objenesis-1.2.jar

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/META-INF/MANIFEST.MF
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework Atomic Change Tests
 Bundle-SymbolicName: tools.vitruv.framework.change.echange.tests
+Automatic-Module-Name: tools.vitruv.framework.change.echange.tests
 Bundle-Version: 0.3.0.qualifier
 Bundle-Vendor: vitruv.tools
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/framework/tools.vitruv.framework.change.tests/META-INF/MANIFEST.MF
+++ b/tests/framework/tools.vitruv.framework.change.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framework Change Metamodel Tests
 Bundle-SymbolicName: tools.vitruv.framework.change.tests
+Automatic-Module-Name: tools.vitruv.framework.change.processing
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,
@@ -18,5 +19,3 @@ Require-Bundle: org.junit,
  tools.vitruv.framework.change.echange,
  tools.vitruv.framework.util
 Bundle-Vendor: vitruv.tools
- 
-

--- a/tests/framework/tools.vitruv.framework.vsum.tests/META-INF/MANIFEST.MF
+++ b/tests/framework/tools.vitruv.framework.vsum.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Framwork Virtual Single Underlying Model Tests
 Bundle-SymbolicName: tools.vitruv.framework.vsum.tests;singleton:=true
+Automatic-Module-Name: tools.vitruv.framework.vsum.tests
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: tools.vitruv.framework.tests.vsum
@@ -26,4 +27,3 @@ Require-Bundle: org.junit,
  org.eclipse.uml2.uml
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: vitruv.tools
-


### PR DESCRIPTION
This PR fixes some metadata issues and especially prepares the plugins for Java 9, adding module descriptions to the manifests.
Additionally, some used code is removed and minor bugs in the text input user interactors are fixed.