### PR TITLE
Correspondence model type modularization

### DIFF
--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/ReactionsCorrespondenceModelViewFactory.java
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/ReactionsCorrespondenceModelViewFactory.java
@@ -1,0 +1,37 @@
+package tools.vitruv.extensions.dslsruntime.reactions;
+
+import tools.vitruv.dsls.reactions.meta.correspondence.reactions.ReactionsCorrespondence;
+import tools.vitruv.framework.correspondence.CorrespondenceModelView;
+import tools.vitruv.framework.correspondence.CorrespondenceModelViewFactory;
+import tools.vitruv.framework.correspondence.InternalCorrespondenceModel;
+import tools.vitruv.framework.correspondence.impl.CorrespondenceModelViewImpl;
+import tools.vitruv.dsls.reactions.meta.correspondence.reactions.ReactionsFactory;
+
+public class ReactionsCorrespondenceModelViewFactory implements
+		CorrespondenceModelViewFactory<CorrespondenceModelView<ReactionsCorrespondence>> {
+	private static ReactionsCorrespondenceModelViewFactory instance;
+	
+	private ReactionsCorrespondenceModelViewFactory() {}
+	
+	public static synchronized ReactionsCorrespondenceModelViewFactory getInstance() {
+		if (instance == null) {
+			instance = new ReactionsCorrespondenceModelViewFactory();
+		}
+		return instance;
+	}
+	
+	@Override
+	public CorrespondenceModelView<ReactionsCorrespondence> createCorrespondenceModelView(
+			InternalCorrespondenceModel correspondenceModel) {
+		return new CorrespondenceModelViewImpl<ReactionsCorrespondence>(ReactionsCorrespondence.class,
+				correspondenceModel, null);
+	}
+
+	@Override
+	public CorrespondenceModelView<ReactionsCorrespondence> createEditableCorrespondenceModelView(
+			InternalCorrespondenceModel correspondenceModel) {
+		return new CorrespondenceModelViewImpl<ReactionsCorrespondence>(ReactionsCorrespondence.class,
+				correspondenceModel, () -> ReactionsFactory.eINSTANCE.createReactionsCorrespondence());
+	}
+
+}

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/ReactionsCorrespondenceHelper.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/ReactionsCorrespondenceHelper.xtend
@@ -4,17 +4,15 @@ import java.util.ArrayList
 import org.eclipse.xtext.xbase.lib.Functions.Function1
 import org.eclipse.emf.ecore.EObject
 import tools.vitruv.dsls.reactions.meta.correspondence.reactions.ReactionsCorrespondence
-import tools.vitruv.dsls.reactions.meta.correspondence.reactions.ReactionsFactory
 import java.util.List
 import tools.vitruv.framework.correspondence.CorrespondenceModel
