### PR TITLE
Remove reflection for setting command domain

### DIFF
--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelFactory.xtend
@@ -2,11 +2,11 @@ package tools.vitruv.framework.correspondence
 
 import tools.vitruv.framework.tuid.TuidResolver
 import tools.vitruv.framework.uuid.UuidResolver
-import tools.vitruv.framework.util.command.VitruviusRecordingCommandExecutor
 import tools.vitruv.framework.domains.repository.VitruvDomainRepository
 import tools.vitruv.framework.util.datatypes.VURI
 import org.eclipse.emf.ecore.resource.Resource
 import tools.vitruv.framework.correspondence.impl.InternalCorrespondenceModelImpl
+import tools.vitruv.framework.util.command.CommandCreatorAndExecutor
 
 public final class CorrespondenceModelFactory {
 	private static CorrespondenceModelFactory instance;
@@ -21,7 +21,7 @@ public final class CorrespondenceModelFactory {
 		return instance;
 	}
 	
-	public def createCorrespondenceModel(TuidResolver tuidResolver, UuidResolver uuidResolver, VitruviusRecordingCommandExecutor modelCommandExecutor,
+	public def createCorrespondenceModel(TuidResolver tuidResolver, UuidResolver uuidResolver, CommandCreatorAndExecutor modelCommandExecutor,
 		VitruvDomainRepository domainRepository, VURI correspondencesVURI, Resource correspondencesResource) {
 		return new InternalCorrespondenceModelImpl(tuidResolver, uuidResolver, modelCommandExecutor, domainRepository, correspondencesVURI, correspondencesResource);
 	}

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/CommandCreatorAndExecutor.xtend
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/CommandCreatorAndExecutor.xtend
@@ -1,0 +1,8 @@
+package tools.vitruv.framework.util.command
+
+import java.util.concurrent.Callable
+
+interface CommandCreatorAndExecutor {
+	def void executeAsCommand(Callable<Void> command);
+	def VitruviusRecordingCommand createCommand(Callable<Void> command);
+}

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/EMFCommandBridge.java
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/EMFCommandBridge.java
@@ -2,7 +2,6 @@ package tools.vitruv.framework.util.command;
 
 import java.util.concurrent.Callable;
 
-import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 
 public class EMFCommandBridge {

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/EMFCommandBridge.java
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/EMFCommandBridge.java
@@ -10,8 +10,8 @@ public class EMFCommandBridge {
     private EMFCommandBridge() {
     }
    
-    public static VitruviusRecordingCommand createVitruviusRecordingCommand(final Callable<Void> callable) {
-        VitruviusRecordingCommand recordingCommand = new VitruviusRecordingCommand() {
+    public static VitruviusRecordingCommand createVitruviusRecordingCommand(final Callable<Void> callable, TransactionalEditingDomain domain) {
+        VitruviusRecordingCommand recordingCommand = new VitruviusRecordingCommand(domain) {
             @Override
             protected void doExecute() {
                 try {
@@ -24,22 +24,19 @@ public class EMFCommandBridge {
         return recordingCommand;
     }
     
-    public static void executeVitruviusRecordingCommand(final TransactionalEditingDomain domain,
-            final VitruviusRecordingCommand command) {
-        command.setTransactionDomain(domain);
-        executeCommand(domain, command);
+    public static void executeVitruviusRecordingCommand(final VitruviusRecordingCommand command) {
+        executeCommand(command);
         command.rethrowRuntimeExceptionIfExisting();
     }
     
-    private static void executeCommand(TransactionalEditingDomain domain,
-            final Command command) {
-        domain.getCommandStack().execute(command);
+    private static void executeCommand(final VitruviusRecordingCommand command) {
+    	command.executeAndRethrowException();
     }
 
     public static void createAndExecuteVitruviusRecordingCommand(final Callable<Void> callable,
     		final TransactionalEditingDomain domain) {
-        final VitruviusRecordingCommand command = createVitruviusRecordingCommand(callable);
-        executeVitruviusRecordingCommand(domain, command);
+        final VitruviusRecordingCommand command = createVitruviusRecordingCommand(callable, domain);
+        executeVitruviusRecordingCommand(command);
     }
 
 }

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/VitruviusRecordingCommand.java
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/VitruviusRecordingCommand.java
@@ -18,9 +18,11 @@ public abstract class VitruviusRecordingCommand extends RecordingCommand impleme
     protected static final Logger logger = Logger.getLogger(VitruviusRecordingCommand.class.getSimpleName());
 
     private RuntimeException runtimeException;
-
-    public VitruviusRecordingCommand() {
-        super(null);
+    private TransactionalEditingDomain domain;
+    
+    public VitruviusRecordingCommand(TransactionalEditingDomain domain) {
+        super(domain);
+        this.domain = domain;
         this.runtimeException = null;
     }
 
@@ -70,4 +72,10 @@ public abstract class VitruviusRecordingCommand extends RecordingCommand impleme
 
         return affectedEObjects;
     }
+
+    public void executeAndRethrowException() {
+    	domain.getCommandStack().execute(this);
+    	rethrowRuntimeExceptionIfExisting();
+    }
+    
 }

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/VitruviusRecordingCommand.java
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/VitruviusRecordingCommand.java
@@ -26,10 +26,6 @@ public abstract class VitruviusRecordingCommand extends RecordingCommand impleme
         this.runtimeException = null;
     }
 
-    public void setTransactionDomain(final TransactionalEditingDomain domain) {
-        JavaBridge.setFieldInClass(RecordingCommand.class, "domain", this, domain);
-    }
-
     @Override
     protected void preExecute() {
         this.runtimeException = null;

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/VitruviusRecordingCommandExecutor.xtend
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/VitruviusRecordingCommandExecutor.xtend
@@ -1,5 +1,0 @@
-package tools.vitruv.framework.util.command
-
-interface VitruviusRecordingCommandExecutor {
-	def void executeRecordingCommand(VitruviusRecordingCommand command);
-}

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/ModelRepository.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/ModelRepository.xtend
@@ -3,20 +3,15 @@ package tools.vitruv.framework.vsum
 import tools.vitruv.framework.util.datatypes.ModelInstance
 import tools.vitruv.framework.util.datatypes.VURI
 import java.util.function.Consumer
-import java.util.concurrent.Callable
-import tools.vitruv.framework.util.command.VitruviusRecordingCommand
-import tools.vitruv.framework.util.command.VitruviusRecordingCommandExecutor
 import tools.vitruv.framework.change.description.TransactionalChange
 import tools.vitruv.framework.uuid.UuidResolver
 import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.util.command.CommandCreatorAndExecutor
 
-interface ModelRepository extends VitruviusRecordingCommandExecutor, ResourceAccess {
+interface ModelRepository extends CommandCreatorAndExecutor, ResourceAccess {
 	def ModelInstance getModel(VURI modelVuri);
 	def void forceReloadModelIfExisting(VURI modelVuri);
     def void saveAllModels();
-    
-    def void createRecordingCommandAndExecuteCommandOnTransactionalDomain(Callable<Void> callable);
-    def void executeRecordingCommandOnTransactionalDomain(VitruviusRecordingCommand command);
     
     /**
      * Executes the function on the {@link UuidResolver} of the model repository.

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -12,7 +12,6 @@ import tools.vitruv.framework.change.description.VitruviusChange
 import tools.vitruv.framework.change.processing.ChangePropagationSpecification
 import tools.vitruv.framework.change.processing.ChangePropagationSpecificationProvider
 import tools.vitruv.framework.correspondence.CorrespondenceProviding
-import tools.vitruv.framework.util.command.EMFCommandBridge
 import tools.vitruv.framework.domains.repository.VitruvDomainRepository
 import tools.vitruv.framework.change.processing.ChangePropagationObserver
 import tools.vitruv.framework.change.description.PropagatedChange
@@ -244,12 +243,12 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 		// TODO HK: Clone the changes for each synchronization! Should even be cloned for
 		// each consistency repair routines that uses it,
 		// or: make them read only, i.e. give them a read-only interface!
-		val command = EMFCommandBridge.createVitruviusRecordingCommand [
+		val command = resourceRepository.createCommand() [
 			propagationSpecification.propagateChange(change, correspondenceModel, resourceRepository);
 			modelRepository.cleanupRootElements();
 			null
 		]
-		resourceRepository.executeRecordingCommandOnTransactionalDomain(command);
+		command.executeAndRethrowException();
 
 		// Store modification information
 		val changedEObjects = command.getAffectedObjects().filter(EObject)


### PR DESCRIPTION
We have some logic for setting the domain of a `Command` after its creation, although that is not supported by the EMF API. To achieve that, we used reflection for setting a final field. However, since Java 12 this is not supported anymore, so the build fails with JDK 12 and above.
To fix that, we removed the reflection logic and instead properly set the domain when creating the command. Independent from removed Java support for that kind of reflection, this provides better design of the code anyhow.