### PR TITLE
Unused Import Removal (Xtend Update)

### DIFF
--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/resources/impl/IntermediateResourceBridgeI.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/resources/impl/IntermediateResourceBridgeI.xtend
@@ -15,8 +15,6 @@ import tools.vitruv.framework.util.datatypes.VURI
 
 import static com.google.common.base.Preconditions.*
 
-import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
-
 // TODO remove once resources are handled by domains
 class IntermediateResourceBridgeI extends IntermediateResourceBridgeImpl {
 

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -32,8 +32,6 @@ import tools.vitruv.framework.userinteraction.UserInteractionListener
 import tools.vitruv.framework.change.interaction.UserInteractionBase
 import tools.vitruv.framework.userinteraction.UserInteractionFactory
 
-import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
-
 class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserver, UserInteractionListener {
 	static Logger logger = Logger.getLogger(ChangePropagatorImpl.getSimpleName())
 	final VitruvDomainRepository metamodelRepository;


### PR DESCRIPTION
Remove import that is unsed because of an update of Xtend already providing the extension method.