### PR TITLE
Correspondence model cleanup

### DIFF
--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/ReactionsCorrespondenceHelper.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/ReactionsCorrespondenceHelper.xtend
@@ -7,7 +7,6 @@ import tools.vitruv.dsls.reactions.meta.correspondence.reactions.ReactionsCorres
 import tools.vitruv.dsls.reactions.meta.correspondence.reactions.ReactionsFactory
 import java.util.List
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import org.eclipse.emf.ecore.util.EcoreUtil
 
 final class ReactionsCorrespondenceHelper {
 	private new() {}
@@ -21,13 +20,7 @@ final class ReactionsCorrespondenceHelper {
 	public static def removeCorrespondencesBetweenElements(CorrespondenceModel correspondenceModel,
 		EObject source, EObject target, String tag) {
 		val correspondenceModelView = correspondenceModel.reactionsView;
-		val correspondences = correspondenceModelView.getCorrespondences(#[source]).filter[it.tag == tag];
-		for (correspondence : correspondences.toList) {
-			if ((correspondence.^as.containsEqualElement(source) && correspondence.bs.containsEqualElement(target)) ||
-				(correspondence.bs.containsEqualElement(source) && correspondence.^as.containsEqualElement(target))) {
-				correspondenceModelView.removeCorrespondencesAndDependendCorrespondences(correspondence);
-			}
-		}
+		correspondenceModelView.removeCorrespondencesBetween(#[source], #[target], tag);
 	}
 	
 	public static def removeCorrespondencesOfObject(CorrespondenceModel correspondenceModel,
@@ -39,10 +32,6 @@ final class ReactionsCorrespondenceHelper {
 		}
 	}
 	
-	private static def containsEqualElement(Iterable<EObject> eObjects, EObject searchedObject) {
-		return eObjects.exists[EcoreUtil.equals(it, searchedObject)];
-	}
-
 	public static def ReactionsCorrespondence addCorrespondence(
 		CorrespondenceModel correspondenceModel, EObject source, EObject target, String tag) {
 		val correspondence = correspondenceModel.reactionsView.

--- a/bundles/framework/tools.vitruv.framework.correspondence/metamodel/correspondence.ecore
+++ b/bundles/framework/tools.vitruv.framework.correspondence/metamodel/correspondence.ecore
@@ -6,7 +6,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="correspondences" upperBound="-1"
         eType="#//Correspondence" containment="true" eOpposite="#//Correspondence/parent"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="correspondenceModel" lowerBound="1"
-        eType="#//CorrespondenceModel" transient="true"/>
+        eType="#//GenericCorrespondenceModel" transient="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Correspondence" abstract="true">
     <eOperations name="getAs" upperBound="-1" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
@@ -28,7 +28,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="tag" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ManualCorrespondence" eSuperTypes="#//Correspondence"/>
-  <eClassifiers xsi:type="ecore:EDataType" name="CorrespondenceModel" instanceClassName="tools.vitruv.framework.correspondence.CorrespondenceModel"
+  <eClassifiers xsi:type="ecore:EDataType" name="GenericCorrespondenceModel" instanceClassName="tools.vitruv.framework.correspondence.GenericCorrespondenceModel"
       serializable="false"/>
   <eClassifiers xsi:type="ecore:EDataType" name="Tuid" instanceClassName="tools.vitruv.framework.tuid.Tuid"/>
 </ecore:EPackage>

--- a/bundles/framework/tools.vitruv.framework.correspondence/metamodel/correspondence.ecore
+++ b/bundles/framework/tools.vitruv.framework.correspondence/metamodel/correspondence.ecore
@@ -5,12 +5,8 @@
   <eClassifiers xsi:type="ecore:EClass" name="Correspondences">
     <eStructuralFeatures xsi:type="ecore:EReference" name="correspondences" upperBound="-1"
         eType="#//Correspondence" containment="true" eOpposite="#//Correspondence/parent"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="correspondenceModel" lowerBound="1"
-        eType="#//GenericCorrespondenceModel" transient="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Correspondence" abstract="true">
-    <eOperations name="getAs" upperBound="-1" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
-    <eOperations name="getBs" upperBound="-1" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="parent" lowerBound="1"
         eType="#//Correspondences" eOpposite="#//Correspondences/correspondences"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="dependsOn" ordered="false"
@@ -28,7 +24,5 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="tag" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ManualCorrespondence" eSuperTypes="#//Correspondence"/>
-  <eClassifiers xsi:type="ecore:EDataType" name="GenericCorrespondenceModel" instanceClassName="tools.vitruv.framework.correspondence.GenericCorrespondenceModel"
-      serializable="false"/>
   <eClassifiers xsi:type="ecore:EDataType" name="Tuid" instanceClassName="tools.vitruv.framework.tuid.Tuid"/>
 </ecore:EPackage>

--- a/bundles/framework/tools.vitruv.framework.correspondence/metamodel/correspondence.genmodel
+++ b/bundles/framework/tools.vitruv.framework.correspondence/metamodel/correspondence.genmodel
@@ -8,11 +8,9 @@
   <foreignModel>correspondence.ecore</foreignModel>
   <genPackages prefix="Correspondence" basePackage="tools.vitruv.framework" disposableProviderFactory="true"
       ecorePackage="correspondence.ecore#/">
-    <genDataTypes ecoreDataType="correspondence.ecore#//GenericCorrespondenceModel"/>
     <genDataTypes ecoreDataType="correspondence.ecore#//Tuid"/>
     <genClasses ecoreClass="correspondence.ecore#//Correspondences">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference correspondence.ecore#//Correspondences/correspondences"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute correspondence.ecore#//Correspondences/correspondenceModel"/>
     </genClasses>
     <genClasses image="false" ecoreClass="correspondence.ecore#//Correspondence">
       <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference correspondence.ecore#//Correspondence/parent"/>
@@ -23,8 +21,6 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute correspondence.ecore#//Correspondence/aUuids"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute correspondence.ecore#//Correspondence/bUuids"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute correspondence.ecore#//Correspondence/tag"/>
-      <genOperations ecoreOperation="correspondence.ecore#//Correspondence/getAs"/>
-      <genOperations ecoreOperation="correspondence.ecore#//Correspondence/getBs"/>
     </genClasses>
     <genClasses ecoreClass="correspondence.ecore#//ManualCorrespondence"/>
   </genPackages>

--- a/bundles/framework/tools.vitruv.framework.correspondence/metamodel/correspondence.genmodel
+++ b/bundles/framework/tools.vitruv.framework.correspondence/metamodel/correspondence.genmodel
@@ -8,7 +8,7 @@
   <foreignModel>correspondence.ecore</foreignModel>
   <genPackages prefix="Correspondence" basePackage="tools.vitruv.framework" disposableProviderFactory="true"
       ecorePackage="correspondence.ecore#/">
-    <genDataTypes ecoreDataType="correspondence.ecore#//CorrespondenceModel"/>
+    <genDataTypes ecoreDataType="correspondence.ecore#//GenericCorrespondenceModel"/>
     <genDataTypes ecoreDataType="correspondence.ecore#//Tuid"/>
     <genClasses ecoreClass="correspondence.ecore#//Correspondences">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference correspondence.ecore#//Correspondences/correspondences"/>
@@ -22,13 +22,9 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute correspondence.ecore#//Correspondence/bTuids"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute correspondence.ecore#//Correspondence/aUuids"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute correspondence.ecore#//Correspondence/bUuids"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute correspondence.ecore#//Correspondence/tag"/>
       <genOperations ecoreOperation="correspondence.ecore#//Correspondence/getAs"/>
       <genOperations ecoreOperation="correspondence.ecore#//Correspondence/getBs"/>
-      <genOperations ecoreOperation="correspondence.ecore#//Correspondence/getElementATuid"/>
-      <genOperations ecoreOperation="correspondence.ecore#//Correspondence/getElementBTuid"/>
-      <genOperations ecoreOperation="correspondence.ecore#//Correspondence/getElementsForMetamodel">
-        <genParameters ecoreParameter="correspondence.ecore#//Correspondence/getElementsForMetamodel/metamodelNamespaceUri"/>
-      </genOperations>
     </genClasses>
     <genClasses ecoreClass="correspondence.ecore#//ManualCorrespondence"/>
   </genPackages>

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/Correspondence.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/Correspondence.java
@@ -186,20 +186,4 @@ public interface Correspondence extends EObject {
 	 */
 	void setTag(String value);
 
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @model kind="operation"
-	 * @generated
-	 */
-	EList<EObject> getAs();
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @model kind="operation"
-	 * @generated
-	 */
-	EList<EObject> getBs();
-
 } // Correspondence

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/CorrespondencePackage.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/CorrespondencePackage.java
@@ -341,14 +341,14 @@ public interface CorrespondencePackage extends EPackage {
 	int MANUAL_CORRESPONDENCE_OPERATION_COUNT = CORRESPONDENCE_OPERATION_COUNT + 0;
 
 	/**
-	 * The meta object id for the '<em>Model</em>' data type.
+	 * The meta object id for the '<em>Generic Correspondence Model</em>' data type.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see tools.vitruv.framework.correspondence.CorrespondenceModel
-	 * @see tools.vitruv.framework.correspondence.impl.CorrespondencePackageImpl#getCorrespondenceModel()
+	 * @see tools.vitruv.framework.correspondence.GenericCorrespondenceModel
+	 * @see tools.vitruv.framework.correspondence.impl.CorrespondencePackageImpl#getGenericCorrespondenceModel()
 	 * @generated
 	 */
-	int CORRESPONDENCE_MODEL = 3;
+	int GENERIC_CORRESPONDENCE_MODEL = 3;
 
 	/**
 	 * The meta object id for the '<em>Tuid</em>' data type.
@@ -522,15 +522,15 @@ public interface CorrespondencePackage extends EPackage {
 	EClass getManualCorrespondence();
 
 	/**
-	 * Returns the meta object for data type '{@link tools.vitruv.framework.correspondence.CorrespondenceModel <em>Model</em>}'.
+	 * Returns the meta object for data type '{@link tools.vitruv.framework.correspondence.GenericCorrespondenceModel <em>Generic Correspondence Model</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for data type '<em>Model</em>'.
-	 * @see tools.vitruv.framework.correspondence.CorrespondenceModel
-	 * @model instanceClass="tools.vitruv.framework.correspondence.CorrespondenceModel" serializeable="false"
+	 * @return the meta object for data type '<em>Generic Correspondence Model</em>'.
+	 * @see tools.vitruv.framework.correspondence.GenericCorrespondenceModel
+	 * @model instanceClass="tools.vitruv.framework.correspondence.GenericCorrespondenceModel" serializeable="false"
 	 * @generated
 	 */
-	EDataType getCorrespondenceModel();
+	EDataType getGenericCorrespondenceModel();
 
 	/**
 	 * Returns the meta object for data type '{@link tools.vitruv.framework.tuid.Tuid <em>Tuid</em>}'.
@@ -693,14 +693,14 @@ public interface CorrespondencePackage extends EPackage {
 		EClass MANUAL_CORRESPONDENCE = eINSTANCE.getManualCorrespondence();
 
 		/**
-		 * The meta object literal for the '<em>Model</em>' data type.
+		 * The meta object literal for the '<em>Generic Correspondence Model</em>' data type.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * @see tools.vitruv.framework.correspondence.CorrespondenceModel
-		 * @see tools.vitruv.framework.correspondence.impl.CorrespondencePackageImpl#getCorrespondenceModel()
+		 * @see tools.vitruv.framework.correspondence.GenericCorrespondenceModel
+		 * @see tools.vitruv.framework.correspondence.impl.CorrespondencePackageImpl#getGenericCorrespondenceModel()
 		 * @generated
 		 */
-		EDataType CORRESPONDENCE_MODEL = eINSTANCE.getCorrespondenceModel();
+		EDataType GENERIC_CORRESPONDENCE_MODEL = eINSTANCE.getGenericCorrespondenceModel();
 
 		/**
 		 * The meta object literal for the '<em>Tuid</em>' data type.

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/CorrespondencePackage.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/CorrespondencePackage.java
@@ -5,7 +5,6 @@ package tools.vitruv.framework.correspondence;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EDataType;
-import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 
@@ -78,22 +77,13 @@ public interface CorrespondencePackage extends EPackage {
 	int CORRESPONDENCES__CORRESPONDENCES = 0;
 
 	/**
-	 * The feature id for the '<em><b>Correspondence Model</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int CORRESPONDENCES__CORRESPONDENCE_MODEL = 1;
-
-	/**
 	 * The number of structural features of the '<em>Correspondences</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int CORRESPONDENCES_FEATURE_COUNT = 2;
+	int CORRESPONDENCES_FEATURE_COUNT = 1;
 
 	/**
 	 * The number of operations of the '<em>Correspondences</em>' class.
@@ -196,31 +186,13 @@ public interface CorrespondencePackage extends EPackage {
 	int CORRESPONDENCE_FEATURE_COUNT = 8;
 
 	/**
-	 * The operation id for the '<em>Get As</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int CORRESPONDENCE___GET_AS = 0;
-
-	/**
-	 * The operation id for the '<em>Get Bs</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int CORRESPONDENCE___GET_BS = 1;
-
-	/**
 	 * The number of operations of the '<em>Correspondence</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int CORRESPONDENCE_OPERATION_COUNT = 2;
+	int CORRESPONDENCE_OPERATION_COUNT = 0;
 
 	/**
 	 * The meta object id for the '{@link tools.vitruv.framework.correspondence.impl.ManualCorrespondenceImpl <em>Manual Correspondence</em>}' class.
@@ -314,24 +286,6 @@ public interface CorrespondencePackage extends EPackage {
 	int MANUAL_CORRESPONDENCE_FEATURE_COUNT = CORRESPONDENCE_FEATURE_COUNT + 0;
 
 	/**
-	 * The operation id for the '<em>Get As</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int MANUAL_CORRESPONDENCE___GET_AS = CORRESPONDENCE___GET_AS;
-
-	/**
-	 * The operation id for the '<em>Get Bs</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int MANUAL_CORRESPONDENCE___GET_BS = CORRESPONDENCE___GET_BS;
-
-	/**
 	 * The number of operations of the '<em>Manual Correspondence</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -341,16 +295,6 @@ public interface CorrespondencePackage extends EPackage {
 	int MANUAL_CORRESPONDENCE_OPERATION_COUNT = CORRESPONDENCE_OPERATION_COUNT + 0;
 
 	/**
-	 * The meta object id for the '<em>Generic Correspondence Model</em>' data type.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see tools.vitruv.framework.correspondence.GenericCorrespondenceModel
-	 * @see tools.vitruv.framework.correspondence.impl.CorrespondencePackageImpl#getGenericCorrespondenceModel()
-	 * @generated
-	 */
-	int GENERIC_CORRESPONDENCE_MODEL = 3;
-
-	/**
 	 * The meta object id for the '<em>Tuid</em>' data type.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -358,7 +302,7 @@ public interface CorrespondencePackage extends EPackage {
 	 * @see tools.vitruv.framework.correspondence.impl.CorrespondencePackageImpl#getTuid()
 	 * @generated
 	 */
-	int TUID = 4;
+	int TUID = 3;
 
 
 	/**
@@ -381,17 +325,6 @@ public interface CorrespondencePackage extends EPackage {
 	 * @generated
 	 */
 	EReference getCorrespondences_Correspondences();
-
-	/**
-	 * Returns the meta object for the attribute '{@link tools.vitruv.framework.correspondence.Correspondences#getCorrespondenceModel <em>Correspondence Model</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the attribute '<em>Correspondence Model</em>'.
-	 * @see tools.vitruv.framework.correspondence.Correspondences#getCorrespondenceModel()
-	 * @see #getCorrespondences()
-	 * @generated
-	 */
-	EAttribute getCorrespondences_CorrespondenceModel();
 
 	/**
 	 * Returns the meta object for class '{@link tools.vitruv.framework.correspondence.Correspondence <em>Correspondence</em>}'.
@@ -492,26 +425,6 @@ public interface CorrespondencePackage extends EPackage {
 	EAttribute getCorrespondence_Tag();
 
 	/**
-	 * Returns the meta object for the '{@link tools.vitruv.framework.correspondence.Correspondence#getAs() <em>Get As</em>}' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the '<em>Get As</em>' operation.
-	 * @see tools.vitruv.framework.correspondence.Correspondence#getAs()
-	 * @generated
-	 */
-	EOperation getCorrespondence__GetAs();
-
-	/**
-	 * Returns the meta object for the '{@link tools.vitruv.framework.correspondence.Correspondence#getBs() <em>Get Bs</em>}' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the '<em>Get Bs</em>' operation.
-	 * @see tools.vitruv.framework.correspondence.Correspondence#getBs()
-	 * @generated
-	 */
-	EOperation getCorrespondence__GetBs();
-
-	/**
 	 * Returns the meta object for class '{@link tools.vitruv.framework.correspondence.ManualCorrespondence <em>Manual Correspondence</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -520,17 +433,6 @@ public interface CorrespondencePackage extends EPackage {
 	 * @generated
 	 */
 	EClass getManualCorrespondence();
-
-	/**
-	 * Returns the meta object for data type '{@link tools.vitruv.framework.correspondence.GenericCorrespondenceModel <em>Generic Correspondence Model</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for data type '<em>Generic Correspondence Model</em>'.
-	 * @see tools.vitruv.framework.correspondence.GenericCorrespondenceModel
-	 * @model instanceClass="tools.vitruv.framework.correspondence.GenericCorrespondenceModel" serializeable="false"
-	 * @generated
-	 */
-	EDataType getGenericCorrespondenceModel();
 
 	/**
 	 * Returns the meta object for data type '{@link tools.vitruv.framework.tuid.Tuid <em>Tuid</em>}'.
@@ -583,14 +485,6 @@ public interface CorrespondencePackage extends EPackage {
 		 * @generated
 		 */
 		EReference CORRESPONDENCES__CORRESPONDENCES = eINSTANCE.getCorrespondences_Correspondences();
-
-		/**
-		 * The meta object literal for the '<em><b>Correspondence Model</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
-		 * @generated
-		 */
-		EAttribute CORRESPONDENCES__CORRESPONDENCE_MODEL = eINSTANCE.getCorrespondences_CorrespondenceModel();
 
 		/**
 		 * The meta object literal for the '{@link tools.vitruv.framework.correspondence.impl.CorrespondenceImpl <em>Correspondence</em>}' class.
@@ -667,22 +561,6 @@ public interface CorrespondencePackage extends EPackage {
 		EAttribute CORRESPONDENCE__TAG = eINSTANCE.getCorrespondence_Tag();
 
 		/**
-		 * The meta object literal for the '<em><b>Get As</b></em>' operation.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
-		 * @generated
-		 */
-		EOperation CORRESPONDENCE___GET_AS = eINSTANCE.getCorrespondence__GetAs();
-
-		/**
-		 * The meta object literal for the '<em><b>Get Bs</b></em>' operation.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
-		 * @generated
-		 */
-		EOperation CORRESPONDENCE___GET_BS = eINSTANCE.getCorrespondence__GetBs();
-
-		/**
 		 * The meta object literal for the '{@link tools.vitruv.framework.correspondence.impl.ManualCorrespondenceImpl <em>Manual Correspondence</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
@@ -691,16 +569,6 @@ public interface CorrespondencePackage extends EPackage {
 		 * @generated
 		 */
 		EClass MANUAL_CORRESPONDENCE = eINSTANCE.getManualCorrespondence();
-
-		/**
-		 * The meta object literal for the '<em>Generic Correspondence Model</em>' data type.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
-		 * @see tools.vitruv.framework.correspondence.GenericCorrespondenceModel
-		 * @see tools.vitruv.framework.correspondence.impl.CorrespondencePackageImpl#getGenericCorrespondenceModel()
-		 * @generated
-		 */
-		EDataType GENERIC_CORRESPONDENCE_MODEL = eINSTANCE.getGenericCorrespondenceModel();
 
 		/**
 		 * The meta object literal for the '<em>Tuid</em>' data type.

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/Correspondences.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/Correspondences.java
@@ -16,7 +16,6 @@ import org.eclipse.emf.ecore.EObject;
  * </p>
  * <ul>
  *   <li>{@link tools.vitruv.framework.correspondence.Correspondences#getCorrespondences <em>Correspondences</em>}</li>
- *   <li>{@link tools.vitruv.framework.correspondence.Correspondences#getCorrespondenceModel <em>Correspondence Model</em>}</li>
  * </ul>
  *
  * @see tools.vitruv.framework.correspondence.CorrespondencePackage#getCorrespondences()
@@ -41,31 +40,5 @@ public interface Correspondences extends EObject {
 	 * @generated
 	 */
 	EList<Correspondence> getCorrespondences();
-
-	/**
-	 * Returns the value of the '<em><b>Correspondence Model</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <p>
-	 * If the meaning of the '<em>Correspondence Model</em>' attribute isn't clear,
-	 * there really should be more of a description here...
-	 * </p>
-	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Correspondence Model</em>' attribute.
-	 * @see #setCorrespondenceModel(GenericCorrespondenceModel)
-	 * @see tools.vitruv.framework.correspondence.CorrespondencePackage#getCorrespondences_CorrespondenceModel()
-	 * @model dataType="tools.vitruv.framework.correspondence.GenericCorrespondenceModel" required="true" transient="true"
-	 * @generated
-	 */
-	GenericCorrespondenceModel getCorrespondenceModel();
-
-	/**
-	 * Sets the value of the '{@link tools.vitruv.framework.correspondence.Correspondences#getCorrespondenceModel <em>Correspondence Model</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Correspondence Model</em>' attribute.
-	 * @see #getCorrespondenceModel()
-	 * @generated
-	 */
-	void setCorrespondenceModel(GenericCorrespondenceModel value);
 
 } // Correspondences

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/Correspondences.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/Correspondences.java
@@ -2,8 +2,6 @@
  */
 package tools.vitruv.framework.correspondence;
 
-import tools.vitruv.framework.correspondence.CorrespondenceModel;
-
 import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.emf.ecore.EObject;
@@ -53,12 +51,12 @@ public interface Correspondences extends EObject {
 	 * </p>
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Correspondence Model</em>' attribute.
-	 * @see #setCorrespondenceModel(CorrespondenceModel)
+	 * @see #setCorrespondenceModel(GenericCorrespondenceModel)
 	 * @see tools.vitruv.framework.correspondence.CorrespondencePackage#getCorrespondences_CorrespondenceModel()
-	 * @model dataType="tools.vitruv.framework.correspondence.CorrespondenceModel" required="true" transient="true"
+	 * @model dataType="tools.vitruv.framework.correspondence.GenericCorrespondenceModel" required="true" transient="true"
 	 * @generated
 	 */
-	CorrespondenceModel getCorrespondenceModel();
+	GenericCorrespondenceModel getCorrespondenceModel();
 
 	/**
 	 * Sets the value of the '{@link tools.vitruv.framework.correspondence.Correspondences#getCorrespondenceModel <em>Correspondence Model</em>}' attribute.
@@ -68,6 +66,6 @@ public interface Correspondences extends EObject {
 	 * @see #getCorrespondenceModel()
 	 * @generated
 	 */
-	void setCorrespondenceModel(CorrespondenceModel value);
+	void setCorrespondenceModel(GenericCorrespondenceModel value);
 
 } // Correspondences

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondenceImpl.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondenceImpl.java
@@ -2,17 +2,13 @@
  */
 package tools.vitruv.framework.correspondence.impl;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
-import java.util.List;
 
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
-import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
@@ -289,54 +285,6 @@ public abstract class CorrespondenceImpl extends MinimalEObjectImpl.Container im
 	}
 
 	/**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated NOT
-     */
-    @Override
-    public EList<EObject> getAs() {
-    	if (getATuids().isEmpty()) {
-    		return resolveEObjectsFromUuids(getAUuids());
-    	} else {
-    		return resolveEObjectsFromTuids(getATuids());
-    	}
-    }
-
-    /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated NOT
-     */
-    @Override
-    public EList<EObject> getBs() {
-    	if (getBTuids().isEmpty()) {
-    		return resolveEObjectsFromUuids(getBUuids());
-    	} else {
-    		return resolveEObjectsFromTuids(getBTuids());
-    	}
-    }
-
-    /**
-     * @generated NOT
-     */
-    private EList<EObject> resolveEObjectsFromTuids(List<Tuid> tuids) {
-    	EList<EObject> result = new BasicEList<EObject>();
-    	for (Tuid tuid : tuids) {
-    		result.add(getParent().getCorrespondenceModel().resolveEObjectFromTuid(tuid));
-    	}
-    	return result;
-    }
-    
-    /**
-     * @generated NOT
-     */
-    private EList<EObject> resolveEObjectsFromUuids(List<String> uuids) {
-    	EList<EObject> result = new BasicEList<EObject>();
-   		result.addAll(getParent().getCorrespondenceModel().resolveEObjectsFromUuids(uuids));
-    	return result;
-    }
-    
-	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -522,22 +470,6 @@ public abstract class CorrespondenceImpl extends MinimalEObjectImpl.Container im
 				return TAG_EDEFAULT == null ? tag != null : !TAG_EDEFAULT.equals(tag);
 		}
 		return super.eIsSet(featureID);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public Object eInvoke(int operationID, EList<?> arguments) throws InvocationTargetException {
-		switch (operationID) {
-			case CorrespondencePackage.CORRESPONDENCE___GET_AS:
-				return getAs();
-			case CorrespondencePackage.CORRESPONDENCE___GET_BS:
-				return getBs();
-		}
-		return super.eInvoke(operationID, arguments);
 	}
 
 	/**

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondenceImpl.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondenceImpl.java
@@ -549,7 +549,7 @@ public abstract class CorrespondenceImpl extends MinimalEObjectImpl.Container im
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuffer result = new StringBuffer(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (aTuids: ");
 		result.append(aTuids);
 		result.append(", bTuids: ");

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondencePackageImpl.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondencePackageImpl.java
@@ -13,9 +13,9 @@ import org.eclipse.emf.ecore.impl.EPackageImpl;
 
 import tools.vitruv.framework.correspondence.Correspondence;
 import tools.vitruv.framework.correspondence.CorrespondenceFactory;
-import tools.vitruv.framework.correspondence.CorrespondenceModel;
 import tools.vitruv.framework.correspondence.CorrespondencePackage;
 import tools.vitruv.framework.correspondence.Correspondences;
+import tools.vitruv.framework.correspondence.GenericCorrespondenceModel;
 import tools.vitruv.framework.correspondence.ManualCorrespondence;
 
 import tools.vitruv.framework.tuid.Tuid;
@@ -55,7 +55,7 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	private EDataType correspondenceModelEDataType = null;
+	private EDataType genericCorrespondenceModelEDataType = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -92,7 +92,7 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 
 	/**
 	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-	 * 
+	 *
 	 * <p>This method is used to initialize {@link CorrespondencePackage#eINSTANCE} when that field is accessed.
 	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
 	 * <!-- begin-user-doc -->
@@ -106,7 +106,8 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 		if (isInited) return (CorrespondencePackage)EPackage.Registry.INSTANCE.getEPackage(CorrespondencePackage.eNS_URI);
 
 		// Obtain or create and register package
-		CorrespondencePackageImpl theCorrespondencePackage = (CorrespondencePackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof CorrespondencePackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new CorrespondencePackageImpl());
+		Object registeredCorrespondencePackage = EPackage.Registry.INSTANCE.get(eNS_URI);
+		CorrespondencePackageImpl theCorrespondencePackage = registeredCorrespondencePackage instanceof CorrespondencePackageImpl ? (CorrespondencePackageImpl)registeredCorrespondencePackage : new CorrespondencePackageImpl();
 
 		isInited = true;
 
@@ -122,7 +123,6 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 		// Mark meta-data to indicate it can't be changed
 		theCorrespondencePackage.freeze();
 
-  
 		// Update the registry and return the package
 		EPackage.Registry.INSTANCE.put(CorrespondencePackage.eNS_URI, theCorrespondencePackage);
 		return theCorrespondencePackage;
@@ -268,8 +268,8 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EDataType getCorrespondenceModel() {
-		return correspondenceModelEDataType;
+	public EDataType getGenericCorrespondenceModel() {
+		return genericCorrespondenceModelEDataType;
 	}
 
 	/**
@@ -328,7 +328,7 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 		manualCorrespondenceEClass = createEClass(MANUAL_CORRESPONDENCE);
 
 		// Create data types
-		correspondenceModelEDataType = createEDataType(CORRESPONDENCE_MODEL);
+		genericCorrespondenceModelEDataType = createEDataType(GENERIC_CORRESPONDENCE_MODEL);
 		tuidEDataType = createEDataType(TUID);
 	}
 
@@ -368,7 +368,7 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 		// Initialize classes, features, and operations; add parameters
 		initEClass(correspondencesEClass, Correspondences.class, "Correspondences", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getCorrespondences_Correspondences(), this.getCorrespondence(), this.getCorrespondence_Parent(), "correspondences", null, 0, -1, Correspondences.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEAttribute(getCorrespondences_CorrespondenceModel(), this.getCorrespondenceModel(), "correspondenceModel", null, 1, 1, Correspondences.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getCorrespondences_CorrespondenceModel(), this.getGenericCorrespondenceModel(), "correspondenceModel", null, 1, 1, Correspondences.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(correspondenceEClass, Correspondence.class, "Correspondence", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getCorrespondence_Parent(), this.getCorrespondences(), this.getCorrespondences_Correspondences(), "parent", null, 1, 1, Correspondence.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -387,7 +387,7 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 		initEClass(manualCorrespondenceEClass, ManualCorrespondence.class, "ManualCorrespondence", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
 		// Initialize data types
-		initEDataType(correspondenceModelEDataType, CorrespondenceModel.class, "CorrespondenceModel", !IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS);
+		initEDataType(genericCorrespondenceModelEDataType, GenericCorrespondenceModel.class, "GenericCorrespondenceModel", !IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS);
 		initEDataType(tuidEDataType, Tuid.class, "Tuid", IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS);
 
 		// Create resource

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondencePackageImpl.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondencePackageImpl.java
@@ -5,7 +5,6 @@ package tools.vitruv.framework.correspondence.impl;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EDataType;
-import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 
@@ -15,7 +14,6 @@ import tools.vitruv.framework.correspondence.Correspondence;
 import tools.vitruv.framework.correspondence.CorrespondenceFactory;
 import tools.vitruv.framework.correspondence.CorrespondencePackage;
 import tools.vitruv.framework.correspondence.Correspondences;
-import tools.vitruv.framework.correspondence.GenericCorrespondenceModel;
 import tools.vitruv.framework.correspondence.ManualCorrespondence;
 
 import tools.vitruv.framework.tuid.Tuid;
@@ -49,13 +47,6 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 	 * @generated
 	 */
 	private EClass manualCorrespondenceEClass = null;
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	private EDataType genericCorrespondenceModelEDataType = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -151,15 +142,6 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getCorrespondences_CorrespondenceModel() {
-		return (EAttribute)correspondencesEClass.getEStructuralFeatures().get(1);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
 	public EClass getCorrespondence() {
 		return correspondenceEClass;
 	}
@@ -241,35 +223,8 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EOperation getCorrespondence__GetAs() {
-		return correspondenceEClass.getEOperations().get(0);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EOperation getCorrespondence__GetBs() {
-		return correspondenceEClass.getEOperations().get(1);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
 	public EClass getManualCorrespondence() {
 		return manualCorrespondenceEClass;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EDataType getGenericCorrespondenceModel() {
-		return genericCorrespondenceModelEDataType;
 	}
 
 	/**
@@ -311,7 +266,6 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 		// Create classes and their features
 		correspondencesEClass = createEClass(CORRESPONDENCES);
 		createEReference(correspondencesEClass, CORRESPONDENCES__CORRESPONDENCES);
-		createEAttribute(correspondencesEClass, CORRESPONDENCES__CORRESPONDENCE_MODEL);
 
 		correspondenceEClass = createEClass(CORRESPONDENCE);
 		createEReference(correspondenceEClass, CORRESPONDENCE__PARENT);
@@ -322,13 +276,10 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 		createEAttribute(correspondenceEClass, CORRESPONDENCE__AUUIDS);
 		createEAttribute(correspondenceEClass, CORRESPONDENCE__BUUIDS);
 		createEAttribute(correspondenceEClass, CORRESPONDENCE__TAG);
-		createEOperation(correspondenceEClass, CORRESPONDENCE___GET_AS);
-		createEOperation(correspondenceEClass, CORRESPONDENCE___GET_BS);
 
 		manualCorrespondenceEClass = createEClass(MANUAL_CORRESPONDENCE);
 
 		// Create data types
-		genericCorrespondenceModelEDataType = createEDataType(GENERIC_CORRESPONDENCE_MODEL);
 		tuidEDataType = createEDataType(TUID);
 	}
 
@@ -368,7 +319,6 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 		// Initialize classes, features, and operations; add parameters
 		initEClass(correspondencesEClass, Correspondences.class, "Correspondences", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getCorrespondences_Correspondences(), this.getCorrespondence(), this.getCorrespondence_Parent(), "correspondences", null, 0, -1, Correspondences.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEAttribute(getCorrespondences_CorrespondenceModel(), this.getGenericCorrespondenceModel(), "correspondenceModel", null, 1, 1, Correspondences.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(correspondenceEClass, Correspondence.class, "Correspondence", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getCorrespondence_Parent(), this.getCorrespondences(), this.getCorrespondences_Correspondences(), "parent", null, 1, 1, Correspondence.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -380,14 +330,9 @@ public class CorrespondencePackageImpl extends EPackageImpl implements Correspon
 		initEAttribute(getCorrespondence_BUuids(), theUuidPackage.getUuid(), "bUuids", null, 0, -1, Correspondence.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getCorrespondence_Tag(), ecorePackage.getEString(), "tag", null, 0, 1, Correspondence.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEOperation(getCorrespondence__GetAs(), ecorePackage.getEObject(), "getAs", 0, -1, IS_UNIQUE, IS_ORDERED);
-
-		initEOperation(getCorrespondence__GetBs(), ecorePackage.getEObject(), "getBs", 0, -1, IS_UNIQUE, IS_ORDERED);
-
 		initEClass(manualCorrespondenceEClass, ManualCorrespondence.class, "ManualCorrespondence", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
 		// Initialize data types
-		initEDataType(genericCorrespondenceModelEDataType, GenericCorrespondenceModel.class, "GenericCorrespondenceModel", !IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS);
 		initEDataType(tuidEDataType, Tuid.class, "Tuid", IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS);
 
 		// Create resource

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondencesImpl.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondencesImpl.java
@@ -5,19 +5,13 @@ package tools.vitruv.framework.correspondence.impl;
 import tools.vitruv.framework.correspondence.Correspondence;
 import tools.vitruv.framework.correspondence.CorrespondencePackage;
 import tools.vitruv.framework.correspondence.Correspondences;
-
-import tools.vitruv.framework.correspondence.GenericCorrespondenceModel;
 import java.util.Collection;
-
-import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
 
 import org.eclipse.emf.common.util.EList;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
-
-import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentWithInverseEList;
 import org.eclipse.emf.ecore.util.InternalEList;
@@ -31,7 +25,6 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * </p>
  * <ul>
  *   <li>{@link tools.vitruv.framework.correspondence.impl.CorrespondencesImpl#getCorrespondences <em>Correspondences</em>}</li>
- *   <li>{@link tools.vitruv.framework.correspondence.impl.CorrespondencesImpl#getCorrespondenceModel <em>Correspondence Model</em>}</li>
  * </ul>
  *
  * @generated
@@ -46,26 +39,6 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 	 * @ordered
 	 */
 	protected EList<Correspondence> correspondences;
-
-	/**
-	 * The default value of the '{@link #getCorrespondenceModel() <em>Correspondence Model</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getCorrespondenceModel()
-	 * @generated
-	 * @ordered
-	 */
-	protected static final GenericCorrespondenceModel CORRESPONDENCE_MODEL_EDEFAULT = null;
-
-	/**
-	 * The cached value of the '{@link #getCorrespondenceModel() <em>Correspondence Model</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getCorrespondenceModel()
-	 * @generated
-	 * @ordered
-	 */
-	protected GenericCorrespondenceModel correspondenceModel = CORRESPONDENCE_MODEL_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -96,27 +69,6 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 			correspondences = new EObjectContainmentWithInverseEList<Correspondence>(Correspondence.class, this, CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCES, CorrespondencePackage.CORRESPONDENCE__PARENT);
 		}
 		return correspondences;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public GenericCorrespondenceModel getCorrespondenceModel() {
-		return correspondenceModel;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public void setCorrespondenceModel(GenericCorrespondenceModel newCorrespondenceModel) {
-		GenericCorrespondenceModel oldCorrespondenceModel = correspondenceModel;
-		correspondenceModel = newCorrespondenceModel;
-		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCE_MODEL, oldCorrespondenceModel, correspondenceModel));
 	}
 
 	/**
@@ -158,8 +110,6 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 		switch (featureID) {
 			case CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCES:
 				return getCorrespondences();
-			case CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCE_MODEL:
-				return getCorrespondenceModel();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -177,9 +127,6 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 				getCorrespondences().clear();
 				getCorrespondences().addAll((Collection<? extends Correspondence>)newValue);
 				return;
-			case CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCE_MODEL:
-				setCorrespondenceModel((GenericCorrespondenceModel)newValue);
-				return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -195,9 +142,6 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 			case CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCES:
 				getCorrespondences().clear();
 				return;
-			case CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCE_MODEL:
-				setCorrespondenceModel(CORRESPONDENCE_MODEL_EDEFAULT);
-				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -212,26 +156,8 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 		switch (featureID) {
 			case CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCES:
 				return correspondences != null && !correspondences.isEmpty();
-			case CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCE_MODEL:
-				return CORRESPONDENCE_MODEL_EDEFAULT == null ? correspondenceModel != null : !CORRESPONDENCE_MODEL_EDEFAULT.equals(correspondenceModel);
 		}
 		return super.eIsSet(featureID);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	@Override
-	public String toString() {
-		if (eIsProxy()) return super.toString();
-
-		StringBuilder result = new StringBuilder(super.toString());
-		result.append(" (correspondenceModel: ");
-		result.append(correspondenceModel);
-		result.append(')');
-		return result.toString();
 	}
 
 } //CorrespondencesImpl

--- a/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondencesImpl.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src-gen/tools/vitruv/framework/correspondence/impl/CorrespondencesImpl.java
@@ -6,8 +6,7 @@ import tools.vitruv.framework.correspondence.Correspondence;
 import tools.vitruv.framework.correspondence.CorrespondencePackage;
 import tools.vitruv.framework.correspondence.Correspondences;
 
-import tools.vitruv.framework.correspondence.CorrespondenceModel;
-
+import tools.vitruv.framework.correspondence.GenericCorrespondenceModel;
 import java.util.Collection;
 
 import org.eclipse.emf.common.notify.Notification;
@@ -56,7 +55,7 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 	 * @generated
 	 * @ordered
 	 */
-	protected static final CorrespondenceModel CORRESPONDENCE_MODEL_EDEFAULT = null;
+	protected static final GenericCorrespondenceModel CORRESPONDENCE_MODEL_EDEFAULT = null;
 
 	/**
 	 * The cached value of the '{@link #getCorrespondenceModel() <em>Correspondence Model</em>}' attribute.
@@ -66,7 +65,7 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 	 * @generated
 	 * @ordered
 	 */
-	protected CorrespondenceModel correspondenceModel = CORRESPONDENCE_MODEL_EDEFAULT;
+	protected GenericCorrespondenceModel correspondenceModel = CORRESPONDENCE_MODEL_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -104,7 +103,7 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public CorrespondenceModel getCorrespondenceModel() {
+	public GenericCorrespondenceModel getCorrespondenceModel() {
 		return correspondenceModel;
 	}
 
@@ -113,8 +112,8 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public void setCorrespondenceModel(CorrespondenceModel newCorrespondenceModel) {
-		CorrespondenceModel oldCorrespondenceModel = correspondenceModel;
+	public void setCorrespondenceModel(GenericCorrespondenceModel newCorrespondenceModel) {
+		GenericCorrespondenceModel oldCorrespondenceModel = correspondenceModel;
 		correspondenceModel = newCorrespondenceModel;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCE_MODEL, oldCorrespondenceModel, correspondenceModel));
@@ -179,7 +178,7 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 				getCorrespondences().addAll((Collection<? extends Correspondence>)newValue);
 				return;
 			case CorrespondencePackage.CORRESPONDENCES__CORRESPONDENCE_MODEL:
-				setCorrespondenceModel((CorrespondenceModel)newValue);
+				setCorrespondenceModel((GenericCorrespondenceModel)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -228,7 +227,7 @@ public class CorrespondencesImpl extends MinimalEObjectImpl.Container implements
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuffer result = new StringBuffer(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (correspondenceModel: ");
 		result.append(correspondenceModel);
 		result.append(')');

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModel.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModel.xtend
@@ -1,10 +1,6 @@
 package tools.vitruv.framework.correspondence
 
 import tools.vitruv.framework.correspondence.Correspondence
-import org.eclipse.emf.ecore.resource.Resource
 
-interface CorrespondenceModel extends GenericCorrespondenceModel<Correspondence> {
-	// TODO HK Remove and define by Model interface!
-	public def Resource getResource();
-	public def void saveModel();
+interface CorrespondenceModel extends CorrespondenceModelView<Correspondence> {
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelFactory.xtend
@@ -1,0 +1,28 @@
+package tools.vitruv.framework.correspondence
+
+import tools.vitruv.framework.tuid.TuidResolver
+import tools.vitruv.framework.uuid.UuidResolver
+import tools.vitruv.framework.util.command.VitruviusRecordingCommandExecutor
+import tools.vitruv.framework.domains.repository.VitruvDomainRepository
+import tools.vitruv.framework.util.datatypes.VURI
+import org.eclipse.emf.ecore.resource.Resource
+import tools.vitruv.framework.correspondence.impl.InternalCorrespondenceModelImpl
+
+public final class CorrespondenceModelFactory {
+	private static CorrespondenceModelFactory instance;
+	
+	private new() {	}
+	
+	public static def getInstance() {
+		if (instance === null) {
+			instance = new CorrespondenceModelFactory();
+		}
+		
+		return instance;
+	}
+	
+	public def createCorrespondenceModel(TuidResolver tuidResolver, UuidResolver uuidResolver, VitruviusRecordingCommandExecutor modelCommandExecutor,
+		VitruvDomainRepository domainRepository, VURI correspondencesVURI, Resource correspondencesResource) {
+		return new InternalCorrespondenceModelImpl(tuidResolver, uuidResolver, modelCommandExecutor, domainRepository, correspondencesVURI, correspondencesResource);
+	}
+}

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
@@ -9,6 +9,7 @@ import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 import tools.vitruv.framework.correspondence.GenericCorrespondenceModel
 import tools.vitruv.framework.correspondence.Correspondence
+import java.util.List
 
 class CorrespondenceModelUtil {
 	private new() {
@@ -40,7 +41,7 @@ class CorrespondenceModelUtil {
 	 * @param b
 	 * @return
 	 */
-	def public static Correspondence claimUniqueCorrespondence(CorrespondenceModel ci,
+	def public static Correspondence claimUniqueCorrespondence(CorrespondenceModelView<Correspondence> ci,
 		EObject eObject) {
 		return ci.getCorrespondences(eObject.toList).claimOne
 	}
@@ -53,7 +54,7 @@ class CorrespondenceModelUtil {
 	 *            the object for which correspondences are to be returned
 	 * @return the correspondences for the specified object
 	 */
-	def public static Set<Correspondence> claimCorrespondences(CorrespondenceModel ci,
+	def public static Set<Correspondence> claimCorrespondences(CorrespondenceModelView<?> ci,
 		EObject eObject) {
 		return ci.getCorrespondences(eObject.toList).claimNotEmpty as Set<Correspondence>
 	}
@@ -93,16 +94,16 @@ class CorrespondenceModelUtil {
 		GenericCorrespondenceModel<U> ci, Class<T> type) {
 		return ci.allCorrespondencesWithoutDependencies.map[it.^as + it.bs].flatten.filter(type).toSet
 	}
-
-	def public static <T extends Correspondence> Set<T> getCorrespondencesBetweenEObjects(GenericCorrespondenceModel<T> ci,
-		Set<EObject> aS, Set<EObject> bS) {
-		val correspondencesThatInvolveAs = ci.getCorrespondencesThatInvolveAtLeast(aS)
-		val atuids = aS.mapFixed[ci.calculateTuidFromEObject(it)]
-		val btuids = bS.mapFixed[ci.calculateTuidFromEObject(it)]
-		val correspondencesBetweenEObjects = correspondencesThatInvolveAs.filter [
-			(it.getATuids.containsAll(atuids) && it.getBTuids.containsAll(btuids)) ||
-				(it.getATuids.containsAll(btuids) && it.getBTuids.containsAll(atuids))
-		]
-		return correspondencesBetweenEObjects.toSet
+	
+	def claimUniqueCorrespondence(InternalCorrespondenceModel correspondenceModel, List<EObject> aEObjects, List<EObject> bEObjects) {
+		val correspondences = correspondenceModel.getCorrespondences(aEObjects, null)
+		for (Correspondence correspondence : correspondences) {
+			val correspondingBs = correspondence.bs
+			if (correspondingBs !== null && correspondingBs.equals(bEObjects)) {
+				return correspondence;
+			}
+		}
+		throw new RuntimeException("No correspondence for '" + aEObjects + "' and '" + bEObjects + "' was found!");
 	}
+
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
@@ -82,16 +82,4 @@ class CorrespondenceModelUtil {
 		return retSet
 	}
 
-	/**
-	 * Returns all eObjects that have some correspondence and are an instance of the given class.
-	 * 
-	 * @param type
-	 *            the class for which instances should be returned
-	 * @return a set containing all eObjects of the given type that have a correspondence
-	 */
-	def public static <T, U extends Correspondence> Set<T> getAllEObjectsOfTypeInCorrespondences(
-		GenericCorrespondenceModel<U> ci, Class<T> type) {
-		return ci.allCorrespondencesWithoutDependencies.map[it.^as + it.bs].flatten.filter(type).toSet
-	}
-	
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
@@ -9,7 +9,6 @@ import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 import tools.vitruv.framework.correspondence.GenericCorrespondenceModel
 import tools.vitruv.framework.correspondence.Correspondence
-import java.util.List
 
 class CorrespondenceModelUtil {
 	private new() {
@@ -95,15 +94,4 @@ class CorrespondenceModelUtil {
 		return ci.allCorrespondencesWithoutDependencies.map[it.^as + it.bs].flatten.filter(type).toSet
 	}
 	
-	def claimUniqueCorrespondence(InternalCorrespondenceModel correspondenceModel, List<EObject> aEObjects, List<EObject> bEObjects) {
-		val correspondences = correspondenceModel.getCorrespondences(aEObjects, null)
-		for (Correspondence correspondence : correspondences) {
-			val correspondingBs = correspondence.bs
-			if (correspondingBs !== null && correspondingBs.equals(bEObjects)) {
-				return correspondence;
-			}
-		}
-		throw new RuntimeException("No correspondence for '" + aEObjects + "' and '" + bEObjects + "' was found!");
-	}
-
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.java
@@ -1,0 +1,33 @@
+package tools.vitruv.framework.correspondence;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.emf.ecore.EObject;
+
+public interface CorrespondenceModelView<T extends Correspondence> extends GenericCorrespondenceModel<T> {
+	/**
+     * Returns all correspondences for the specified object and an empty set if the object has no
+     * correspondences. Should never return {@link null}.
+     *
+     * @param eObjects
+     * @return all correspondences for the specified object and an empty set if the object has no
+     *         correspondences.
+     */
+
+    public Set<T> getCorrespondences(List<EObject> eObjects);
+    
+    /**
+     * Returns all correspondences for the specified object having the given tag, and an empty set 
+     * if the object has no correspondences. Should never return {@link null}.
+     *
+     * @param eObjects
+     * @param tag the tag to filter correspondences for
+     * @return all correspondences for the specified object and an empty set if the object has no
+     *         correspondences.
+     */
+
+    public Set<T> getCorrespondences(List<EObject> eObjects, String tag);
+    
+    public T claimUniqueCorrespondence(final List<EObject> aEObjects, final List<EObject> bEObjects);
+}

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.java
@@ -32,4 +32,13 @@ public interface CorrespondenceModelView<T extends Correspondence> extends Gener
     public T claimUniqueCorrespondence(final List<EObject> aEObjects, final List<EObject> bEObjects);
     
     public void removeCorrespondencesBetween(List<EObject> aEObjects, List<EObject> bEObjects, String tag);
+    
+	/**
+	 * Returns all eObjects that have some correspondence and are an instance of the given class.
+	 * 
+	 * @param type
+	 *            the class for which instances should be returned
+	 * @return a set containing all eObjects of the given type that have a correspondence
+	 */
+    public <E> Set<E> getAllEObjectsOfTypeInCorrespondences(Class<E> type);
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.java
@@ -30,4 +30,6 @@ public interface CorrespondenceModelView<T extends Correspondence> extends Gener
     public Set<T> getCorrespondences(List<EObject> eObjects, String tag);
     
     public T claimUniqueCorrespondence(final List<EObject> aEObjects, final List<EObject> bEObjects);
+    
+    public void removeCorrespondencesBetween(List<EObject> aEObjects, List<EObject> bEObjects, String tag);
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceUtil.xtend
@@ -1,0 +1,37 @@
+package tools.vitruv.framework.correspondence
+
+import java.util.List
+import tools.vitruv.framework.tuid.Tuid
+
+class CorrespondenceUtil {
+	static def List<Tuid> getCorrespondingTuids(Correspondence correspondence, List<Tuid> tuids) {
+		var List<Tuid> aTuids = correspondence.getATuids()
+		var List<Tuid> bTuids = correspondence.getBTuids()
+		if (aTuids === null || bTuids === null || aTuids.size == 0 || bTuids.size == 0) {
+			throw new IllegalStateException(
+				'''The correspondence '«»«correspondence»' links to an empty Tuid '«»«aTuids»' or '«»«bTuids»'!'''.
+					toString)
+		}
+		if (aTuids.equals(tuids)) {
+			return bTuids
+		} else {
+			return aTuids
+		}
+	}
+	
+	static def getCorrespondingUuids(Correspondence correspondence, List<String> uuids) {
+		var List<String> aUuids = correspondence.getAUuids()
+		var List<String> bUuids = correspondence.getBUuids()
+		if (aUuids === null || bUuids === null || aUuids.size == 0 || bUuids.size == 0) {
+			throw new IllegalStateException(
+				'''The correspondence '«»«correspondence»' links to an empty Uuid '«»«aUuids»' or '«»«bUuids»'!'''.
+					toString)
+		}
+		if (aUuids.equals(uuids)) {
+			return bUuids;
+		} else {
+			return aUuids
+		}
+	}
+	
+}

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceUtil.xtend
@@ -34,4 +34,7 @@ class CorrespondenceUtil {
 		}
 	}
 	
+	static def isUuidBased(Correspondence correspondence) {
+		return !correspondence.AUuids.empty && !correspondence.BUuids.empty
+	}
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/GenericCorrespondenceModel.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/GenericCorrespondenceModel.java
@@ -42,17 +42,6 @@ public interface GenericCorrespondenceModel<T extends Correspondence> extends UR
     public boolean hasCorrespondences();
 
     /**
-     * Returns all correspondences for the specified object and an empty set if the object has no
-     * correspondences. Should never return {@link null}.
-     *
-     * @param eObjects
-     * @return all correspondences for the specified object and an empty set if the object has no
-     *         correspondences.
-     */
-
-    public Set<T> getCorrespondences(List<EObject> eObjects);
-
-    /**
      * Returns all correspondences for the object with the specified tuid and an empty set if the
      * object has no correspondences. Should never return {@link null}.
      *
@@ -79,18 +68,6 @@ public interface GenericCorrespondenceModel<T extends Correspondence> extends UR
      */
     public Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects, String tag);
     
-    /**
-     * Returns the elements corresponding to the given one, if the correspondence is of the given type and contains the given tag.
-     * 
-     * @param correspondenceType - the type of correspondence to filter
-     * @param eObjects - the objects to get the corresponding ones for
-     * @param tag - the tag to filter correspondences for. If the tag is <code>null</code>, all correspondences will be returned
-     * @return the elements corresponding to the given ones
-     */
-    public Set<List<EObject>> getCorrespondingEObjects(Class<? extends Correspondence> correspondenceType, List<EObject> eObjects, String tag);
-
-    public T claimUniqueCorrespondence(final List<EObject> aEObjects, final List<EObject> bEObjects);
-
     public Set<T> getCorrespondencesThatInvolveAtLeast(Set<EObject> eObjects);
     
     // renamed from addSameTypeCorrespondence
@@ -166,7 +143,7 @@ public interface GenericCorrespondenceModel<T extends Correspondence> extends UR
      * @return the restricted view on the {@link CorrespondenceModel}
      * @author Heiko Klare
      */
-    public <U extends Correspondence> GenericCorrespondenceModel<U> getView(Class<U> correspondenceType);
+    public <U extends Correspondence> CorrespondenceModelView<U> getView(Class<U> correspondenceType);
 
     /**
      * Creates a editable view on the {@link CorrespondenceModel} restricted to the specified
@@ -178,7 +155,9 @@ public interface GenericCorrespondenceModel<T extends Correspondence> extends UR
      * @param correspondenceCreator
      * @return the restricted editable view on the {@link CorrespondenceModel}
      */
-    public <U extends Correspondence> GenericCorrespondenceModel<U> getEditableView(Class<U> correspondenceType,
+    public <U extends Correspondence> CorrespondenceModelView<U> getEditableView(Class<U> correspondenceType,
             Supplier<U> correspondenceCreator);
+    
+    public CorrespondenceModel getGenericView();
 
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/InternalCorrespondenceModel.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/InternalCorrespondenceModel.java
@@ -21,4 +21,6 @@ public interface InternalCorrespondenceModel extends GenericCorrespondenceModel<
     public Set<List<EObject>> getCorrespondingEObjects(Class<? extends Correspondence> correspondenceType, List<EObject> eObjects, String tag);
 
     public Set<Correspondence> getCorrespondences(List<EObject> eObjects, String tag);
+
+    public void removeCorrespondencesBetween(Class<? extends Correspondence> correspondenceType, List<EObject> aEObjects, List<EObject> bEObjects, String tag);
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/InternalCorrespondenceModel.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/InternalCorrespondenceModel.java
@@ -23,4 +23,6 @@ public interface InternalCorrespondenceModel extends GenericCorrespondenceModel<
     public Set<Correspondence> getCorrespondences(List<EObject> eObjects, String tag);
 
     public void removeCorrespondencesBetween(Class<? extends Correspondence> correspondenceType, List<EObject> aEObjects, List<EObject> bEObjects, String tag);
+    
+    public <E> Set<E> getAllEObjectsOfTypeInCorrespondences(Class<? extends Correspondence> correspondenceType, Class<E> type);
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/InternalCorrespondenceModel.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/InternalCorrespondenceModel.java
@@ -1,8 +1,24 @@
 package tools.vitruv.framework.correspondence;
 
-import tools.vitruv.framework.correspondence.CorrespondenceModel;
+import java.util.List;
+import java.util.Set;
 
-public interface InternalCorrespondenceModel extends CorrespondenceModel {
+import org.eclipse.emf.ecore.EObject;
+
+public interface InternalCorrespondenceModel extends GenericCorrespondenceModel<Correspondence> {
 	public boolean changedAfterLastSave();
     public void resetChangedAfterLastSave();
+    public void saveModel();
+    
+    /**
+     * Returns the elements corresponding to the given one, if the correspondence is of the given type and contains the given tag.
+     * 
+     * @param correspondenceType - the type of correspondence to filter
+     * @param eObjects - the objects to get the corresponding ones for
+     * @param tag - the tag to filter correspondences for. If the tag is <code>null</code>, all correspondences will be returned
+     * @return the elements corresponding to the given ones
+     */
+    public Set<List<EObject>> getCorrespondingEObjects(Class<? extends Correspondence> correspondenceType, List<EObject> eObjects, String tag);
+
+    public Set<Correspondence> getCorrespondences(List<EObject> eObjects, String tag);
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
@@ -150,5 +150,9 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 	override removeCorrespondencesBetween(List<EObject> aEObjects, List<EObject> bEObjects, String tag) {
 		correspondenceModelDelegate.removeCorrespondencesBetween(correspondenceType, aEObjects, bEObjects, tag);
 	}
+	
+	override <E> getAllEObjectsOfTypeInCorrespondences(Class<E> type) {
+		correspondenceModelDelegate.getAllEObjectsOfTypeInCorrespondences(correspondenceType, type);
+	}
 
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
@@ -146,5 +146,9 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 	override resolveEObjectsFromUuids(List<String> uuids) {
 		return correspondenceModelDelegate.resolveEObjectsFromUuids(uuids);
 	}
+	
+	override removeCorrespondencesBetween(List<EObject> aEObjects, List<EObject> bEObjects, String tag) {
+		correspondenceModelDelegate.removeCorrespondencesBetween(correspondenceType, aEObjects, bEObjects, tag);
+	}
 
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
@@ -1,19 +1,20 @@
-package tools.vitruv.framework.correspondence
+package tools.vitruv.framework.correspondence.impl
 
 import java.util.List
 import java.util.Set
 import org.eclipse.emf.ecore.EObject
 import java.util.function.Supplier
-import tools.vitruv.framework.correspondence.GenericCorrespondenceModel
 import tools.vitruv.framework.correspondence.Correspondence
 import tools.vitruv.framework.tuid.Tuid
+import tools.vitruv.framework.correspondence.CorrespondenceModelView
+import tools.vitruv.framework.correspondence.InternalCorrespondenceModel
 
-class CorrespondenceModelView<T extends Correspondence> implements GenericCorrespondenceModel<T> {
-	private final GenericCorrespondenceModel<Correspondence> correspondenceModelDelegate;
+class CorrespondenceModelViewImpl<T extends Correspondence> implements CorrespondenceModelView<T> {
+	private final InternalCorrespondenceModel correspondenceModelDelegate;
 	private final Class<T> correspondenceType;
 	private final Supplier<T> correspondenceCreator
 
-	public new(Class<T> correspondenceType, GenericCorrespondenceModel<Correspondence> correspondenceModel) {
+	public new(Class<T> correspondenceType, InternalCorrespondenceModel correspondenceModel) {
 		this(correspondenceType, correspondenceModel, null)
 	}
 
@@ -21,7 +22,7 @@ class CorrespondenceModelView<T extends Correspondence> implements GenericCorres
 		correspondenceModelDelegate.getCorrespondencesForTuids(tuids).filter(correspondenceType).toSet();
 	}
 	
-	public new(Class<T> correspondenceType, GenericCorrespondenceModel<Correspondence> correspondenceModel,
+	public new(Class<T> correspondenceType, InternalCorrespondenceModel correspondenceModel,
 		Supplier<T> correspondenceCreator) {
 		this.correspondenceType = correspondenceType;
 		this.correspondenceModelDelegate = correspondenceModel;
@@ -69,7 +70,11 @@ class CorrespondenceModelView<T extends Correspondence> implements GenericCorres
 	}
 
 	override getCorrespondences(List<EObject> eObjects) {
-		correspondenceModelDelegate.getCorrespondences(eObjects).filter(correspondenceType).toSet();
+		getCorrespondences(eObjects, null);
+	}
+	
+	override getCorrespondences(List<EObject> eObjects, String tag) {
+		correspondenceModelDelegate.getCorrespondences(eObjects, tag).filter(correspondenceType).toSet();
 	}
 
 	override getCorrespondencesThatInvolveAtLeast(Set<EObject> eObjects) {
@@ -79,6 +84,10 @@ class CorrespondenceModelView<T extends Correspondence> implements GenericCorres
 
 	override <U extends Correspondence> getView(Class<U> correspondenceType) {
 		correspondenceModelDelegate.getView(correspondenceType);
+	}
+	
+	override getGenericView() {
+		correspondenceModelDelegate.genericView;
 	}
 
 	override hasCorrespondences(List<EObject> eObjects) {
@@ -105,14 +114,10 @@ class CorrespondenceModelView<T extends Correspondence> implements GenericCorres
 
 	// TODO re-design the CorrespondenceModel to avoid a functionality depending on the correpondenceType
 	override getCorrespondingEObjects(List<EObject> eObjects) {
-		correspondenceModelDelegate.getCorrespondingEObjects(correspondenceType, eObjects, "");
+		correspondenceModelDelegate.getCorrespondingEObjects(correspondenceType, eObjects, null);
 	}
 
 	override getCorrespondingEObjects(List<EObject> eObjects, String tag) {
-		correspondenceModelDelegate.getCorrespondingEObjects(correspondenceType, eObjects, tag);
-	}
-
-	override getCorrespondingEObjects(Class<? extends Correspondence> correspondenceType, List<EObject> eObjects, String tag) {
 		correspondenceModelDelegate.getCorrespondingEObjects(correspondenceType, eObjects, tag);
 	}
 

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
@@ -47,14 +47,15 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 
 	// Re-implement this method, because we cannot claim a unique generic correspondence and restrict it to the given type afterwards 
 	override claimUniqueCorrespondence(List<EObject> aEObjects, List<EObject> bEObjects) {
-		val correspondences = getCorrespondences(aEObjects)
-		for (T correspondence : correspondences) {
-			val correspondingBs = correspondence.bs
-			if (correspondingBs !== null && correspondingBs.equals(bEObjects)) {
-				return correspondence;
-			}
+		val correspondencesA = getCorrespondences(aEObjects)
+		val correspondencesB = getCorrespondences(bEObjects)
+		correspondencesA.retainAll(correspondencesB);
+		if (correspondencesA.size > 1) {
+			throw new IllegalStateException("Only one correspondence for " + aEObjects + " and " + bEObjects + " expected, but found more");
+		} else if (correspondencesA.size == 0) {
+			throw new IllegalStateException("No correspondence for '" + aEObjects + "' and '" + bEObjects + "' was found!");
 		}
-		throw new RuntimeException("No correspondence for '" + aEObjects + "' and '" + bEObjects + "' was found!");
+		return correspondencesA.get(0);
 	}
 
 	override createAndAddManualCorrespondence(List<EObject> eObjects1, List<EObject> eObjects2) {

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/GenericCorrespondenceModelViewImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/GenericCorrespondenceModelViewImpl.xtend
@@ -1,0 +1,15 @@
+package tools.vitruv.framework.correspondence.impl
+
+import tools.vitruv.framework.correspondence.Correspondence
+import tools.vitruv.framework.correspondence.CorrespondenceModel
+import tools.vitruv.framework.correspondence.InternalCorrespondenceModel
+import tools.vitruv.framework.correspondence.CorrespondenceFactory
+
+class GenericCorrespondenceModelViewImpl extends CorrespondenceModelViewImpl<Correspondence> implements CorrespondenceModel {
+	
+	new(InternalCorrespondenceModel correspondenceModel) {
+		// FIXME Finally the CorrespondenceModel should not be editable
+		super(Correspondence, correspondenceModel, [CorrespondenceFactory.eINSTANCE.createManualCorrespondence]);
+	}
+	
+}

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
@@ -512,4 +512,15 @@ class InternalCorrespondenceModelImpl extends ModelInstance implements InternalC
 		return uuids.map[uuidResolver.getPotentiallyCachedEObject(it)]
 	}
 
+	override removeCorrespondencesBetween(Class<? extends Correspondence> correspondenceType, List<EObject> aEObjects, List<EObject> bEObjects, String tag) {
+		val correspondences = getCorrespondences(aEObjects, tag).filter(correspondenceType);
+		for (correspondence : correspondences) { 
+			val correspondingEObjects = resolveCorrespondingObjects(correspondence, aEObjects);
+			if (EcoreUtil.equals(bEObjects, correspondingEObjects)) {
+				removeCorrespondencesAndDependendCorrespondences(correspondence);
+			}
+		}
+		
+	}
+	
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
@@ -1,11 +1,6 @@
-package tools.vitruv.framework.correspondence
+package tools.vitruv.framework.correspondence.impl
 
 import com.google.common.collect.Sets
-import tools.vitruv.framework.util.datatypes.VURI
-import tools.vitruv.framework.util.VitruviusConstants
-import tools.vitruv.framework.util.bridges.EcoreResourceBridge
-import tools.vitruv.framework.util.datatypes.ClaimableHashMap
-import tools.vitruv.framework.util.datatypes.ClaimableMap
 import edu.kit.ipd.sdq.commons.util.java.Pair
 import java.io.IOException
 import java.util.ArrayList
@@ -20,42 +15,50 @@ import org.eclipse.emf.common.util.EList
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.util.EcoreUtil
+import tools.vitruv.framework.correspondence.Correspondence
+import tools.vitruv.framework.correspondence.CorrespondenceFactory
+import tools.vitruv.framework.correspondence.Correspondences
+import tools.vitruv.framework.domains.TuidAwareVitruvDomain
+import tools.vitruv.framework.domains.VitruvDomain
+import tools.vitruv.framework.domains.repository.VitruvDomainRepository
+import tools.vitruv.framework.tuid.Tuid
+import tools.vitruv.framework.tuid.TuidManager
+import tools.vitruv.framework.tuid.TuidResolver
+import tools.vitruv.framework.tuid.TuidUpdateListener
+import tools.vitruv.framework.util.VitruviusConstants
+import tools.vitruv.framework.util.bridges.EcoreResourceBridge
+import tools.vitruv.framework.util.command.EMFCommandBridge
+import tools.vitruv.framework.util.command.VitruviusRecordingCommandExecutor
+import tools.vitruv.framework.util.datatypes.ClaimableHashMap
+import tools.vitruv.framework.util.datatypes.ClaimableMap
+import tools.vitruv.framework.util.datatypes.ModelInstance
+import tools.vitruv.framework.util.datatypes.VURI
+import tools.vitruv.framework.uuid.UuidResolver
 
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import static extension tools.vitruv.framework.util.bridges.JavaBridge.*
-import tools.vitruv.framework.correspondence.Correspondences
-import tools.vitruv.framework.correspondence.Correspondence
-import tools.vitruv.framework.tuid.Tuid
-import tools.vitruv.framework.correspondence.CorrespondenceFactory
-import tools.vitruv.framework.tuid.TuidUpdateListener
-import tools.vitruv.framework.tuid.TuidManager
-import tools.vitruv.framework.util.datatypes.ModelInstance
-import tools.vitruv.framework.domains.TuidAwareVitruvDomain
-import tools.vitruv.framework.domains.repository.VitruvDomainRepository
-import tools.vitruv.framework.util.command.VitruviusRecordingCommandExecutor
-import tools.vitruv.framework.util.command.EMFCommandBridge
-import tools.vitruv.framework.tuid.TuidResolver
-import tools.vitruv.framework.uuid.UuidResolver
-import tools.vitruv.framework.domains.VitruvDomain
+import static extension tools.vitruv.framework.correspondence.CorrespondenceUtil.*
+import tools.vitruv.framework.correspondence.InternalCorrespondenceModel
 
 // TODO move all methods that don't need direct instance variable access to some kind of util class
-class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespondenceModel, TuidUpdateListener {
-	static final Logger logger = Logger::getLogger(typeof(CorrespondenceModelImpl).getSimpleName())
+class InternalCorrespondenceModelImpl extends ModelInstance implements InternalCorrespondenceModel, TuidUpdateListener {
+	static final Logger logger = Logger::getLogger(typeof(InternalCorrespondenceModelImpl).getSimpleName())
 	final VitruviusRecordingCommandExecutor modelCommandExecutor
 	final VitruvDomainRepository domainRepository;
 	final Correspondences correspondences
-	final ClaimableMap<Tuid,Set<List<Tuid>>> tuid2tuidListsMap
+	final ClaimableMap<Tuid, Set<List<Tuid>>> tuid2tuidListsMap
 	protected final ClaimableMap<List<Tuid>, Set<Correspondence>> tuid2CorrespondencesMap
 	boolean changedAfterLastSave = false
 	final Map<String, String> saveCorrespondenceOptions
 	final TuidResolver tuidResolver;
 	final UuidResolver uuidResolver;
-	
-	new(TuidResolver tuidResolver, UuidResolver uuidResolver, VitruviusRecordingCommandExecutor modelCommandExecutor, VitruvDomainRepository domainRepository, VURI correspondencesVURI, Resource correspondencesResource) {
+
+	new(TuidResolver tuidResolver, UuidResolver uuidResolver, VitruviusRecordingCommandExecutor modelCommandExecutor,
+		VitruvDomainRepository domainRepository, VURI correspondencesVURI, Resource correspondencesResource) {
 		super(correspondencesVURI, correspondencesResource)
 		this.modelCommandExecutor = modelCommandExecutor
 		// TODO MK use MutatingListFixing... when necessary (for both maps!)
-		this.tuid2tuidListsMap = new ClaimableHashMap<Tuid,Set<List<Tuid>>>()
+		this.tuid2tuidListsMap = new ClaimableHashMap<Tuid, Set<List<Tuid>>>()
 		this.tuid2CorrespondencesMap = new ClaimableHashMap<List<Tuid>, Set<Correspondence>>()
 		this.saveCorrespondenceOptions = new HashMap<String, String>()
 		this.saveCorrespondenceOptions.put(VitruviusConstants::getOptionProcessDanglingHref(),
@@ -69,30 +72,30 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 
 	override void addCorrespondence(Correspondence correspondence) {
 		this.modelCommandExecutor.executeRecordingCommand(EMFCommandBridge.createVitruviusRecordingCommand(
-				[ |
-					addCorrespondenceToModel(correspondence)
-					registerCorrespondence(correspondence)
-					setChangeAfterLastSaveFlag()
-					return null
-				]));
+				[|
+			addCorrespondenceToModel(correspondence)
+			registerCorrespondence(correspondence)
+			setChangeAfterLastSaveFlag()
+			return null
+		]));
 	}
 
 	def private void registerCorrespondence(Correspondence correspondence) {
 		registerTuidLists(correspondence)
 		registerCorrespondenceForTuids(correspondence)
 	}
-	
+
 	def private registerTuidLists(Correspondence correspondence) {
 		registerTuidList(correspondence.getATuids)
 		registerTuidList(correspondence.getBTuids)
 	}
-	
+
 	def private registerTuidList(List<Tuid> tuidList) {
 		for (Tuid tuid : tuidList) {
 			var tuidLists = this.tuid2tuidListsMap.get(tuid)
 			if (tuidLists === null) {
 				tuidLists = new HashSet<List<Tuid>>()
-				this.tuid2tuidListsMap.put(tuid,tuidLists)
+				this.tuid2tuidListsMap.put(tuid, tuidLists)
 			}
 			tuidLists.add(tuidList)
 		}
@@ -102,31 +105,31 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 		var EList<Correspondence> correspondenceListForAddition = this.correspondences.getCorrespondences()
 		correspondenceListForAddition.add(correspondence)
 	}
-	
+
 	override calculateTuidFromEObject(EObject eObject) {
 		val VitruvDomain metamodel = eObject.getMetamodelForEObject()
-		 if (null === metamodel || !(metamodel instanceof TuidAwareVitruvDomain)){
-		 	return null 
-		 }
-		 val typedDomain = metamodel as TuidAwareVitruvDomain;
-         return typedDomain.calculateTuid(eObject)
+		if (null === metamodel || !(metamodel instanceof TuidAwareVitruvDomain)) {
+			return null
+		}
+		val typedDomain = metamodel as TuidAwareVitruvDomain;
+		return typedDomain.calculateTuid(eObject)
 	}
-	
+
 	@Deprecated
 	override calculateTuidFromEObject(EObject eObject, EObject virtualRootObject, String prefix) {
-		 val VitruvDomain metamodel = eObject.getMetamodelForEObject()
-		 if(null === metamodel || !(metamodel instanceof TuidAwareVitruvDomain)){
-		 	return null 
-		 }
-		 val typedDomain = metamodel as TuidAwareVitruvDomain
-		 if(null === virtualRootObject || null === prefix){
-		 	logger.info("virtualRootObject or prefix is null. Using standard calculation method for EObject " + eObject)
-         	return typedDomain.calculateTuid(eObject)
-     	}
-     	return Tuid::getInstance(typedDomain.calculateTuidFromEObject(eObject, virtualRootObject, prefix))
+		val VitruvDomain metamodel = eObject.getMetamodelForEObject()
+		if (null === metamodel || !(metamodel instanceof TuidAwareVitruvDomain)) {
+			return null
+		}
+		val typedDomain = metamodel as TuidAwareVitruvDomain
+		if (null === virtualRootObject || null === prefix) {
+			logger.info("virtualRootObject or prefix is null. Using standard calculation method for EObject " + eObject)
+			return typedDomain.calculateTuid(eObject)
+		}
+		return Tuid::getInstance(typedDomain.calculateTuidFromEObject(eObject, virtualRootObject, prefix))
 	}
-	
-	def private getMetamodelForEObject(EObject eObject){
+
+	def private getMetamodelForEObject(EObject eObject) {
 		return this.domainRepository.getDomain(eObject);
 	}
 
@@ -138,24 +141,12 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 		return this.changedAfterLastSave
 	}
 
-	
-	override Correspondence claimUniqueCorrespondence(List<EObject> aEObjects, List<EObject> bEObjects) {
-		 val correspondences = getCorrespondences(aEObjects)
-		 for (Correspondence correspondence : correspondences) {
-		 	val correspondingBs = if (correspondence.^as.containsAll(aEObjects)) correspondence.bs else correspondence.^as
-		 	if (correspondingBs !== null && correspondingBs.equals(bEObjects)) {
-		 		return correspondence;
-		 	}
-		 }
-		 throw new RuntimeException("No correspondence for '" + aEObjects + "' and '" + bEObjects + "' was found!");
-	}
-	
 	@Deprecated
 	override Correspondence createAndAddCorrespondence(List<EObject> eObjects1, List<EObject> eObjects2) {
 		return createAndAddManualCorrespondence(eObjects1, eObjects2)
 	}
 
-	override  createAndAddCorrespondence(List<EObject> eObjects1, List<EObject> eObjects2, 
+	override createAndAddCorrespondence(List<EObject> eObjects1, List<EObject> eObjects2,
 		Supplier<Correspondence> correspondenceCreator) {
 		val Correspondence correspondence = correspondenceCreator.get
 		createAndAddCorrespondence(eObjects1, eObjects2, correspondence)
@@ -164,17 +155,26 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	override Correspondence createAndAddManualCorrespondence(List<EObject> eObjects1, List<EObject> eObjects2) {
 		val correspondence = CorrespondenceFactory.eINSTANCE.createManualCorrespondence
 		createAndAddCorrespondence(eObjects1, eObjects2, correspondence)
-	} 
+	}
 
-	def private createAndAddCorrespondence(List<EObject> eObjects1, List<EObject> eObjects2, Correspondence correspondence){
+	def private createAndAddCorrespondence(List<EObject> eObjects1, List<EObject> eObjects2,
+		Correspondence correspondence) {
 		setCorrespondenceFeatures(correspondence, eObjects1, eObjects2)
 		addCorrespondence(correspondence)
 		return correspondence
 	}
-	
-	override Set<Correspondence> getCorrespondences(List<EObject> eObjects) {
-		var List<Tuid> tuids = calculateTuidsFromEObjects(eObjects)
-		return getCorrespondencesForTuids(tuids)
+
+	override Set<Correspondence> getCorrespondences(List<EObject> eObjects, String tag) {
+		val Set<Correspondence> correspondences = new HashSet<Correspondence>()
+		if (eObjects.haveUuids) {
+			val uuids = eObjects.map[uuidResolver.getPotentiallyCachedUuid(it)];
+			correspondences += getCorrespondencesForUuids(uuids);
+		}
+		
+		val List<Tuid> tuids = calculateTuidsFromEObjects(eObjects)
+		correspondences += getCorrespondencesForTuids(tuids);
+		
+		return correspondences.filter[tag === null || it.tag == tag].toSet;
 	}
 	
 	override Set<Correspondence> getCorrespondencesForTuids(List<Tuid> tuids) {
@@ -186,7 +186,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 		}
 		return correspondences
 	}
-	
+
 	def Set<Correspondence> getCorrespondencesForUuids(List<String> uuids) {
 		return this.correspondences.correspondences.filter[AUuids.containsAll(uuids) || BUuids.containsAll(uuids)].toSet
 	}
@@ -194,49 +194,48 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	override Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects) {
 		this.getCorrespondingEObjects(eObjects, null);
 	}
-	
+
 	override Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects, String tag) {
 		this.getCorrespondingEObjects(Correspondence, eObjects, tag);
 	}
 
-	def private <T extends Correspondence> Iterable<T> filterCorrespondences(Iterable<? extends Correspondence> correspondences, Class<T> correspondenceType, String tag) {
+	def private <T extends Correspondence> Iterable<T> filterCorrespondences(
+		Iterable<? extends Correspondence> correspondences, Class<T> correspondenceType, String tag) {
 		return correspondences.filter(correspondenceType).filter[tag === null || tag == it.tag]
 	}
-	
-	def private Set<List<String>> getCorrespondingUuids(Class<? extends Correspondence> correspondenceType, List<String> uuids, String tag) {
+
+	def private Set<List<String>> getCorrespondingUuids(Class<? extends Correspondence> correspondenceType,
+		List<String> uuids, String tag) {
 		var Set<Correspondence> allCorrespondences = getCorrespondencesForUuids(uuids)
 		var Set<List<String>> correspondingTuidLists = new HashSet<List<String>>(allCorrespondences.size())
 		for (Correspondence correspondence : allCorrespondences.filterCorrespondences(correspondenceType, tag)) {
-			var List<String> aUuids = correspondence.getAUuids()
-			var List<String> bUuids = correspondence.getBUuids()
-			if (aUuids === null || bUuids === null || aUuids.size == 0 || bUuids.size == 0) {
-				throw new IllegalStateException(
-					'''The correspondence '«»«correspondence»' links to an empty Uuid '«»«aUuids»' or '«»«bUuids»'!'''.
-						toString)
-			}
-			if (aUuids.equals(uuids)) {
-				correspondingTuidLists.add(bUuids)
-			} else {
-				correspondingTuidLists.add(aUuids)
-			}
+			correspondingTuidLists += correspondence.getCorrespondingUuids(uuids);
 		}
-		return correspondingTuidLists	
+		return correspondingTuidLists;
 	}
 
-	override Set<List<EObject>> getCorrespondingEObjects(Class<? extends Correspondence> correspondenceType, List<EObject> eObjects, String tag) {
-		val result = newArrayList;
-		
-		// If all elements support UUIDs, first get correspondences using UUIDs
+	private def haveUuids(List<EObject> eObjects) {
 		if (eObjects.forall[domainRepository.getDomain(it).supportsUuids]) {
 			if (eObjects.forall[uuidResolver.hasPotentiallyCachedUuid(it)]) {
-				val uuids = eObjects.map[uuidResolver.getPotentiallyCachedUuid(it)];
-				var Set<List<String>> correspondingTuidLists = getCorrespondingUuids(correspondenceType, uuids, tag)
-				result += correspondingTuidLists.mapFixed[it.map[uuidResolver.getPotentiallyCachedEObject(it)]].toSet;	
+				return true;
 			} else {
 				logger.warn("UUID resolver has no UUID for one of the elements: " + eObjects);
 			}
-		}	
-		
+		}
+		return false;
+	}
+
+	override Set<List<EObject>> getCorrespondingEObjects(Class<? extends Correspondence> correspondenceType,
+		List<EObject> eObjects, String tag) {
+		val result = newArrayList;
+
+		// If all elements support UUIDs, first get correspondences using UUIDs
+		if (eObjects.haveUuids) {
+			val uuids = eObjects.map[uuidResolver.getPotentiallyCachedUuid(it)];
+			val correspondingUuidLists = getCorrespondingUuids(correspondenceType, uuids, tag)
+			result += correspondingUuidLists.mapFixed[it.map[uuidResolver.getPotentiallyCachedEObject(it)]].toSet;
+		}
+
 		// Afterwards, add correspondences based on TUIDs
 		var List<Tuid> tuids = calculateTuidsFromEObjects(eObjects)
 		var Set<List<Tuid>> correspondingTuidLists = getCorrespondingTuids(correspondenceType, tuids, tag)
@@ -251,23 +250,13 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 		}
 		return result.toSet;
 	}
-	
-	def private Set<List<Tuid>> getCorrespondingTuids(Class<? extends Correspondence> correspondenceType, List<Tuid> tuids, String tag) {
+
+	def private Set<List<Tuid>> getCorrespondingTuids(Class<? extends Correspondence> correspondenceType,
+		List<Tuid> tuids, String tag) {
 		var Set<Correspondence> allCorrespondences = getCorrespondencesForTuids(tuids)
 		var Set<List<Tuid>> correspondingTuidLists = new HashSet<List<Tuid>>(allCorrespondences.size())
 		for (Correspondence correspondence : allCorrespondences.filterCorrespondences(correspondenceType, tag)) {
-			var List<Tuid> aTuids = correspondence.getATuids()
-			var List<Tuid> bTuids = correspondence.getBTuids()
-			if (aTuids === null || bTuids === null || aTuids.size == 0 || bTuids.size == 0) {
-				throw new IllegalStateException(
-					'''The correspondence '«»«correspondence»' links to an empty Tuid '«»«aTuids»' or '«»«bTuids»'!'''.
-						toString)
-			}
-			if (aTuids.equals(tuids)) {
-				correspondingTuidLists.add(bTuids)
-			} else {
-				correspondingTuidLists.add(aTuids)
-			}
+			correspondingTuidLists += correspondence.getCorrespondingTuids(tuids)
 		}
 		return correspondingTuidLists
 	}
@@ -308,7 +297,8 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 			}
 		}
 		// TODO implement lazy loading for correspondences because they may get really big
-		var Correspondences correspondences = EcoreResourceBridge::getResourceContentRootIfUnique(getResource())?.dynamicCast(Correspondences, "correspondence model")
+		var Correspondences correspondences = EcoreResourceBridge::getResourceContentRootIfUnique(getResource())?.
+			dynamicCast(Correspondences, "correspondence model")
 		if (correspondences === null) {
 			correspondences = CorrespondenceFactory::eINSTANCE.createCorrespondences()
 			correspondencesResource.getContents().add(correspondences)
@@ -346,7 +336,7 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 			tuid2CorrespondencesMap.remove(bTuids);
 		}
 	}
-	
+
 	def private void removeTuid2TuidListsEntries(List<Tuid> tuids) {
 		for (Tuid tuid : tuids) {
 			val tuidLists = this.tuid2tuidListsMap.get(tuid)
@@ -359,21 +349,22 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 		removeMarkedCorrespondences(markedCorrespondences)
 		return markedCorrespondences
 	}
-	
+
 	private def Set<Correspondence> markCorrespondenceAndDependingCorrespondences(Correspondence correspondence) {
 		var Set<Correspondence> markedCorrespondences = new HashSet<Correspondence>()
 		markCorrespondenceAndDependingCorrespondencesRecursively(markedCorrespondences, correspondence)
 		return markedCorrespondences
 	}
-	
-	private def void markCorrespondenceAndDependingCorrespondencesRecursively(Set<Correspondence> markedCorrespondences, Correspondence correspondence) {
+
+	private def void markCorrespondenceAndDependingCorrespondencesRecursively(Set<Correspondence> markedCorrespondences,
+		Correspondence correspondence) {
 		markedCorrespondences.add(correspondence);
 		// FIXME MK detect dependency cycles in correspondences already when the reference is updated
-		for(dependingCorrespondence : correspondence.dependedOnBy) {
-			markCorrespondenceAndDependingCorrespondencesRecursively(markedCorrespondences,dependingCorrespondence)
+		for (dependingCorrespondence : correspondence.dependedOnBy) {
+			markCorrespondenceAndDependingCorrespondencesRecursively(markedCorrespondences, dependingCorrespondence)
 		}
 	}
-	
+
 	private def removeMarkedCorrespondences(Iterable<Correspondence> markedCorrespondences) {
 		for (Correspondence markedCorrespondence : markedCorrespondences) {
 			removeCorrespondenceFromMaps(markedCorrespondence)
@@ -381,9 +372,11 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 			setChangeAfterLastSaveFlag()
 		}
 	}
-	
+
 	override Set<Correspondence> removeCorrespondencesThatInvolveAtLeastAndDependend(Set<EObject> eObjects) {
-		return removeCorrespondencesThatInvolveAtLeastAndDependendForTuids(eObjects.mapFixed[calculateTuidFromEObject(it)].toSet)
+		return removeCorrespondencesThatInvolveAtLeastAndDependendForTuids(eObjects.mapFixed [
+			calculateTuidFromEObject(it)
+		].toSet)
 	}
 
 	private def Set<Correspondence> removeCorrespondencesThatInvolveAtLeastAndDependendForTuids(Set<Tuid> tuids) {
@@ -406,25 +399,24 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 	override EObject resolveEObjectFromTuid(Tuid tuid) {
 		tuidResolver.resolveEObjectFromTuid(tuid);
 	}
-	
+
 	def public void setChangeAfterLastSaveFlag() {
 		this.changedAfterLastSave = true
 	}
 
-	def private void setCorrespondenceFeatures(
-		Correspondence correspondence, List<EObject> eObjects1,
+	def private void setCorrespondenceFeatures(Correspondence correspondence, List<EObject> eObjects1,
 		List<EObject> eObjects2) {
 		var aEObjects = eObjects1
 		var bEObjects = eObjects2
 		if ((aEObjects + bEObjects).forall[domainRepository.getDomain(it).supportsUuids]) {
-			correspondence.getAUuids().addAll(aEObjects.map[
+			correspondence.getAUuids().addAll(aEObjects.map [
 				if (uuidResolver.hasPotentiallyCachedUuid(it)) {
 					uuidResolver.getPotentiallyCachedUuid(it)
 				} else {
 					uuidResolver.registerCachedEObject(it);
 				}
 			])
-			correspondence.getBUuids().addAll(bEObjects.map[
+			correspondence.getBUuids().addAll(bEObjects.map [
 				if (uuidResolver.hasPotentiallyCachedUuid(it)) {
 					uuidResolver.getPotentiallyCachedUuid(it)
 				} else {
@@ -435,50 +427,57 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 			var List<Tuid> aTuids = calculateTuidsFromEObjects(aEObjects)
 			correspondence.getATuids().addAll(aTuids)
 			var List<Tuid> bTuids = calculateTuidsFromEObjects(bEObjects)
-			correspondence.getBTuids().addAll(bTuids)	
+			correspondence.getBTuids().addAll(bTuids)
 		}
 	}
 
 	override getAllCorrespondencesWithoutDependencies() {
 		this.correspondences.correspondences.filter[it.dependsOn === null || it.dependsOn.size == 0].toSet
 	}
-	
+
 	override getCorrespondencesThatInvolveAtLeast(Set<EObject> eObjects) {
 		return getCorrespondencesThatInvolveAtLeastTuids(eObjects.mapFixed[calculateTuidFromEObject(it)].toSet)
 	}
-	
+
 	private def getCorrespondencesThatInvolveAtLeastTuids(Set<Tuid> tuids) {
-		val supTuidLists = tuids?.mapFixed[this.tuid2tuidListsMap.get(it)].filterNull.flatten.filter[it.containsAll(tuids)]
+		val supTuidLists = tuids?.mapFixed[this.tuid2tuidListsMap.get(it)].filterNull.flatten.filter [
+			it.containsAll(tuids)
+		]
 		val corrit = supTuidLists?.mapFixed[getCorrespondencesForTuids(it)]
 		val flatcorr = corrit.flatten
-		if(flatcorr.nullOrEmpty){
+		if (flatcorr.nullOrEmpty) {
 			logger.debug("could not find correspondences for tuids: " + tuids)
 			return Sets.newHashSet
 		}
 		val corrset = flatcorr.toSet
 		return corrset
 	}
-	
+
 	override getAllCorrespondences() {
 		return correspondences.correspondences
 	}
-	
+
 	override <U extends Correspondence> getView(Class<U> correspondenceType) {
-		return new CorrespondenceModelView(correspondenceType, this);
+		return new CorrespondenceModelViewImpl(correspondenceType, this);
+	}
+
+	override <U extends Correspondence> getEditableView(Class<U> correspondenceType,
+		Supplier<U> correspondenceCreator) {
+		return new CorrespondenceModelViewImpl(correspondenceType, this, correspondenceCreator);
+	}
+
+	override getGenericView() {
+		return new GenericCorrespondenceModelViewImpl(this);
 	}
 	
-	override <U extends Correspondence> getEditableView(Class<U> correspondenceType, Supplier<U> correspondenceCreator) {
-		return new CorrespondenceModelView(correspondenceType, this, correspondenceCreator);
-	}
-	
-	private Iterable<Pair<List<Tuid>,Set<Correspondence>>> tuidUpdateData;
-		
+	private Iterable<Pair<List<Tuid>, Set<Correspondence>>> tuidUpdateData;
+
 	/**
 	 * Removes the current entries in the
 	 * {@link CorrespondenceModelImpl#tuid2CorrespondencesMap} map for the given oldTuid
 	 * before the hash code of it is updated and returns a pair containing the oldTuid and
 	 * the removed correspondence model elements of the map.
-	 *
+	 * 
 	 * @param oldCurrentTuid
 	 * @return oldCurrentTuidAndStringAndMapEntriesTriple
 	 */
@@ -490,23 +489,25 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 		// the hashCode of the Tuid changes.
 		// remove the old map entries for the tuid before its hashcode changes
 		val oldTuidLists = tuid2tuidListsMap.remove(oldCurrentTuid) ?: new HashSet<List<Tuid>>()
-		val oldTuidList2Correspondences = new ArrayList<Pair<List<Tuid>,Set<Correspondence>>>(oldTuidLists.size);
+		val oldTuidList2Correspondences = new ArrayList<Pair<List<Tuid>, Set<Correspondence>>>(oldTuidLists.size);
 		for (oldTuidList : oldTuidLists) {
-			val correspondencesForOldTuidList = tuid2CorrespondencesMap.remove(oldTuidList) ?: new HashSet<Correspondence>()
-			oldTuidList2Correspondences.add(new Pair<List<Tuid>,Set<Correspondence>>(oldTuidList,correspondencesForOldTuidList))
+			val correspondencesForOldTuidList = tuid2CorrespondencesMap.remove(oldTuidList) ?:
+				new HashSet<Correspondence>()
+			oldTuidList2Correspondences.add(
+				new Pair<List<Tuid>, Set<Correspondence>>(oldTuidList, correspondencesForOldTuidList))
 		}
 		tuidUpdateData = oldTuidList2Correspondences
 	}
-		
-	 /**
+
+	/**
 	 * Re-adds all map entries after the hash code of tuids was updated.
-	 *
+	 * 
 	 * @param removedMapEntries
 	 */
 	override void performPostAction(Tuid tuid) {
 		// The correspondence model is an EMF-based model, so modifications have to be
 		// performed within a transaction.
-		this.modelCommandExecutor.executeRecordingCommand(EMFCommandBridge.createVitruviusRecordingCommand([ |
+		this.modelCommandExecutor.executeRecordingCommand(EMFCommandBridge.createVitruviusRecordingCommand([|
 			if (tuidUpdateData === null) {
 				throw new IllegalStateException("Update was not started before performing post action");
 			}
@@ -527,9 +528,9 @@ class CorrespondenceModelImpl extends ModelInstance implements InternalCorrespon
 			return null;
 		]));
 	}
-	
+
 	override resolveEObjectsFromUuids(List<String> uuids) {
 		return uuids.map[uuidResolver.getPotentiallyCachedEObject(it)]
 	}
 
-}		
+}

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
@@ -523,4 +523,14 @@ class InternalCorrespondenceModelImpl extends ModelInstance implements InternalC
 		
 	}
 	
+	override <E> getAllEObjectsOfTypeInCorrespondences(Class<? extends Correspondence> correspondenceType, Class<E> type) {
+		allCorrespondencesWithoutDependencies.filter(correspondenceType).map[
+			if(it.isUuidBased) {
+				(it.AUuids + it.BUuids).toList.resolveEObjectsFromUuids
+			} else {
+				(it.ATuids + it.BTuids).toList.map[resolveEObjectFromTuid]
+			}
+		].flatten.filter(type).toSet
+	}
+	
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
@@ -284,7 +284,6 @@ class InternalCorrespondenceModelImpl extends ModelInstance implements InternalC
 		} else {
 			registerLoadedCorrespondences(correspondences)
 		}
-		correspondences.setCorrespondenceModel(this)
 		return correspondences
 	}
 

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.java
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.java
@@ -29,7 +29,7 @@ import tools.vitruv.framework.change.description.VitruviusChange;
 import tools.vitruv.framework.change.description.VitruviusChangeFactory;
 import tools.vitruv.framework.change.recording.AtomicEmfChangeRecorder;
 import tools.vitruv.framework.correspondence.CorrespondenceModel;
-import tools.vitruv.framework.correspondence.CorrespondenceModelImpl;
+import tools.vitruv.framework.correspondence.CorrespondenceModelFactory;
 import tools.vitruv.framework.correspondence.CorrespondenceProviding;
 import tools.vitruv.framework.correspondence.InternalCorrespondenceModel;
 import tools.vitruv.framework.domains.VitruvDomain;
@@ -95,9 +95,9 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
     }
 
     /**
-     * Supports three cases: 1) get registered 2) create non-existing 3) get unregistered but existing
-     * that contains at most a root element without children. But throws an exception if an instance
-     * that contains more than one element exists at the uri.
+     * Supports three cases: 1) get registered 2) create non-existing 3) get unregistered but
+     * existing that contains at most a root element without children. But throws an exception if an
+     * instance that contains more than one element exists at the uri.
      *
      * DECISION Since we do not throw an exception (which can happen in 3) we always return a valid
      * model. Hence the caller do not have to check whether the retrieved model is null.
@@ -161,8 +161,8 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
 
     private void registerModelInstance(final VURI modelUri, final ModelInstance modelInstance) {
         this.modelInstances.put(modelUri, modelInstance);
-        // Do not record other URI types than file and platform (e.g. pathmap) because they cannot be
-        // modified
+        // Do not record other URI types than file and platform (e.g. pathmap) because they cannot
+        // be modified
         if (modelUri.getEMFUri().isFile() || modelUri.getEMFUri().isPlatform()) {
             AtomicEmfChangeRecorder recorder = getOrCreateChangeRecorder(modelUri);
             recorder.addToRecording(modelInstance.getResource());
@@ -256,8 +256,8 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
         createRecordingCommandAndExecuteCommandOnTransactionalDomain(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
-                logger.debug("  Saving correspondence model: "
-                        + ResourceRepositoryImpl.this.correspondenceModel.getResource());
+                logger.debug(
+                        "  Saving correspondence model: " + ResourceRepositoryImpl.this.correspondenceModel.getURI());
                 ResourceRepositoryImpl.this.correspondenceModel.saveModel();
                 ResourceRepositoryImpl.this.correspondenceModel.resetChangedAfterLastSave();
                 return null;
@@ -311,9 +311,9 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
             AtomicEmfChangeRecorder recorder = getOrCreateChangeRecorder(correspondencesVURI);
             recorder.addToRecording(correspondencesResource);
             recorder.beginRecording();
-            this.correspondenceModel = new CorrespondenceModelImpl(new TuidResolverImpl(this.metamodelRepository, this),
-                    this.uuidGeneratorAndResolver, this, this.metamodelRepository, correspondencesVURI,
-                    correspondencesResource);
+            this.correspondenceModel = CorrespondenceModelFactory.getInstance().createCorrespondenceModel(
+                    new TuidResolverImpl(this.metamodelRepository, this), this.uuidGeneratorAndResolver, this,
+                    this.metamodelRepository, correspondencesVURI, correspondencesResource);
             recorder.endRecording();
             recorder.addToRecording(correspondencesResource);
             return null;
@@ -331,8 +331,9 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
             } else {
                 uuidProviderResource = this.resourceSet.createResource(uuidProviderVURI.getEMFUri());
             }
-            // TODO HK We cannot enable strict mode here, because for textual views we will not get create
-            // changes in any case. We should therefore use one monitor per model and turn on strict mode
+            // TODO HK We cannot enable strict mode here, because for textual views we will not get
+            // create changes in any case. We should therefore use one monitor per model and turn on 
+            // strict mode
             // depending on the kind of model/view (textual vs. semantic)
             this.uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidProviderResource,
                     false);
@@ -347,7 +348,7 @@ public class ResourceRepositoryImpl implements ModelRepository, CorrespondencePr
      */
     @Override
     public CorrespondenceModel getCorrespondenceModel() {
-        return this.correspondenceModel;
+        return this.correspondenceModel.getGenericView();
     }
 
     private void loadVURIsOfVSMUModelInstances() {

--- a/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/CorrespondenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/CorrespondenceTest.xtend
@@ -96,7 +96,7 @@ class CorrespondenceTest extends VsumTest {
 	def private void assertRepositoryCorrespondences(Repository repo,
 		CorrespondenceModel correspondenceModel) {
 		// get the correspondence of repo
-		var Set<Correspondence> correspondences = correspondenceModel.getCorrespondences(repo.toList)
+		var Set<Correspondence> correspondences = correspondenceModel.getCorrespondences(repo.toList, null)
 		assertEquals("Only one correspondence is expected for the repository.", 1, correspondences.size())
 		for (Correspondence correspondence : correspondences) {
 			var Correspondence eoc = correspondence


### PR DESCRIPTION
This PR completely refactors the correspondence model. The internal implementation is now completely encapsulated in the `InternalCorrespondenceModelImpl` and views, typed with the correspondence type, are strictly separated from the internal representation. The internal representation does not work as a generic view any more. This is necessary to allow the views to provide different functionality than the internal representation. E.g. the internal representation has to expect a correspondence type for `getCorrespondingEObjects`, as it internally has to get the appropriate correspondendes to extract the elements from. To hide this from the user, the view interface provides functions without the necessity to specify the correspondence type, which is automatically set by the type of the view.
This allows to remove redundancies by implementing functionality for getting corresponding elements based on getting the existing correspondences.
Additionally, a factory for creating the correspondence model is introduced to avoid the necessity to expose the implementation class.

This PR also fixes a bug in the `getCorrespondences` operation of the `CorrespondenceModelImpl`, which returned only TUID-based correspondences. Logic for also extracting UUID-based correspondences was added.