### PR TITLE
Domain provider registry improvement

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.mirbase.ui/src/tools/vitruv/dsls/mirbase/ui/quickfix/MirBaseQuickfixProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase.ui/src/tools/vitruv/dsls/mirbase/ui/quickfix/MirBaseQuickfixProvider.xtend
@@ -26,14 +26,15 @@ class MirBaseQuickfixProvider extends XbaseQuickfixProvider {
 	def addDomainDependencyToManifest(Issue issue, IssueResolutionAcceptor acceptor) {
 		acceptor.accept(issue, 'Add dependency.', 'Add the dependency.', null) [ element, context |
 			val domainReference = element as DomainReference
-			
-			val domainProvider = VitruvDomainProviderRegistry.getDomainProvider(domainReference.domain);
-			val contributorName = EclipseBridge.getNameOfContributorOfExtension(
-					VitruvDomainProviderRegistry.EXTENSION_POINT_ID,
-					"class", domainProvider.class.name);
-			val project = getProject(domainReference.eResource)
-			if (!hasDependency(project, contributorName)) {
-				addDependency(project, contributorName)
+			if (VitruvDomainProviderRegistry.hasDomainProvider(domainReference.domain)) {
+				val domainProvider = VitruvDomainProviderRegistry.getDomainProvider(domainReference.domain);
+				val contributorName = EclipseBridge.getNameOfContributorOfExtension(
+						VitruvDomainProviderRegistry.EXTENSION_POINT_ID,
+						"class", domainProvider.class.name);
+				val project = getProject(domainReference.eResource)
+				if (!hasDependency(project, contributorName)) {
+					addDependency(project, contributorName)
+				}
 			}
 		]
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageHelper.xtend
@@ -51,7 +51,11 @@ final class ReactionsLanguageHelper {
 	}
 
 	public static def VitruvDomainProvider<?> getProviderForDomain(VitruvDomain domain) {
-		return VitruvDomainProviderRegistry.getDomainProvider(domain.name);
+		return if (VitruvDomainProviderRegistry.hasDomainProvider(domain.name)) {
+			VitruvDomainProviderRegistry.getDomainProvider(domain.name);
+		} else {
+			null;
+		}
 	}
 
 	public static def VitruvDomain getDomainForReference(DomainReference domainReference) {
@@ -59,7 +63,9 @@ final class ReactionsLanguageHelper {
 	}
 
 	public static def VitruvDomainProvider<?> getDomainProviderForReference(DomainReference domainReference) {
-		val referencedDomainProvider = VitruvDomainProviderRegistry.getDomainProvider(domainReference.domain)
+		val referencedDomainProvider = if (VitruvDomainProviderRegistry.hasDomainProvider(domainReference.domain)) {
+			VitruvDomainProviderRegistry.getDomainProvider(domainReference.domain)
+		}
 		if (referencedDomainProvider === null) {
 			throw new IllegalStateException("Given domain reference references no existing domain");
 		}

--- a/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruvDomainProviderRegistry.xtend
+++ b/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruvDomainProviderRegistry.xtend
@@ -66,6 +66,15 @@ class VitruvDomainProviderRegistry {
 	}
 
 	/**
+	 * Returns whether a domain with the given name is registered or not
+	 * 
+	 * @param domainName - the name of the domain to look for
+	 */
+	def static boolean hasDomainProvider(String domainName) {
+		return runtimeRegisteredProviders.containsKey(domainName) || getExtensionPointProviders(domainName).size > 0;
+	}
+
+	/**
 	 * Retrieves the provider for the domain with the given name.
 	 * 
 	 * @param domainName - the name of the domain to retrieve

--- a/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruvDomainProviderRegistry.xtend
+++ b/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruvDomainProviderRegistry.xtend
@@ -96,9 +96,11 @@ class VitruvDomainProviderRegistry {
 	 */
 	def private static Iterable<VitruvDomainProvider<?>> getAllDomainProvidersFromExtensionPoint() {
 		val List<VitruvDomainProvider<?>> domainProvider = new LinkedList<VitruvDomainProvider<?>>();
-		Platform.getExtensionRegistry().getConfigurationElementsFor(EXTENSION_POINT_ID).map [
-			it.createExecutableExtension("class")
-		].forEach[if (it instanceof VitruvDomainProvider<?>) domainProvider.add(it)];
+		if (Platform.running) {
+			Platform.getExtensionRegistry().getConfigurationElementsFor(EXTENSION_POINT_ID).map [
+				it.createExecutableExtension("class")
+			].forEach[if (it instanceof VitruvDomainProvider<?>) domainProvider.add(it)];
+		}
 		return domainProvider
 	}
 }


### PR DESCRIPTION
This PR resolves an issue with the domain provider registry: It retrieves domains providers from an extension point, which only accessible in an Eclipse environment. The PR ensures that the extension point is only accessed in an Eclipse environment and that in any case of access to the registry a check for the existence of a domain is performed previously.