### PR TITLE
Separate id log output

### DIFF
--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidCalculatorAndResolverBase.xtend
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidCalculatorAndResolverBase.xtend
@@ -21,7 +21,7 @@ import org.eclipse.emf.ecore.EClass
  * @author Stephan Seifermann
  */
 abstract class TuidCalculatorAndResolverBase implements TuidCalculatorAndResolver {
-	static final Logger LOGGER = Logger.getLogger(TuidCalculatorAndResolverBase.getSimpleName())
+	static final Logger LOGGER = Logger.getLogger(TuidCalculatorAndResolverBase)
 	final String tuidPrefix
 	// TODO MK check whether cachedResourcelessRoots and cachedRoot2KeyMap can be replaced with a
 	// BiMap

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/util/TestUtil.java
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/util/TestUtil.java
@@ -19,8 +19,11 @@ import tools.vitruv.framework.change.processing.ChangePropagationSpecification;
 import tools.vitruv.framework.domains.AbstractVitruvDomain;
 import tools.vitruv.framework.domains.VitruvDomain;
 import tools.vitruv.framework.domains.VitruviusProjectBuilderApplicator;
+import tools.vitruv.framework.tuid.TuidCalculatorAndResolverBase;
+import tools.vitruv.framework.tuid.TuidManager;
 import tools.vitruv.framework.userinteraction.InternalUserInteractor;
 import tools.vitruv.framework.util.VitruviusConstants;
+import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl;
 import tools.vitruv.framework.vsum.InternalVirtualModel;
 import tools.vitruv.framework.vsum.VirtualModel;
 import tools.vitruv.framework.vsum.VirtualModelConfiguration;
@@ -35,6 +38,7 @@ import tools.vitruv.framework.vsum.VirtualModelImpl;
  */
 public final class TestUtil {
 	private static final String VM_ARGUMENT_LOG_OUTPUT_LEVEL = "logOutputLevel";
+	private static final String VM_ARGUMENT_LOG_OUTPUT_ID_INFO = "logOutputIdInfo";
 	private static final String VM_ARGUMENT_TEST_WORKSPACE_PATH = "testWorkspacePath";
 	public static final String SOURCE_FOLDER = "src";
 
@@ -240,8 +244,8 @@ public final class TestUtil {
 	public static void initializeLogger() {
 		Logger.getRootLogger().setLevel(Level.ERROR);
 		Logger.getRootLogger().removeAllAppenders();
-		Logger.getRootLogger()
-				.addAppender(new ConsoleAppender(new PatternLayout("[%-5p] %d{HH:mm:ss,SSS} %-30C{1} - %m%n")));
+		ConsoleAppender appender = new ConsoleAppender(new PatternLayout("[%-5p] %d{HH:mm:ss,SSS} %-30C{1} - %m%n"));
+		Logger.getRootLogger().addAppender(appender);
 		String outputLevelProperty = System.getProperty(VM_ARGUMENT_LOG_OUTPUT_LEVEL);
 		if (outputLevelProperty != null) {
 			if (!Logger.getRootLogger().getAllAppenders().hasMoreElements()) {
@@ -250,6 +254,12 @@ public final class TestUtil {
 			Logger.getRootLogger().setLevel(Level.toLevel(outputLevelProperty));
 		} else {
 			Logger.getRootLogger().setLevel(Level.ERROR);
+		}
+		String outputIdInfoProperty = System.getProperty(VM_ARGUMENT_LOG_OUTPUT_ID_INFO);
+		if (outputIdInfoProperty == null) {
+			Logger.getLogger(TuidManager.class).setLevel(Level.OFF);
+			Logger.getLogger(TuidCalculatorAndResolverBase.class).setLevel(Level.OFF);
+			Logger.getLogger(UuidGeneratorAndResolverImpl.class).setLevel(Level.OFF);
 		}
 	}
 


### PR DESCRIPTION
This PR makes log output of ID-related information (UUID/TUID creation and changes) optional by adding a VM argument that can be passed to enable output. This reduces verbosity of the log output. We do explicitly not use the level structure of log output for this kind of information, as it is not relevant in most cases.