+import tools.vitruv.extensions.dslsruntime.reactions.ReactionsCorrespondenceModelViewFactory
 
 final class ReactionsCorrespondenceHelper {
 	private new() {}
 
 	private static def getReactionsView(CorrespondenceModel correspondenceModel) {
-		return correspondenceModel.getEditableView(ReactionsCorrespondence, [
-			ReactionsFactory.eINSTANCE.createReactionsCorrespondence()
-		]);
+		return correspondenceModel.getEditableView(ReactionsCorrespondenceModelViewFactory.instance);
 	}
 
 	public static def removeCorrespondencesBetweenElements(CorrespondenceModel correspondenceModel,

--- a/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/src/tools/vitruv/extensions/integration/correspondence/util/IntegrationCorrespondenceHelper.xtend
+++ b/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/src/tools/vitruv/extensions/integration/correspondence/util/IntegrationCorrespondenceHelper.xtend
@@ -1,23 +1,14 @@
 package tools.vitruv.extensions.integration.correspondence.util
 
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.correspondence.GenericCorrespondenceModel
-import tools.vitruv.extensions.integration.correspondence.integration.IntegrationCorrespondence
-import tools.vitruv.extensions.integration.correspondence.integration.IntegrationFactory
 
 final class IntegrationCorrespondenceHelper {
 	private new() {
 	}
 
-	def static final GenericCorrespondenceModel<IntegrationCorrespondence> getEditableView(
+	def static final IntegrationCorrespondenceModelView getEditableView(
 		CorrespondenceModel correspondenceModel) {
-		return correspondenceModel.getEditableView(typeof(IntegrationCorrespondence), [createIntegrationCorrespondence])
+		return correspondenceModel.getEditableView(IntegrationCorrespondenceModelViewFactory.instance)
 	}
 
-	def static final IntegrationCorrespondence createIntegrationCorrespondence() {
-		val integratedCorrespondence = IntegrationFactory::eINSTANCE.
-			createIntegrationCorrespondence()
-		integratedCorrespondence.setCreatedByIntegration(true)
-		return integratedCorrespondence
-	}
 }

--- a/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/src/tools/vitruv/extensions/integration/correspondence/util/IntegrationCorrespondenceModelView.java
+++ b/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/src/tools/vitruv/extensions/integration/correspondence/util/IntegrationCorrespondenceModelView.java
@@ -1,0 +1,13 @@
+package tools.vitruv.extensions.integration.correspondence.util;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.emf.ecore.EObject;
+
+import tools.vitruv.extensions.integration.correspondence.integration.IntegrationCorrespondence;
+import tools.vitruv.framework.correspondence.CorrespondenceModelView;
+
+public interface IntegrationCorrespondenceModelView extends CorrespondenceModelView<IntegrationCorrespondence> {
+	public Set<List<EObject>> getCorrespondingIntegratedEObjects(List<EObject> objects, String tag);
+}

--- a/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/src/tools/vitruv/extensions/integration/correspondence/util/IntegrationCorrespondenceModelViewFactory.java
+++ b/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/src/tools/vitruv/extensions/integration/correspondence/util/IntegrationCorrespondenceModelViewFactory.java
@@ -1,0 +1,37 @@
+package tools.vitruv.extensions.integration.correspondence.util;
+
+import tools.vitruv.framework.correspondence.CorrespondenceModelViewFactory;
+import tools.vitruv.framework.correspondence.InternalCorrespondenceModel;
+import tools.vitruv.extensions.integration.correspondence.integration.IntegrationCorrespondence;
+import tools.vitruv.extensions.integration.correspondence.integration.IntegrationFactory;
+
+public class IntegrationCorrespondenceModelViewFactory implements
+		CorrespondenceModelViewFactory<IntegrationCorrespondenceModelView> {
+	private static IntegrationCorrespondenceModelViewFactory instance;
+	
+	private IntegrationCorrespondenceModelViewFactory() {}
+	
+	public static synchronized IntegrationCorrespondenceModelViewFactory getInstance() {
+		if (instance == null) {
+			instance = new IntegrationCorrespondenceModelViewFactory();
+		}
+		return instance;
+	}
+	
+	@Override
+	public IntegrationCorrespondenceModelView createCorrespondenceModelView(
+			InternalCorrespondenceModel correspondenceModel) {
+		return new IntegrationCorrespondenceModelViewImpl(correspondenceModel);
+	}
+
+	@Override
+	public IntegrationCorrespondenceModelView createEditableCorrespondenceModelView(
+			InternalCorrespondenceModel correspondenceModel) {
+		return new IntegrationCorrespondenceModelViewImpl(correspondenceModel, () -> {
+					IntegrationCorrespondence correspondence = IntegrationFactory.eINSTANCE.createIntegrationCorrespondence();
+					correspondence.setCreatedByIntegration(true);
+					return correspondence;
+				});
+	}
+
+}

--- a/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/src/tools/vitruv/extensions/integration/correspondence/util/IntegrationCorrespondenceModelViewImpl.java
+++ b/bundles/extensions/integration/tools.vitruv.extensions.integration.correspondence/src/tools/vitruv/extensions/integration/correspondence/util/IntegrationCorrespondenceModelViewImpl.java
@@ -1,0 +1,29 @@
+package tools.vitruv.extensions.integration.correspondence.util;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.eclipse.emf.ecore.EObject;
+
+import tools.vitruv.extensions.integration.correspondence.integration.IntegrationCorrespondence;
+import tools.vitruv.framework.correspondence.InternalCorrespondenceModel;
+import tools.vitruv.framework.correspondence.impl.CorrespondenceModelViewImpl;
+
+class IntegrationCorrespondenceModelViewImpl extends CorrespondenceModelViewImpl<IntegrationCorrespondence> implements IntegrationCorrespondenceModelView {
+
+	public IntegrationCorrespondenceModelViewImpl(InternalCorrespondenceModel correspondenceModel) {
+		this(correspondenceModel, null);
+	}
+	
+	public IntegrationCorrespondenceModelViewImpl(InternalCorrespondenceModel correspondenceModel, Supplier<IntegrationCorrespondence> correspondenceCreator) {
+		super(IntegrationCorrespondence.class, correspondenceModel, correspondenceCreator);
+	}
+
+	@Override
+	public Set<List<EObject>> getCorrespondingIntegratedEObjects(List<EObject> objects, String tag) {
+		return getCorrespondenceModelDelegate().getCorrespondingEObjects(IntegrationCorrespondence.class,
+				correspondence -> correspondence.isCreatedByIntegration(), objects, tag);
+	}
+	
+}

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
@@ -7,7 +7,6 @@ import org.eclipse.emf.ecore.EObject
 import static extension tools.vitruv.framework.util.bridges.CollectionBridge.toList
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.correspondence.GenericCorrespondenceModel
 import tools.vitruv.framework.correspondence.Correspondence
 
 class CorrespondenceModelUtil {
@@ -24,7 +23,7 @@ class CorrespondenceModelUtil {
 	 *         no correspondences.
 	 */
 	// FIXME ML is this method correct? Is there some cool Xtend feature which makes this method shorter? 
-	def public static Set<EObject> getCorrespondingEObjects(GenericCorrespondenceModel<?> ci, EObject eObject) {
+	def public static Set<EObject> getCorrespondingEObjects(CorrespondenceModelView<?> ci, EObject eObject) {
 		val correspondingEObjects = ci.getCorrespondingEObjects(eObject.toList)
 		val eObjects = Sets.newHashSet
 		correspondingEObjects.forEach(list|eObjects.addAll(list))
@@ -74,7 +73,7 @@ class CorrespondenceModelUtil {
 	 * @return the corresponding object of the specified type for the specified object if there is
 	 *         exactly one corresponding object of this type
 	 */
-	def public static <T, U extends Correspondence> Set<T> getCorrespondingEObjectsByType(GenericCorrespondenceModel<U> ci,
+	def public static <T, U extends Correspondence> Set<T> getCorrespondingEObjectsByType(CorrespondenceModelView<U> ci,
 		EObject eObject, Class<T> type) {
 		// return getCorrespondingEObjects(ci, eObject).filter[eObj | type.isInstance(eObj)].toSet
 		val Set<T> retSet = Sets.newHashSet

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelView.java
@@ -71,6 +71,28 @@ public interface CorrespondenceModelView<T extends Correspondence> extends Gener
 	public T claimUniqueCorrespondence(final List<EObject> aEObjects, final List<EObject> bEObjects);
 
 	/**
+	 * Returns all elements corresponding to the given one.
+	 * 
+	 * @param eObjects
+	 *            - the objects to get the corresponding ones for
+	 * @return the elements corresponding to the given ones
+	 */
+	public Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects);
+
+	/**
+	 * Returns the elements corresponding to the given one, if the correspondence
+	 * contains the given tag.
+	 * 
+	 * @param eObjects
+	 *            - the objects to get the corresponding ones for
+	 * @param tag
+	 *            - the tag to filter correspondences for. If the tag is
+	 *            <code>null</code>, all correspondences will be returned
+	 * @return the elements corresponding to the given ones
+	 */
+	public Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects, String tag);
+	
+	/**
 	 * Removes the correspondences between the given lists of {@link EObjects} with
 	 * the given tag.
 	 * 

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelViewFactory.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelViewFactory.java
@@ -1,0 +1,13 @@
+package tools.vitruv.framework.correspondence;
+
+/**
+ * Generic interface for factories generating {@link CorrespondenceModelView}s
+ * for special correspondence types.
+ * 
+ * @author Heiko Klare
+ *
+ */
+public interface CorrespondenceModelViewFactory<T extends CorrespondenceModelView<?>> {
+	public T createCorrespondenceModelView(InternalCorrespondenceModel correspondenceModel);
+	public T createEditableCorrespondenceModelView(InternalCorrespondenceModel correspondenceModel);
+}

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/GenericCorrespondenceModel.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/GenericCorrespondenceModel.java
@@ -1,8 +1,6 @@
 package tools.vitruv.framework.correspondence;
 
 import java.util.List;
-import java.util.Set;
-import java.util.function.Supplier;
 
 import org.eclipse.emf.ecore.EObject;
 
@@ -22,7 +20,8 @@ import tools.vitruv.framework.util.datatypes.URIHaving;
  * @author kramerm
  * @author Heiko Klare
  * 
- * @param <T> - the type of correspondence that is handled
+ * @param <T>
+ *            - the type of correspondence that is handled
  */
 public interface GenericCorrespondenceModel<T extends Correspondence>
 		extends URIHaving, TuidResolvingCorrespondenceModel {
@@ -30,10 +29,13 @@ public interface GenericCorrespondenceModel<T extends Correspondence>
 	 * Creates a {@link ManualCorresponendce} with the given tag between the given
 	 * lists of {@link EObject}s.
 	 * 
-	 * @param eObjects1 - the first list of {@link EObject}s
-	 * @param eObjects2 - the second list of {@link EObject}s
-	 * @param tag       - the tag to be added to the correspondence or
-	 *                  <code>null</code> if none shall be added
+	 * @param eObjects1
+	 *            - the first list of {@link EObject}s
+	 * @param eObjects2
+	 *            - the second list of {@link EObject}s
+	 * @param tag
+	 *            - the tag to be added to the correspondence or <code>null</code>
+	 *            if none shall be added
 	 * @return the created correspondence
 	 */
 	public Correspondence createAndAddManualCorrespondence(List<EObject> eObjects1, List<EObject> eObjects2,
@@ -42,7 +44,8 @@ public interface GenericCorrespondenceModel<T extends Correspondence>
 	/**
 	 * Returns whether at least one object corresponds to the given object.
 	 *
-	 * @param eObject - the object for which correspondences should be looked up
+	 * @param eObject
+	 *            - the object for which correspondences should be looked up
 	 * @return true if number of corresponding objects > 0
 	 */
 
@@ -54,53 +57,56 @@ public interface GenericCorrespondenceModel<T extends Correspondence>
 	 * @return true if # of correspondences > 0
 	 */
 	public boolean hasCorrespondences();
-
+	
 	/**
-	 * Returns all elements corresponding to the given one.
+	 * Returns the elements corresponding to the given ones in the given correspondence.
 	 * 
-	 * @param eObjects - the objects to get the corresponding ones for
+	 * @param correspondence
+	 *            - the correspondence to investigate
+	 * @param eObjects
+	 *            - the objects to get the corresponding ones for
 	 * @return the elements corresponding to the given ones
 	 */
-	public Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects);
-
+	public List<EObject> getCorrespondingEObjectsInCorrespondence(Correspondence correspondence, 
+			List<EObject> eObjects);
+	
 	/**
-	 * Returns the elements corresponding to the given one, if the correspondence
-	 * contains the given tag.
+	 * Returns all correspondences in this correspondence model.
 	 * 
-	 * @param eObjects - the objects to get the corresponding ones for
-	 * @param tag      - the tag to filter correspondences for. If the tag is
-	 *                 <code>null</code>, all correspondences will be returned
-	 * @return the elements corresponding to the given ones
+	 * @return all correspondences in this correspondence model
 	 */
-	public Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects, String tag);
+	public List<Correspondence> getAllCorrespondences();
 
 	/**
 	 * Returns a view on the {@link GenericCorrespondenceModel} restricted to the
 	 * specified kind of {@link Correspondence}. The functions of the view will only
 	 * act on the given implementation of {@link Correspondence}s.
 	 *
-	 * @param correspondenceType - the type of {@link Correspondence}s to be handled
-	 *                           by the view
+	 * @param correspondenceModelViewFactory
+	 *            - the factory for creating views for the type of
+	 *            {@link Correspondence}s of interest
 	 * @return the restricted view on the {@link GenericCorrespondenceModel}
 	 * @author Heiko Klare
 	 */
-	public <U extends Correspondence> CorrespondenceModelView<U> getView(Class<U> correspondenceType);
+	public <V extends CorrespondenceModelView<?>> V getView(
+			CorrespondenceModelViewFactory<V> correspondenceModelViewFactory);
 
 	/**
 	 * Creates a editable view on the {@link CorrespondenceModel} restricted to the
 	 * specified kind of {@link Correspondence}. To enable the creation of new
 	 * Correspondences a Supplier method has to be provided to the writable view.
 	 *
-	 * @param correspondenceType    - the type of {@link Correspondence}s to be
-	 *                              handled by the view
-	 * @param correspondenceCreator - a supplier that creates a new
-	 *                              {@link Correspondence} of appropriate type on
-	 *                              demand
+	* @param correspondenceModelViewFactory
+	 *            - the factory for creating views for the type of
+	 *            {@link Correspondence}s of interest
+	 * @param correspondenceCreator
+	 *            - a supplier that creates a new {@link Correspondence} of
+	 *            appropriate type on demand
 	 * @return the restricted editable view on the {@link CorrespondenceModel}
 	 * @author Heiko Klare
 	 */
-	public <U extends Correspondence> CorrespondenceModelView<U> getEditableView(Class<U> correspondenceType,
-			Supplier<U> correspondenceCreator);
+	public <V extends CorrespondenceModelView<?>> V getEditableView(
+			CorrespondenceModelViewFactory<V> correspondenceModelViewFactory);
 
 	/**
 	 * Creates a generic {@link CorrespondenceModel} view on the

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/InternalCorrespondenceModel.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/InternalCorrespondenceModel.java
@@ -2,6 +2,7 @@ package tools.vitruv.framework.correspondence;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.eclipse.emf.ecore.EObject;
@@ -23,91 +24,108 @@ public interface InternalCorrespondenceModel extends GenericCorrespondenceModel<
 	 * Creates a correspondence of given type <C> with the given tag between the
 	 * given lists of {@link EObject}s.
 	 * 
-	 * @param eObjects1            - the first list of {@link EObject}s
-	 * @param eObjects2            - the second list of {@link EObject}s
-	 * @param tag                  - the tag to be added to the correspondence or
-	 *                             <code>null</code> if none shall be added
-	 * @param correspondenceCreate - a supplier for creating correspondences of the
-	 *                             appropriate type
+	 * @param eObjects1
+	 *            - the first list of {@link EObject}s
+	 * @param eObjects2
+	 *            - the second list of {@link EObject}s
+	 * @param tag
+	 *            - the tag to be added to the correspondence or <code>null</code>
+	 *            if none shall be added
+	 * @param correspondenceCreate
+	 *            - a supplier for creating correspondences of the appropriate type
 	 * @return the created correspondence
 	 */
 	public <C extends Correspondence> C createAndAddCorrespondence(List<EObject> eObjects1, List<EObject> eObjects2,
 			String tag, Supplier<C> correspondenceCreator);
 
 	/**
-	 * Returns all correspondences in this correspondence model.
-	 * 
-	 * @return all correspondences in this correspondence model
-	 */
-	public List<Correspondence> getAllCorrespondences();
-
-	/**
 	 * Returns all correspondences of the given type for the given {@link EObject}s
 	 * with the given tag.
 	 * 
-	 * @param correspondenceType - the type of correspondence to filter for
-	 * @param eObjects           - the {@link EObject}s to find the correspondence
-	 *                           for
-	 * @param tag                - the tag to filter the correspondences for
+	 * @param correspondenceType
+	 *            - the type of correspondence to filter for
+	 * @param correspondencesFilter
+	 *            - the filter for getting the correspondences of interest
+	 * @param eObjects
+	 *            - the {@link EObject}s to find the correspondence for
+	 * @param tag
+	 *            - the tag to filter the correspondences for
 	 * @return all correspondences for the given objects with the given tag
 	 */
 	public <C extends Correspondence> Set<C> getCorrespondences(Class<C> correspondenceType,
-			List<EObject> eObjects, String tag);
+			Predicate<C> correspondencesFilter, List<EObject> eObjects, String tag);
 
 	/**
-	 * Returns the elements corresponding to the given one, if the correspondence is
+	 * Returns the elements corresponding to the given ones, if the correspondence is
 	 * of the given type and contains the given tag.
 	 * 
-	 * @param correspondenceType - the type of correspondence to filter
-	 * @param eObjects           - the objects to get the corresponding ones for
-	 * @param tag                - the tag to filter correspondences for. If the tag
-	 *                           is <code>null</code>, all correspondences will be
-	 *                           returned
+	 * @param correspondenceType
+	 *            - the type of correspondence to filter for
+	 * @param correspondencesFilter
+	 *            - the filter for getting the correspondences of interest
+	 * @param eObjects
+	 *            - the objects to get the corresponding ones for
+	 * @param tag
+	 *            - the tag to filter correspondences for. If the tag is
+	 *            <code>null</code>, all correspondences will be returned
 	 * @return the elements corresponding to the given ones
 	 */
-	public Set<List<EObject>> getCorrespondingEObjects(Class<? extends Correspondence> correspondenceType,
-			List<EObject> eObjects, String tag);
+	public <C extends Correspondence> Set<List<EObject>> getCorrespondingEObjects(Class<C> correspondenceType,
+			Predicate<C> correspondencesFilter, List<EObject> eObjects, String tag);
 
 	/**
 	 * Returns all elements of a given type that are present in any of the stored
 	 * correspondences.
 	 * 
-	 * @param correspondenceType - the type of correspondence to filter for
-	 * @param type               - the object type to search for in the
-	 *                           correspondences
+	 * @param correspondenceType
+	 *            - the type of correspondence to filter for
+	 * @param correspondencesFilter
+	 *            - the filter for getting the correspondences of interest
+	 * @param type
+	 *            - the object type to search for in the correspondences
 	 * @return the elements in any of the correspondences having the specified type
 	 */
-	public <E> Set<E> getAllEObjectsOfTypeInCorrespondences(Class<? extends Correspondence> correspondenceType,
-			Class<E> type);
+	public <E, C extends Correspondence> Set<E> getAllEObjectsOfTypeInCorrespondences(Class<C> correspondenceType,
+			Predicate<C> correspondencesFilter, Class<E> type);
 
 	/**
 	 * Removes the correspondences of the given type and with the given type between
 	 * the given sets of {@link EObject}s. It also removes dependent
 	 * correspondences.
 	 * 
-	 * @param correspondenceType - the type correspondence to remove
-	 * @param aEObjects          - the first list of corresponding {@link EObject}s
-	 * @param bEObjects          - the second list of corresponding {@link EObject}s
-	 * @param tag                - the tag to filter removed correspondences for or
-	 *                           <code>null</code> if all correspondences shall be
-	 *                           removed
+	 * @param correspondenceType
+	 *            - the type of correspondence to filter for
+	 * @param correspondencesFilter
+	 *            - the filter for getting the correspondences of interest
+	 * @param aEObjects
+	 *            - the first list of corresponding {@link EObject}s
+	 * @param bEObjects
+	 *            - the second list of corresponding {@link EObject}s
+	 * @param tag
+	 *            - the tag to filter removed correspondences for or
+	 *            <code>null</code> if all correspondences shall be removed
 	 * @return the removed correspondences
 	 */
-	public Set<Correspondence> removeCorrespondencesBetween(Class<? extends Correspondence> correspondenceType,
-			List<EObject> aEObjects, List<EObject> bEObjects, String tag);
+	public <C extends Correspondence> Set<Correspondence> removeCorrespondencesBetween(Class<C> correspondenceType,
+			Predicate<C> correspondencesFilter, List<EObject> aEObjects, List<EObject> bEObjects, String tag);
 
 	/**
 	 * Removes all correspondences of the given type in which the given set of
 	 * {@link EObject}s is references. It also removes dependent correspondences.
 	 * 
-	 * @param correspondenceType - the type correspondence to remove
-	 * @param eObjects           - the list of {@link EObject}s whose
-	 *                           correspondences shall be removed
-	 * @param tag                - the tag to filter removed correspondences for or
-	 *                           <code>null</code> if all correspondences shall be
-	 *                           removed
+	 * @param correspondenceType
+	 *            - the type of correspondence to filter for
+	 * @param correspondencesFilter
+	 *            - the filter for getting the correspondences of interest
+	 * @param eObjects
+	 *            - the list of {@link EObject}s whose correspondences shall be
+	 *            removed
+	 * @param tag
+	 *            - the tag to filter removed correspondences for or
+	 *            <code>null</code> if all correspondences shall be removed
 	 * @return the removed correspondences
 	 */
-	public Set<Correspondence> removeCorrespondencesFor(Class<? extends Correspondence> correspondenceType,
-			List<EObject> eObjects, String tag);
+	public <C extends Correspondence> Set<Correspondence> removeCorrespondencesFor(Class<C> correspondenceType,
+			Predicate<C> correspondencesFilter, List<EObject> eObjects, String tag);
+
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
@@ -18,7 +18,10 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 	@Accessors(PROTECTED_GETTER)
 	private final Class<T> correspondenceType;
 	private final Supplier<T> correspondenceCreator
-
+	
+	@Accessors(PROTECTED_GETTER)
+	private final Predicate<T> defaultCorrespondenceFilter;
+	 
 	public new(Class<T> correspondenceType, InternalCorrespondenceModel correspondenceModel) {
 		this(correspondenceType, correspondenceModel, null)
 	}
@@ -26,6 +29,7 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 	public new(Class<T> correspondenceType, InternalCorrespondenceModel correspondenceModel,
 		Supplier<T> correspondenceCreator) {
 		this.correspondenceType = correspondenceType;
+		this.defaultCorrespondenceFilter =  [true];
 		this.correspondenceModelDelegate = correspondenceModel;
 		this.correspondenceCreator = correspondenceCreator
 	}
@@ -68,7 +72,7 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 	}
 	
 	override getCorrespondences(List<EObject> eObjects, String tag) {
-		correspondenceModelDelegate.getCorrespondences(correspondenceType, eObjects, tag).toSet();
+		correspondenceModelDelegate.getCorrespondences(correspondenceType, defaultCorrespondenceFilter, eObjects, tag).toSet();
 	}
 
 	override claimUniqueCorrespondence(List<EObject> aEObjects, List<EObject> bEObjects) {
@@ -88,23 +92,23 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 	}
 
 	override getCorrespondingEObjects(List<EObject> eObjects) {
-		correspondenceModelDelegate.getCorrespondingEObjects(correspondenceType, eObjects, null);
+		correspondenceModelDelegate.getCorrespondingEObjects(correspondenceType, defaultCorrespondenceFilter, eObjects, null);
 	}
 
 	override getCorrespondingEObjects(List<EObject> eObjects, String tag) {
-		correspondenceModelDelegate.getCorrespondingEObjects(correspondenceType, eObjects, tag);
+		correspondenceModelDelegate.getCorrespondingEObjects(correspondenceType, defaultCorrespondenceFilter, eObjects, tag);
 	}
 
 	override <E> getAllEObjectsOfTypeInCorrespondences(Class<E> type) {
-		correspondenceModelDelegate.getAllEObjectsOfTypeInCorrespondences(correspondenceType, type);
+		correspondenceModelDelegate.getAllEObjectsOfTypeInCorrespondences(correspondenceType, defaultCorrespondenceFilter, type);
 	}
 	
 	override removeCorrespondencesBetween(List<EObject> aEObjects, List<EObject> bEObjects, String tag) {
-		correspondenceModelDelegate.removeCorrespondencesBetween(correspondenceType, aEObjects, bEObjects, tag);
+		correspondenceModelDelegate.removeCorrespondencesBetween(correspondenceType, defaultCorrespondenceFilter, aEObjects, bEObjects, tag);
 	}
 
 	override removeCorrespondencesFor(List<EObject> eObjects, String tag) {
-		correspondenceModelDelegate.removeCorrespondencesFor(correspondenceType, eObjects, tag);
+		correspondenceModelDelegate.removeCorrespondencesFor(correspondenceType, defaultCorrespondenceFilter, eObjects, tag);
 	}
 	
 	override <V extends CorrespondenceModelView<?>> getView(CorrespondenceModelViewFactory<V> correspondenceModelViewFactory) {
@@ -130,5 +134,5 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 	override resolveEObjectFromTuid(Tuid tuid) {
 		correspondenceModelDelegate.resolveEObjectFromTuid(tuid);
 	}
-
+	
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
@@ -8,9 +8,14 @@ import tools.vitruv.framework.correspondence.Correspondence
 import tools.vitruv.framework.tuid.Tuid
 import tools.vitruv.framework.correspondence.CorrespondenceModelView
 import tools.vitruv.framework.correspondence.InternalCorrespondenceModel
+import tools.vitruv.framework.correspondence.CorrespondenceModelViewFactory
+import org.eclipse.xtend.lib.annotations.Accessors
+import java.util.function.Predicate
 
 class CorrespondenceModelViewImpl<T extends Correspondence> implements CorrespondenceModelView<T> {
+	@Accessors(PROTECTED_GETTER)
 	private final InternalCorrespondenceModel correspondenceModelDelegate;
+	@Accessors(PROTECTED_GETTER)
 	private final Class<T> correspondenceType;
 	private final Supplier<T> correspondenceCreator
 
@@ -53,6 +58,11 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 		correspondenceModelDelegate.hasCorrespondences();
 	}
 	
+	override getAllCorrespondences() {
+		correspondenceModelDelegate.allCorrespondences;
+	}
+	
+	
 	override getCorrespondences(List<EObject> eObjects) {
 		getCorrespondences(eObjects, null);
 	}
@@ -71,6 +81,10 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 			throw new IllegalStateException("No correspondence for '" + aEObjects + "' and '" + bEObjects + "' was found!");
 		}
 		return correspondencesA.get(0);
+	}
+	
+	override getCorrespondingEObjectsInCorrespondence(Correspondence correspondence, List<EObject> eObjects) {
+		correspondenceModelDelegate.getCorrespondingEObjectsInCorrespondence(correspondence, eObjects);
 	}
 
 	override getCorrespondingEObjects(List<EObject> eObjects) {
@@ -93,13 +107,12 @@ class CorrespondenceModelViewImpl<T extends Correspondence> implements Correspon
 		correspondenceModelDelegate.removeCorrespondencesFor(correspondenceType, eObjects, tag);
 	}
 	
-	override <U extends Correspondence> getView(Class<U> correspondenceType) {
-		correspondenceModelDelegate.getView(correspondenceType);
+	override <V extends CorrespondenceModelView<?>> getView(CorrespondenceModelViewFactory<V> correspondenceModelViewFactory) {
+		correspondenceModelDelegate.getView(correspondenceModelViewFactory);
 	}
 	
-	override <U extends Correspondence> getEditableView(Class<U> correspondenceType,
-		Supplier<U> correspondenceCreator) {
-		correspondenceModelDelegate.getEditableView(correspondenceType, correspondenceCreator)
+	override <V extends CorrespondenceModelView<?>> getEditableView(CorrespondenceModelViewFactory<V> correspondenceModelViewFactory) {
+		correspondenceModelDelegate.getEditableView(correspondenceModelViewFactory)
 	}
 	
 	override getGenericView() {

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
@@ -38,6 +38,9 @@ import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import static extension tools.vitruv.framework.util.bridges.JavaBridge.*
 import static extension tools.vitruv.framework.correspondence.CorrespondenceUtil.*
 import tools.vitruv.framework.correspondence.InternalCorrespondenceModel
+import tools.vitruv.framework.correspondence.CorrespondenceModelView
+import tools.vitruv.framework.correspondence.CorrespondenceModelViewFactory
+import java.util.function.Predicate
 
 // TODO move all methods that don't need direct instance variable access to some kind of util class
 class InternalCorrespondenceModelImpl extends ModelInstance implements InternalCorrespondenceModel, TuidUpdateListener {
@@ -189,14 +192,6 @@ class InternalCorrespondenceModelImpl extends ModelInstance implements InternalC
 		return this.correspondences.correspondences.filter[AUuids.containsAll(uuids) || BUuids.containsAll(uuids)].toSet
 	}
 
-	override Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects) {
-		this.getCorrespondingEObjects(eObjects, null);
-	}
-
-	override Set<List<EObject>> getCorrespondingEObjects(List<EObject> eObjects, String tag) {
-		this.getCorrespondingEObjects(Correspondence, eObjects, tag);
-	}
-
 	private def haveUuids(List<EObject> eObjects) {
 		if (eObjects.forall[domainRepository.getDomain(it).supportsUuids]) {
 			if (eObjects.forall[uuidResolver.hasPotentiallyCachedUuid(it)]) {
@@ -218,7 +213,11 @@ class InternalCorrespondenceModelImpl extends ModelInstance implements InternalC
 		return result.toSet;
 	}
 	
-	def List<EObject> resolveCorrespondingObjects(Correspondence correspondence, List<EObject> eObjects) {
+	override List<EObject> getCorrespondingEObjectsInCorrespondence(Correspondence correspondence, List<EObject> eObjects) {
+		resolveCorrespondingObjects(correspondence, eObjects)	
+	}
+
+	private def List<EObject> resolveCorrespondingObjects(Correspondence correspondence, List<EObject> eObjects) {
 		if (correspondence.isUuidBased) {
 			val uuids = eObjects.map[uuidResolver.getPotentiallyCachedUuid(it)];
 			val correspondingUuids = correspondence.getCorrespondingUuids(uuids);
@@ -482,17 +481,16 @@ class InternalCorrespondenceModelImpl extends ModelInstance implements InternalC
 		].flatten.filter(type).toSet
 	}
 
-	override <U extends Correspondence> getView(Class<U> correspondenceType) {
-		return new CorrespondenceModelViewImpl(correspondenceType, this);
+	override <V extends CorrespondenceModelView<?>> getView(CorrespondenceModelViewFactory<V> correspondenceModelViewFactory) {
+		return correspondenceModelViewFactory.createCorrespondenceModelView(this);
 	}
 
-	override <U extends Correspondence> getEditableView(Class<U> correspondenceType,
-		Supplier<U> correspondenceCreator) {
-		return new CorrespondenceModelViewImpl(correspondenceType, this, correspondenceCreator);
+	override <V extends CorrespondenceModelView<?>> getEditableView(CorrespondenceModelViewFactory<V> correspondenceModelViewFactory) {
+		return correspondenceModelViewFactory.createEditableCorrespondenceModelView(this);
 	}
 
 	override getGenericView() {
 		return new GenericCorrespondenceModelViewImpl(this);
 	}
-	
+
 }


### PR DESCRIPTION
This PR modularizes the specification of concrete correspondence model view types, i.e., different views for the different types of correspondences such as `ReactionsCorrespondence` or `IntegrationCorrespondences`. Before, such views were generically derived and only filtered the access according to the type of correspondence. Additional filtering logic, which can be necessary due to additional information in correspondences (e.g. the `createdByIntegration` flag in `IntegrationCorrespondence`s), which was not accessible and usable before.

Now, a generic factory for creating a view is introduced. It can be instantiated generically, only filtering for the type of correspondence, or can be specialized to return specialized views for the appropriate types.