### PR TITLE
Fixed missing containment in the UML mockup metamodel

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils.metamodels/metamodels/uml_mockup.ecore
+++ b/bundles/testutils/tools.vitruv.testutils.metamodels/metamodels/uml_mockup.ecore
@@ -20,7 +20,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="classCount" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="attributes" upperBound="-1"
-        eType="#//UAttribute"/>
+        eType="#//UAttribute" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="UNamedElement" abstract="true">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>


### PR DESCRIPTION
Fixed a missing containment in the UML mockup metamodel. The metaclass `UAttribute` was never contained by anything. Fixed this issue by making the reference `attributes` of `UClass` a containment reference.