### PR TITLE
Change Recorder Fix Removal

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
@@ -13,6 +13,7 @@ import tools.vitruv.framework.change.echange.feature.reference.ReplaceSingleValu
 import tools.vitruv.framework.change.echange.feature.reference.RemoveEReference
 import tools.vitruv.framework.change.echange.root.RemoveRootEObject
 import tools.vitruv.framework.change.echange.feature.reference.AdditiveReferenceEChange
+import tools.vitruv.framework.change.echange.root.InsertRootEObject
 
 /**
  * Static utility class for the EChange package and subpackages.
@@ -75,7 +76,7 @@ class EChangeUtil {
 	}
 	
 	public static def dispatch isContainmentRemoval(ReplaceSingleValuedEReference<?,?> change) {
-		return change.affectedFeature.containment && change.oldValue !== null && change.oldValue !== change.newValue;
+		return change.affectedFeature.containment && change.oldValueID !== null && change.oldValueID !== change.newValueID;
 	}
 	
 	public static def dispatch isContainmentRemoval(RemoveEReference<?,?> change) {
@@ -91,10 +92,14 @@ class EChangeUtil {
 	}
 	
 	public static def dispatch isContainmentInsertion(AdditiveReferenceEChange<?,?> change) {
-		return change.affectedFeature.containment && change.newValue !== null;
+		return change.affectedFeature.containment && change.newValueID !== null;
 	}
 	
 	public static def dispatch isContainmentInsertion(RemoveRootEObject<?> change) {
+		return true;
+	}
+	
+	public static def dispatch isContainmentInsertion(InsertRootEObject<?> change) {
 		return true;
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
@@ -77,9 +77,7 @@ class AtomicEmfChangeRecorder {
 	
 	def void removeFromRecording(Notifier elementToObserve) {
 		this.elementsToObserve -= elementToObserve;
-		if (isRecording) {
-			elementToObserve.eAdapters.remove(changeRecorder);
-		}
+		changeRecorder.removeFromRecording(elementToObserve)
 	}
 
 	/** Stops recording without returning a result */

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
@@ -2,6 +2,14 @@ package tools.vitruv.framework.uuid
 
 import org.eclipse.emf.ecore.EObject
 
+/**
+ * A {@link UuidGeneratorAndResolver} assigns {@link Uuid}s to {@link EObject}s and is able to 
+ * resolve the relation in both directions.
+ * It is possible to define a hierarchy of them.
+ * A {@link UuidGeneratorAndResolver} is assigned to a {@link ResourceSet} it is responsible for. 
+ * It registers a notifier on that {@link ResourceSet}, which informs about newly added/loaded {@link Resource}s
+ * and automatically loads the assigned {@link Uuid}s for contained elements from the parent resolver.
+ */
 interface UuidGeneratorAndResolver extends UuidResolver {
 	/**
 	 * Registers an object and returns the generated UUID for it.

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -16,6 +16,9 @@ import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EClass
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil.*
 
+/**
+ * {@link UuidGeneratorAndResolver}
+ */
 class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	static val logger = Logger.getLogger(UuidGeneratorAndResolverImpl)
 	final ResourceSet resourceSet;


### PR DESCRIPTION
This PR fixes a bug that caused only the given element but not its childs to be removed from a change recorder. Like the operation for adding elements to the recorder, removal should be done recursively, which is now properly implemented.
Additionally, the containment identification used by the recorder for creating changes is improved by using element IDs instead of concrete elements to match removals from containments (although this did not lead a problem yet).