### PR TITLE
No identity changes

### DIFF
--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractReactionsExecutor.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractReactionsExecutor.xtend
@@ -39,7 +39,7 @@ abstract class AbstractReactionsExecutor extends AbstractEChangePropagationSpeci
 		ResourceAccess resourceAccess) {
 		LOGGER.trace("Call relevant reactions");
 		for (reaction : reactions) {
-			LOGGER.debug("Calling reaction: " + reaction.class.simpleName + " with change: " + change);
+			LOGGER.trace("Calling reaction: " + reaction.class.simpleName + " with change: " + change);
 			val executionState = new ReactionExecutionState(userInteractor, correspondenceModel, resourceAccess, this);
 			reaction.applyEvent(change, executionState)
 		}

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationToEChangeConverter.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationToEChangeConverter.xtend
@@ -38,6 +38,10 @@ final class NotificationToEChangeConverter {
 			return #[]
 		}
 
+		if (notification.oldValue == notification.newValue) {
+			return #[]
+		}
+
 		switch (notification.getEventType()) {
 			case Notification.SET: {
 				if (notification.isAttributeNotification()) {


### PR DESCRIPTION
It was possible that `EChanges` were created that have an equal `newValue` and `oldValue`, i.e., they do not perform any actual change.
This PR introduces a check that ensure that no such identity changes are created.