### PR TITLE
Eclipse API break fix

### DIFF
--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModel.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModel.java
@@ -1,5 +1,13 @@
 package tools.vitruv.framework.correspondence;
 
+/**
+ * Extension of the generic {@link CorrespondenceModelView}, but without generically typed operations.
+ * Nevertheless, it is still a view, handling only specific types of correspondences, which are not
+ * known from outside.
+ * 
+ * @author Heiko Klare
+ *
+ */
 public interface CorrespondenceModel extends CorrespondenceModelView<Correspondence> {
 
 }


### PR DESCRIPTION
Eclipse introduced a breaking API change in the `PDECore` class. A method signature was changes from expecting a class instead of its name. To support both the old version (delivered with oxygen) as well as the new (delivered with photon), we employ reflection to call the appropriate available operation....