### PR TITLE
Ignore .polyglot.build.properties Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ xtend-gen/
 
 # Maven
 target/
+.polyglot.build.properties
 
 # Custom
 EvaluationData


### PR DESCRIPTION
The Maven build generates `.polyglot.build.properties` files. They are deleted when the build is done or aborted, but nevertheless, I think it’s better to ignore them, because:

 * they never should be checked in
 * they are annoying when using git during a build