### PR TITLE
Remove MirBase metamodel import validation

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.mirbase.ui/src/tools/vitruv/dsls/mirbase/ui/quickfix/MirBaseQuickfixProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase.ui/src/tools/vitruv/dsls/mirbase/ui/quickfix/MirBaseQuickfixProvider.xtend
@@ -3,7 +3,6 @@
  */
 package tools.vitruv.dsls.mirbase.ui.quickfix
 
-import tools.vitruv.dsls.mirbase.mirBase.MetamodelImport
 import tools.vitruv.dsls.mirbase.validation.MirBaseValidator
 import tools.vitruv.framework.util.bridges.EclipseBridge
 import org.eclipse.xtext.ui.editor.quickfix.Fix
@@ -22,20 +21,6 @@ import org.eclipse.xtext.xbase.ui.quickfix.XbaseQuickfixProvider
  * See https://www.eclipse.org/Xtext/documentation/304_ide_concepts.html#quick-fixes
  */
 class MirBaseQuickfixProvider extends XbaseQuickfixProvider {
-	@Fix(MirBaseValidator.METAMODEL_IMPORT_DEPENDENCY_MISSING)
-	def addMetamodelDependencyToManifest(Issue issue, IssueResolutionAcceptor acceptor) {
-		acceptor.accept(issue, 'Add dependency.', 'Add the dependency.', null) [ element, context |
-			val metamodelImport = element as MetamodelImport
-
-			val contributorName = EclipseBridge.getNameOfContributorOfExtension(
-				"org.eclipse.emf.ecore.generated_package", "uri", metamodelImport.package.nsURI)
-
-			val project = getProject(metamodelImport.eResource)
-			if (!hasDependency(project, contributorName)) {
-				addDependency(project, contributorName)
-			}
-		]
-	}
 	
 	@Fix(MirBaseValidator.DOMAIN_IMPORT_DEPENDENCY_MISSING)
 	def addDomainDependencyToManifest(Issue issue, IssueResolutionAcceptor acceptor) {

--- a/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/validation/MirBaseValidator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase/src/tools/vitruv/dsls/mirbase/validation/MirBaseValidator.xtend
@@ -3,7 +3,6 @@
  */
 package tools.vitruv.dsls.mirbase.validation
 
-import tools.vitruv.dsls.mirbase.mirBase.MetamodelImport
 import tools.vitruv.dsls.mirbase.mirBase.MirBaseFile
 import tools.vitruv.dsls.mirbase.mirBase.MirBasePackage
 import tools.vitruv.framework.util.bridges.EclipseBridge
@@ -20,22 +19,9 @@ import tools.vitruv.framework.domains.VitruvDomainProviderRegistry
  * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#validation
  */
 class MirBaseValidator extends AbstractMirBaseValidator {
-	public static val METAMODEL_IMPORT_DEPENDENCY_MISSING = "metamodelImportDependencyMissing"
 	public static val DOMAIN_IMPORT_DEPENDENCY_MISSING = "domainImportDependencyMissing"
 	public static val VITRUVIUS_DEPENDENCY_MISSING = "vitruviusDependencyMissing"
-	
-	@Check
-	def checkMetamodelImportDependencyMissing(MetamodelImport metamodelImport) {
-		val contributorName = EclipseBridge.getNameOfContributorOfExtension(
-					"org.eclipse.emf.ecore.generated_package",
-					"uri", metamodelImport.package.nsURI)
-					
-		val project = getProject(metamodelImport.eResource)
-		if (!hasDependency(project, contributorName)) {
-			warning('''Dependency to plug-in '«contributorName»' missing.''', metamodelImport, MirBasePackage.Literals.METAMODEL_IMPORT__PACKAGE, METAMODEL_IMPORT_DEPENDENCY_MISSING)
-		}
-	}
-	
+
 	@Check
 	def checkDomainDependency(DomainReference domainReference) {
 		if (!isValidDomainReference(domainReference)) {
@@ -59,9 +45,6 @@ class MirBaseValidator extends AbstractMirBaseValidator {
 			warning('''The resource should be contained in a plug-in project.''', mirBaseFile, null)
 		}
 	}
-	
-	// TODO DW: move to appropriate plugin
-
 	
 	@Check
 	def checkVitruviusDependencies(MirBaseFile mirBaseFile) {


### PR DESCRIPTION
The MirBase metamodel import is not necessary (actually even wrong), because domains are supposed to reexport the metamodel the encapsulate, which makes an expliclt import of metamodels in the application unnecessary.