### PR TITLE
Fix Warnings

### DIFF
--- a/bundles/demo/addressesrecipients/tools.vitruv.demo.domains.addresses/src/tools/vitruv/demo/domains/addresses/AddressesDomainProvider.xtend
+++ b/bundles/demo/addressesrecipients/tools.vitruv.demo.domains.addresses/src/tools/vitruv/demo/domains/addresses/AddressesDomainProvider.xtend
@@ -3,9 +3,9 @@ package tools.vitruv.demo.domains.addresses
 import tools.vitruv.framework.domains.VitruvDomainProvider
 
 class AddressesDomainProvider implements VitruvDomainProvider<AddressesDomain> {
-	private static var AddressesDomain instance;
+	static var AddressesDomain instance;
 	
-	override public AddressesDomain getDomain() {
+	override AddressesDomain getDomain() {
 		if (instance === null) {
 			instance = new AddressesDomain();
 		}

--- a/bundles/demo/addressesrecipients/tools.vitruv.demo.domains.recipients/src/tools/vitruv/demo/domains/recipients/RecipientsDomainProvider.xtend
+++ b/bundles/demo/addressesrecipients/tools.vitruv.demo.domains.recipients/src/tools/vitruv/demo/domains/recipients/RecipientsDomainProvider.xtend
@@ -3,9 +3,9 @@ package tools.vitruv.demo.domains.recipients
 import tools.vitruv.framework.domains.VitruvDomainProvider
 
 class RecipientsDomainProvider implements VitruvDomainProvider<RecipientsDomain> {
-	private static var RecipientsDomain instance;
+	static var RecipientsDomain instance;
 	
-	override public RecipientsDomain getDomain() {
+	override RecipientsDomain getDomain() {
 		if (instance === null) {
 			instance = new RecipientsDomain();
 		}

--- a/bundles/demo/familiespersons/tools.vitruv.demo.domains.families/src/tools/vitruv/domains/families/FamiliesDomain.xtend
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.domains.families/src/tools/vitruv/domains/families/FamiliesDomain.xtend
@@ -7,8 +7,8 @@ import tools.vitruv.domains.emf.builder.VitruviusEmfBuilderApplicator
 import tools.vitruv.framework.domains.AbstractTuidAwareVitruvDomain
 
 class FamiliesDomain extends AbstractTuidAwareVitruvDomain {
-	private static final String METAMODEL_NAME = "Families";
-	private static val FILE_EXTENSION = "families"
+	static final String METAMODEL_NAME = "Families";
+	static val FILE_EXTENSION = "families"
 	public static val NAMESPACE_URIS = FamiliesPackage.eINSTANCE.nsURIsRecursive;
 
 	package new() {

--- a/bundles/demo/familiespersons/tools.vitruv.demo.domains.families/src/tools/vitruv/domains/families/FamiliesDomainProvider.xtend
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.domains.families/src/tools/vitruv/domains/families/FamiliesDomainProvider.xtend
@@ -3,7 +3,7 @@ package tools.vitruv.domains.families
 import tools.vitruv.framework.domains.VitruvDomainProvider
 
 class FamiliesDomainProvider implements VitruvDomainProvider<FamiliesDomain>{
-	private static var FamiliesDomain instance;
+	static var FamiliesDomain instance;
 	override getDomain() {
 		if (instance === null) {
 			instance = new FamiliesDomain();

--- a/bundles/demo/familiespersons/tools.vitruv.demo.domains.insurance/src/tools/vitruv/domains/insurance/InsuranceDomain.xtend
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.domains.insurance/src/tools/vitruv/domains/insurance/InsuranceDomain.xtend
@@ -7,8 +7,8 @@ import edu.kit.ipd.sdq.metamodels.insurance.InsurancePackage
 import tools.vitruv.domains.insurance.tuid.InsuranceTuidCalculatorAndResolver
 
 class InsuranceDomain extends AbstractTuidAwareVitruvDomain {
-	private static final String METAMODEL_NAME = "Insurance";
-	private static val FILE_EXTENSION = "insurance"
+	static final String METAMODEL_NAME = "Insurance";
+	static val FILE_EXTENSION = "insurance"
 	public static val NAMESPACE_URIS = InsurancePackage.eINSTANCE.nsURIsRecursive;
 
 	package new() {

--- a/bundles/demo/familiespersons/tools.vitruv.demo.domains.insurance/src/tools/vitruv/domains/insurance/InsuranceDomainProvider.xtend
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.domains.insurance/src/tools/vitruv/domains/insurance/InsuranceDomainProvider.xtend
@@ -3,7 +3,7 @@ package tools.vitruv.domains.insurance
 import tools.vitruv.framework.domains.VitruvDomainProvider
 
 class InsuranceDomainProvider implements VitruvDomainProvider<InsuranceDomain>{
-	private static var InsuranceDomain instance;
+	static var InsuranceDomain instance;
 	
 	override getDomain() {
 		if (instance === null) {

--- a/bundles/demo/familiespersons/tools.vitruv.demo.domains.persons/src/tools/vitruv/domains/persons/PersonsDomain.xtend
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.domains.persons/src/tools/vitruv/domains/persons/PersonsDomain.xtend
@@ -7,8 +7,8 @@ import tools.vitruv.domains.persons.tuid.PersonsTuidCalculatorAndResolver
 import tools.vitruv.domains.emf.builder.VitruviusEmfBuilderApplicator
 
 class PersonsDomain extends  AbstractTuidAwareVitruvDomain {
-	private static final String METAMODEL_NAME = "Persons";
-	private static final String FILE_EXTENSION = "persons";
+	static final String METAMODEL_NAME = "Persons";
+	static final String FILE_EXTENSION = "persons";
 	public static val NAMESPACE_URIS = PersonsPackage.eINSTANCE.nsURIsRecursive;
 
 	package new() {

--- a/bundles/demo/familiespersons/tools.vitruv.demo.domains.persons/src/tools/vitruv/domains/persons/PersonsDomainProvider.xtend
+++ b/bundles/demo/familiespersons/tools.vitruv.demo.domains.persons/src/tools/vitruv/domains/persons/PersonsDomainProvider.xtend
@@ -3,7 +3,7 @@ package tools.vitruv.domains.persons
 import tools.vitruv.framework.domains.VitruvDomainProvider
 
 class PersonsDomainProvider implements VitruvDomainProvider<PersonsDomain>{
-	private static var PersonsDomain instance;
+	static var PersonsDomain instance;
 	
 	override getDomain() {
 		if (instance === null) {

--- a/bundles/dsls/tools.vitruv.dsls.common/src/tools/vitruv/dsls/common/helper/JavaImportHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.common/src/tools/vitruv/dsls/common/helper/JavaImportHelper.xtend
@@ -6,11 +6,11 @@ import org.eclipse.emf.ecore.EClassifier
 
 class JavaImportHelper {
 	public static final char FQN_SEPARATOR = '.';
-	private static val NO_IMPORT_NEEDED = Collections.singleton('java.lang')
-	private val Map<String, String> imports = newHashMap
-	private val Map<String, String> staticImports = newHashMap
+	static val NO_IMPORT_NEEDED = Collections.singleton('java.lang')
+	val Map<String, String> imports = newHashMap
+	val Map<String, String> staticImports = newHashMap
 
-	public def generateImportCode() '''
+	def generateImportCode() '''
 		«FOR i : imports.values»
 			import «i»;
 		«ENDFOR»
@@ -19,7 +19,7 @@ class JavaImportHelper {
 		«ENDFOR»
 	'''
 
-	public def staticRef(Class<?> javaClass, String methodName) {
+	def staticRef(Class<?> javaClass, String methodName) {
 		if (!staticImports.containsKey(methodName)) {
 			staticImports.put(methodName, javaClass.name)
 			return methodName;
@@ -28,19 +28,19 @@ class JavaImportHelper {
 		return javaClass.name + FQN_SEPARATOR + methodName;
 	}
 	
-	public def typeRef(ClassNameGenerator nameGenerator) {
+	def typeRef(ClassNameGenerator nameGenerator) {
 		typeRef(nameGenerator.qualifiedName)
 	}
 
-	public def typeRef(Class<?> javaClass) {
+	def typeRef(Class<?> javaClass) {
 		typeRef(javaClass.name)
 	}
 
-	public def typeRef(EClassifier eClassifier) {
+	def typeRef(EClassifier eClassifier) {
 		typeRef(eClassifier.instanceTypeName)
 	}
 
-	public def typeRef(CharSequence fullyQualifiedJVMName) {
+	def typeRef(CharSequence fullyQualifiedJVMName) {
 		val fullyQualifiedJVMNameString = fullyQualifiedJVMName.toString
 		if (fullyQualifiedJVMNameString.isSimpleName)
 			return fullyQualifiedJVMNameString

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/conversion/CommonalitiesLanguageValueConverterService.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/conversion/CommonalitiesLanguageValueConverterService.xtend
@@ -14,22 +14,22 @@ class CommonalitiesLanguageValueConverterService extends XbaseValueConverterServ
 	@Inject QualifiedClassValueConverter qualifiedClassValueConverter
 
 	@ValueConverter(rule = "DomainName")
-	public def IValueConverter<String> getDomainNameConverter() {
+	def IValueConverter<String> getDomainNameConverter() {
 		return validIDConverter
 	}
 
 	@ValueConverter(rule = "UnqualifiedClass")
-	public def IValueConverter<String> getUnqualifiedClassConverter() {
+	def IValueConverter<String> getUnqualifiedClassConverter() {
 		return validIDConverter
 	}
 
 	@ValueConverter(rule = "QualifiedClass")
-	public def IValueConverter<String> getQualifiedClassConverter() {
+	def IValueConverter<String> getQualifiedClassConverter() {
 		return qualifiedClassValueConverter
 	}
 
 	@ValueConverter(rule = "UnqualifiedAttribute")
-	public def IValueConverter<String> getUnqualifiedAttributeConverter() {
+	def IValueConverter<String> getUnqualifiedAttributeConverter() {
 		return validIDConverter
 	}
 }

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/ReactionsGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/ReactionsGenerator.xtend
@@ -27,7 +27,7 @@ import static extension tools.vitruv.dsls.commonalities.language.extensions.Comm
  */
 class ReactionsGenerator extends SubGenerator {
 
-	private static val Logger logger = Logger.getLogger(ReactionsGenerator)
+	static val Logger logger = Logger.getLogger(ReactionsGenerator)
 
 	@Inject IGlobalServiceProvider globalServiceProvider
 	@Inject Provider<IReactionsGenerator> reactionsGeneratorProvider

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/ReactionsGeneratorConventions.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/ReactionsGeneratorConventions.xtend
@@ -28,7 +28,7 @@ class ReactionsGeneratorConventions {
 	public static val RESOURCE_BRIDGE = 'resourceBridge'
 	public static val SINGLETON = 'singleton'
 
-	private static val EXTERNAL_CLASS_PREFIX = 'external_'
+	static val EXTERNAL_CLASS_PREFIX = 'external_'
 
 	static def String getName(ContextClass contextClass) {
 		val participationClass = contextClass.participationClass

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/attribute/AttributeMappingOperatorHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/attribute/AttributeMappingOperatorHelper.xtend
@@ -21,7 +21,7 @@ import static extension tools.vitruv.dsls.commonalities.language.extensions.Comm
 
 class AttributeMappingOperatorHelper extends ReactionsGenerationHelper {
 
-	public static class AttributeMappingOperatorContext implements OperatorContext {
+	static class AttributeMappingOperatorContext implements OperatorContext {
 
 		val extension TypeProvider typeProvider
 		val Supplier<XExpression> intermediate

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/condition/ParticipationConditionOperatorHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/condition/ParticipationConditionOperatorHelper.xtend
@@ -20,7 +20,7 @@ import static extension tools.vitruv.dsls.commonalities.generator.reactions.util
 
 class ParticipationConditionOperatorHelper extends ReactionsGenerationHelper {
 
-	public static class ParticipationConditionOperatorContext implements OperatorContext {
+	static class ParticipationConditionOperatorContext implements OperatorContext {
 
 		val extension TypeProvider typeProvider
 

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/matching/MatchParticipationReactionsBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/matching/MatchParticipationReactionsBuilder.xtend
@@ -19,7 +19,7 @@ import static extension tools.vitruv.dsls.commonalities.participation.Participat
  */
 class MatchParticipationReactionsBuilder extends ReactionsSubGenerator {
 
-	private static val Logger logger = Logger.getLogger(MatchParticipationReactionsBuilder)
+	static val Logger logger = Logger.getLogger(MatchParticipationReactionsBuilder)
 
 	static class Factory extends InjectingFactoryBase {
 		def createFor(Participation participation) {

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/matching/ParticipationMatchingReactionsBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/matching/ParticipationMatchingReactionsBuilder.xtend
@@ -143,7 +143,7 @@ import static extension tools.vitruv.dsls.commonalities.language.extensions.Comm
  */
 class ParticipationMatchingReactionsBuilder extends ReactionsGenerationHelper {
 
-	private static val Logger logger = Logger.getLogger(ParticipationMatchingReactionsBuilder)
+	static val Logger logger = Logger.getLogger(ParticipationMatchingReactionsBuilder)
 
 	static class Provider extends ReactionsSegmentScopedProvider<ParticipationMatchingReactionsBuilder> {
 		protected override createFor(FluentReactionsSegmentBuilder segment) {

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/operator/OperatorContext.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/operator/OperatorContext.xtend
@@ -5,7 +5,7 @@ import tools.vitruv.dsls.commonalities.language.ParticipationClass
 import tools.vitruv.dsls.reactions.builder.TypeProvider
 import tools.vitruv.extensions.dslruntime.commonalities.operators.AttributeOperand
 
-public interface OperatorContext {
+interface OperatorContext {
 
 	/**
 	 * Gets the {@link TypeProvider}.

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/reference/ReferenceMappingOperatorHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/reference/ReferenceMappingOperatorHelper.xtend
@@ -23,7 +23,7 @@ import static extension tools.vitruv.dsls.commonalities.language.extensions.Comm
 
 class ReferenceMappingOperatorHelper extends ReactionsGenerationHelper {
 
-	public static class ReferenceMappingOperatorContext implements OperatorContext {
+	static class ReferenceMappingOperatorContext implements OperatorContext {
 
 		val extension TypeProvider typeProvider
 

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/util/JvmTypeProviderHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/util/JvmTypeProviderHelper.xtend
@@ -279,7 +279,7 @@ class JvmTypeProviderHelper {
 	}
 }
 
-public class NoSuchJvmElementException extends IllegalStateException {
+class NoSuchJvmElementException extends IllegalStateException {
 
 	new(String message) {
 		super(message)

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/util/EMFJavaTypesUtil.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/util/EMFJavaTypesUtil.xtend
@@ -12,7 +12,7 @@ class EMFJavaTypesUtil {
 	 * the classifier of the corresponding wrapper type instead. Otherwise we
 	 * return the given classifier without changes.
 	 */
-	public static def EClassifier wrapJavaPrimitiveTypes(EClassifier eClassifier) {
+	static def EClassifier wrapJavaPrimitiveTypes(EClassifier eClassifier) {
 		if (eClassifier === null) return null
 		// We check the instance class rather than the EClassifier itself,
 		// since it is theoretically possible to create new EDataTypes which

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/GenerateMappingsLanguage.mwe2
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/GenerateMappingsLanguage.mwe2
@@ -76,7 +76,7 @@ Workflow {
 		language = StandardLanguage {			
 			name = qualifiedLanguageName
 			fileExtensions = fileExtension
-			junitSupport = junit.Junit4Fragment2 {
+			junitSupport = junit.JUnitFragment {
 				generateStub = false
 			}
 			referencedResource = "platform:/resource/tools.vitruv.dsls.mirbase/model/generated/MirBase.genmodel"

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/MappingsLanguageRuntimeModule.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/MappingsLanguageRuntimeModule.xtend
@@ -25,13 +25,13 @@ class MappingsLanguageRuntimeModule extends AbstractMappingsLanguageRuntimeModul
 		MappingsLanguageGenerator
 	}
 	
-	public override void configureIScopeProviderDelegate(Binder binder) {
+	override void configureIScopeProviderDelegate(Binder binder) {
 		binder.bind(IScopeProvider)
 		      .annotatedWith(Names.named(AbstractDeclarativeScopeProvider.NAMED_DELEGATE))
 		      .to(MappingsLanguageScopeProviderDelegate);
 	}
 	
-	public override Class<? extends IQualifiedNameConverter> bindIQualifiedNameConverter() {
+	override Class<? extends IQualifiedNameConverter> bindIQualifiedNameConverter() {
 		return MirBaseQualifiedNameConverter;
 	}
 	
@@ -39,7 +39,7 @@ class MappingsLanguageRuntimeModule extends AbstractMappingsLanguageRuntimeModul
 		return ReactionsLanguageGlobalScopeProvider;
 	}
 	
-	public override Class<? extends ILinkingService> bindILinkingService() {
+	override Class<? extends ILinkingService> bindILinkingService() {
 		return ReactionsLinkingService;
 	}
 }

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/conditions/MappingParameterGraphTraverser.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/conditions/MappingParameterGraphTraverser.xtend
@@ -64,7 +64,7 @@ class MappingParameterGraphTraverser {
 	/**
 	 * Returns a path between two nodes in the graph
 	 */
-	public def findPath(String from, String to) {
+	def findPath(String from, String to) {
 		val fromNode = nodes.get(from)
 		val toNode = nodes.get(to)
 		fromNode.findPath(toNode, new NodePath(fromNode))
@@ -74,7 +74,7 @@ class MappingParameterGraphTraverser {
 	 * Finds the shortest path between a list of start nodes to a target node.
 	 * The returned path starts from one of the start nodes and ends at the target node.
 	 */
-	public def findPath(List<String> startPoints, String to) {
+	def findPath(List<String> startPoints, String to) {
 		startPoints.map[it.findPath(to)].minBy[it.steps.size]
 	}
 
@@ -82,7 +82,7 @@ class MappingParameterGraphTraverser {
 	 * Returns a path with one step from a list of start nodes. The target node is of the remaining
 	 * nodes in the graph without the starting nodes. 
 	 */
-	public def findStepToNextNode(List<String> startPoints) {
+	def findStepToNextNode(List<String> startPoints) {
 		val remainingNodes = nodes.keySet.filter[!startPoints.contains(it)]
 		if(remainingNodes.empty){
 			throw new IllegalStateException('Can not find step to next node, because all nodes are visited already!')
@@ -98,16 +98,16 @@ class MappingParameterGraphTraverser {
 	/**
 	 * Returns a node by its key
 	 */
-	public def getNode(String parameter) {
+	def getNode(String parameter) {
 		return nodes.get(parameter)
 	}
 
-	public static class Node {
-		private List<Node> parents = new ArrayList
+	static class Node {
+		List<Node> parents = new ArrayList
 		@Accessors(PUBLIC_GETTER)
-		private List<ChildNode> children = new ArrayList
+		List<ChildNode> children = new ArrayList
 		@Accessors(PUBLIC_GETTER)
-		private String parameter
+		String parameter
 
 		new(String parameter) {
 			this.parameter = parameter
@@ -116,7 +116,7 @@ class MappingParameterGraphTraverser {
 		/**
 		 * Adds a parent node
 		 */
-		public def addParent(Node parent) {
+		def addParent(Node parent) {
 			if (!parents.contains(parent)) {
 				parents += parent
 				containmentCheck
@@ -139,21 +139,21 @@ class MappingParameterGraphTraverser {
 		/**
 		 * Returns a child node by its parameter
 		 */
-		public def getChild(String childParameter) {
+		def getChild(String childParameter) {
 			children.findFirst[node.parameter == childParameter]
 		}
 		
 		/**
 		 * Adds a child node
 		 */
-		public def addChild(Node child, EReference inFeature) {
+		def addChild(Node child, EReference inFeature) {
 			this.children += new ChildNode(child, inFeature)
 		}
 		
 		/**
 		 * Checks for cycles in the graph. If a cycle is found, an exception will be thrown
 		 */
-		public def void cycleCheck(List<Node> visitedNodes) throws IllegalStateException{
+		def void cycleCheck(List<Node> visitedNodes) throws IllegalStateException{
 			if (parents.empty) {
 				// top level node
 				return
@@ -173,7 +173,7 @@ class MappingParameterGraphTraverser {
 		 * Returns the count of other nodes in the graph that can be reached from this node,
 		 * provided a list of already reached nodes.
 		 */
-		public def int reachableNodesCount(List<Node> discoveredNodes) {
+		def int reachableNodesCount(List<Node> discoveredNodes) {
 			if (!discoveredNodes.contains(this)) {
 				discoveredNodes += this
 			}
@@ -197,7 +197,7 @@ class MappingParameterGraphTraverser {
 		/**
 		 * Finds a path from this node to a target node
 		 */
-		public def NodePath findPath(Node node, NodePath path) {
+		def NodePath findPath(Node node, NodePath path) {
 			if (this == node) {
 				// found node
 				return path
@@ -233,11 +233,11 @@ class MappingParameterGraphTraverser {
 
 	}
 
-	public static class ChildNode {
+	static class ChildNode {
 		@Accessors(PUBLIC_GETTER)
-		private Node node
+		Node node
 		@Accessors(PUBLIC_GETTER)
-		private EReference inFeature
+		EReference inFeature
 
 		new(Node node, EReference inFeature) {
 			this.node = node
@@ -245,10 +245,10 @@ class MappingParameterGraphTraverser {
 		}
 	}
 
-	public static class NodePath {
-		private Node startNode
+	static class NodePath {
+		Node startNode
 		@Accessors(PUBLIC_GETTER)
-		private List<TraverseStep> steps = new ArrayList
+		List<TraverseStep> steps = new ArrayList
 
 		new(Node startNode) {
 			this.startNode = startNode
@@ -257,7 +257,7 @@ class MappingParameterGraphTraverser {
 		/**
 		 * Returns the start node name
 		 */
-		public def getStartNode() {
+		def getStartNode() {
 			startNode.parameter
 		}
 
@@ -272,7 +272,7 @@ class MappingParameterGraphTraverser {
 		}
 	}
 
-	public abstract static class TraverseStep {
+	abstract static class TraverseStep {
 		@Accessors(PUBLIC_GETTER)
 		protected EReference feature
 		protected Node to
@@ -285,12 +285,12 @@ class MappingParameterGraphTraverser {
 		/**
 		 * Returns the feature name of the edge traversed in this step
 		 */
-		public def getParameter() {
+		def getParameter() {
 			return to.parameter
 		}
 	}
 
-	public static class TraverseStepDown extends TraverseStep {
+	static class TraverseStepDown extends TraverseStep {
 
 		new(ChildNode to) {
 			super(to.node, to.inFeature)
@@ -302,7 +302,7 @@ class MappingParameterGraphTraverser {
 		}
 	}
 
-	public static class TraverseStepUp extends TraverseStep {
+	static class TraverseStepUp extends TraverseStep {
 		new(Node to, EReference feature) {
 			super(to, feature)
 		}

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/conditions/impl/BidirectionalMappingRoutineGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/conditions/impl/BidirectionalMappingRoutineGenerator.xtend
@@ -68,7 +68,7 @@ class BidirectionalMappingRoutineGenerator implements AbstractBidirectionalCondi
 		]
 	}
 
-	public def integrateRoutine(MappingGeneratorContext context) {
+	def integrateRoutine(MappingGeneratorContext context) {
 		var generatedRoutine = AbstractReactionIntegrationGenerator.generateRoutine(routine)
 		targetRoutineBuilder = context.create.from(generatedRoutine)
 		context.getSegmentBuilder += targetRoutineBuilder

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/conditions/impl/InValueConditionGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/conditions/impl/InValueConditionGenerator.xtend
@@ -27,21 +27,21 @@ class InValueConditionGenerator extends MultiValueConditionGenerator {
 	/**
 	 * Returns the child parameter of this  in-value condition
 	 */
-	public def getChildParameter() {
+	def getChildParameter() {
 		featureCondition.leftMappingParameter
 	}
 
 	/**
 	 * Returns the parent parameter of this  in-value condition
 	 */
-	public def getParentParameter() {
+	def getParentParameter() {
 		featureCondition.feature.parameter
 	}
 
 	/**
 	 * Returns the feature of this  in-value condition
 	 */
-	public def getInFeature() {
+	def getInFeature() {
 		featureCondition.feature.feature
 	}
 

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/integration/AbstractReactionIntegrationGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/integration/AbstractReactionIntegrationGenerator.xtend
@@ -58,7 +58,7 @@ abstract class AbstractReactionIntegrationGenerator implements IReactionIntegrat
 	/**
 	 * Creates a reaction from an integrated reaction specification
 	 */
-	public static def generateReaction(ReactionIntegration reactionIntegration) {
+	static def generateReaction(ReactionIntegration reactionIntegration) {
 		val reaction = ReactionsLanguageFactory.eINSTANCE.createReaction
 		reaction.callRoutine = EcoreUtil.copy(reactionIntegration.callRoutine)
 		reaction.documentation = reactionIntegration.documentation
@@ -70,7 +70,7 @@ abstract class AbstractReactionIntegrationGenerator implements IReactionIntegrat
 	/**
 	 * Creates a routine from an integrated routine specification
 	 */
-	public static def generateRoutine(RoutineIntegration routineIntegration) {
+	static def generateRoutine(RoutineIntegration routineIntegration) {
 		val routine = ReactionsLanguageFactory.eINSTANCE.createRoutine
 		routine.name = routineIntegration.name
 		routine.input = EcoreUtil.copy(routineIntegration.input)

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/reactions/AbstractReactionTriggerGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/reactions/AbstractReactionTriggerGenerator.xtend
@@ -29,14 +29,14 @@ abstract class AbstractReactionTriggerGenerator extends AbstractMappingEntityGen
 	}
 	
 	//should only be called for triggers derived from bidirectional conditions
-	def public overwriteScenarioType(MappingScenarioType scenarioType){
+	def overwriteScenarioType(MappingScenarioType scenarioType){
 		this.scenarioType = scenarioType
 	}
 	
 	/**
 	 * Returns the name of the reaction to generate
 	 */
-	def public String reactionName() '''
+	def String reactionName() '''
 	On«mappingName.toFirstUpper»«reactionName»«IF scenarioType==MappingScenarioType.UPDATE»Bidirectional«ENDIF»'''
 	
 	/**

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/routines/MappingParameterRetrievalGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/routines/MappingParameterRetrievalGenerator.xtend
@@ -31,7 +31,7 @@ class MappingParameterRetrievalGenerator extends AbstractRoutineContentGenerator
 			map[parameterName], [it.parameterName])
 	}
 	
-	public def generate(TypeProvider provider, Function0<XExpression> finishedRetrievingParameters,
+	def generate(TypeProvider provider, Function0<XExpression> finishedRetrievingParameters,
 		Function0<XExpression> failedToRetrieveParameters) {
 		this.finishedRetrievingParameters = finishedRetrievingParameters
 		XbaseFactory.eINSTANCE.createXBlockExpression => [
@@ -270,7 +270,7 @@ class MappingParameterRetrievalGenerator extends AbstractRoutineContentGenerator
 		}
 	}
 
-	public def skipParameterCheck() {
+	def skipParameterCheck() {
 		parameters.size == 1 && conditions.empty
 	}
 

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/routines/MappingRoutineStorage.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/routines/MappingRoutineStorage.xtend
@@ -30,7 +30,7 @@ class MappingRoutineStorage {
 	/**
 	 * Initializes the fields 
 	 */
-	public def init(String mappingName, MappingGeneratorContext context,
+	def init(String mappingName, MappingGeneratorContext context,
 		List<AbstractSingleSidedCondition<?>> singleSidedConditions,
 		List<AbstractSingleSidedCondition<?>> correspondingSingleSidedConditions,
 		List<AbstractBidirectionalCondition> bidirectionalConditions) {
@@ -44,7 +44,7 @@ class MappingRoutineStorage {
 	/**
 	 * Generates a routine from a routine generator
 	 */
-	public def generateRoutine(AbstractMappingRoutineGenerator generator) {
+	def generateRoutine(AbstractMappingRoutineGenerator generator) {
 		logger.info('''=> generate routine: «generator.toString»''')
 		generator.init(mappingName, fromParameters, toParameters)
 		generator.prepareGenerator(singleSidedConditions, correspondingSingleSidedConditions, bidirectionalConditions,
@@ -57,14 +57,14 @@ class MappingRoutineStorage {
 	/**
 	 * Returns a routine generator by the class
 	 */
-	public def getRoutine(Class<? extends AbstractMappingRoutineGenerator> key) {
+	def getRoutine(Class<? extends AbstractMappingRoutineGenerator> key) {
 		routineGenerators.get(key)
 	}
 
 	/**
 	 * Returns a FluentRoutineBuilder used within a routine generator by the class
 	 */
-	public def getRoutineBuilder(Class<? extends AbstractMappingRoutineGenerator> key) {
+	def getRoutineBuilder(Class<? extends AbstractMappingRoutineGenerator> key) {
 		routineGenerators.get(key).routine
 	}
 }

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/routines/MappingRoutinesGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/routines/MappingRoutinesGenerator.xtend
@@ -30,7 +30,7 @@ class MappingRoutinesGenerator {
 	/**
 	 * Generates the routines for a mapping specification
 	 */
-	public def generateRoutines(String mappingName, MappingGeneratorContext context,
+	def generateRoutines(String mappingName, MappingGeneratorContext context,
 		List<AbstractSingleSidedCondition<?>> singleSidedConditions,
 		List<AbstractSingleSidedCondition<?>> correspondingSingleSidedConditions,
 		List<AbstractBidirectionalCondition> bidirectionalConditions) {
@@ -49,7 +49,7 @@ class MappingRoutinesGenerator {
 	/**
 	 * Connects a reaction trigger with a generated routine by creating a routine-call
 	 */
-	public def generateRoutineCall(PreconditionOrRoutineCallBuilder reactionBuilder,
+	def generateRoutineCall(PreconditionOrRoutineCallBuilder reactionBuilder,
 		AbstractReactionTriggerGenerator generator) {
 		switch (generator.getScenarioType) {
 			case CREATE:

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/utils/ParameterCorrespondenceTagging.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/utils/ParameterCorrespondenceTagging.xtend
@@ -11,14 +11,14 @@ class ParameterCorrespondenceTagging {
 	/**
 	 * Sets the current generator context
 	 */
-	public static def setContext(MappingGeneratorContext context) {
+	static def setContext(MappingGeneratorContext context) {
 		ParameterCorrespondenceTagging.context = context
 	}
 
 	/**
 	 * Returns the correspondence tag between two mapping parameters
 	 */
-	public static def String getCorrespondenceTag(MappingParameter reactionParameter,
+	static def String getCorrespondenceTag(MappingParameter reactionParameter,
 		MappingParameter correspondingParameter) {
 		if (!context.left2right) {
 			return createCorrespondenceTag(correspondingParameter.value, reactionParameter.value)

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/utils/XBaseMethodFinder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/utils/XBaseMethodFinder.xtend
@@ -15,45 +15,45 @@ class XBaseMethodFinder {
 	val static String PACKAGE_BOOLEAN = 'org.eclipse.xtext.xbase.lib.BooleanExtensions'
 	val static String PACKAGE_ITERATOR = 'org.eclipse.xtext.xbase.lib.IteratorExtensions'
 
-	public static def optionalIsPresent(TypeProvider typeProvider) {
+	static def optionalIsPresent(TypeProvider typeProvider) {
 		typeProvider.findXbaseMethod(PACKAGE_OPTIONAL, 'isPresent')
 	}
 
-	public static def optionalGet(TypeProvider typeProvider) {
+	static def optionalGet(TypeProvider typeProvider) {
 		typeProvider.findXbaseMethod(PACKAGE_OPTIONAL, 'get')
 	}
 
 	// should find the correct filter method because it is listed first in the class
-	public static def listFilter(TypeProvider typeProvider) {
+	static def listFilter(TypeProvider typeProvider) {
 		typeProvider.findXbaseMethod(PACKAGE_ITERATOR, 'filter')
 	}
 	
-	public static def listContains(TypeProvider typeProvider) {
+	static def listContains(TypeProvider typeProvider) {
 		typeProvider.findXbaseMethod(PACKAGE_LIST, 'contains')
 	}
 
 	// should find first add
-	public static def collectionAdd(TypeProvider typeProvider) {
+	static def collectionAdd(TypeProvider typeProvider) {
 		typeProvider.findXbaseMethod(PACKAGE_LIST, 'add')
 	}
 
-	public static def and(TypeProvider typeProvider) {
+	static def and(TypeProvider typeProvider) {
 		typeProvider.findXbaseMethod(PACKAGE_BOOLEAN, 'operator_and')
 	}
 
-	public static def or(TypeProvider typeProvider) {
+	static def or(TypeProvider typeProvider) {
 		typeProvider.findXbaseMethod(PACKAGE_BOOLEAN, 'operator_or')
 	}
 
-	public static def tripleEquals(TypeProvider typeProvider) {
+	static def tripleEquals(TypeProvider typeProvider) {
 		typeProvider.findXbaseMethod(PACKAGE_OBJECT, 'operator_tripleEquals')
 	}
 
-	public static def tripleNotEquals(TypeProvider typeProvider) {
+	static def tripleNotEquals(TypeProvider typeProvider) {
 		typeProvider.findXbaseMethod(PACKAGE_OBJECT, 'operator_tripleNotEquals')
 	}
 
-	public static def findXbaseMethod(TypeProvider typeProvider, String pkg, String method) {
+	static def findXbaseMethod(TypeProvider typeProvider, String pkg, String method) {
 		val member = (typeProvider.findTypeByName(pkg) as JvmDeclaredType).members.findFirst [
 			it.simpleName == method
 		]
@@ -63,13 +63,13 @@ class XBaseMethodFinder {
 		member
 	}
 
-	public static def findMetaclassMethodGetter(TypeProvider typeProvider, EClass metaclass,
+	static def findMetaclassMethodGetter(TypeProvider typeProvider, EClass metaclass,
 		EStructuralFeature feature) throws MethodNotFoundException {
 		val name = '''get«feature.name.toFirstUpper»'''
 		typeProvider.findMetaclassMethodCandidate(metaclass, name, feature.many)
 	}
 
-	public static def findMetaclassMethodSetter(TypeProvider typeProvider, EClass metaclass,
+	static def findMetaclassMethodSetter(TypeProvider typeProvider, EClass metaclass,
 		EStructuralFeature feature) throws MethodNotFoundException {
 		val name = '''set«feature.name.toFirstUpper»'''
 		typeProvider.findMetaclassMethodCandidate(metaclass, name, feature.many)
@@ -87,12 +87,12 @@ class XBaseMethodFinder {
 		typeProvider.findMetaclassMethod(metaclass, method)
 	}
 
-	public static def findMetaclassMethodGetter(TypeProvider typeProvider,
+	static def findMetaclassMethodGetter(TypeProvider typeProvider,
 		MetaclassFeatureReference ref) throws MethodNotFoundException {
 		typeProvider.findMetaclassMethodGetter(ref.metaclass, ref.feature)
 	}
 
-	public static def findMetaclassMethod(TypeProvider typeProvider, EClass metaclass,
+	static def findMetaclassMethod(TypeProvider typeProvider, EClass metaclass,
 		String method) throws MethodNotFoundException {
 		val package = metaclass.instanceTypeName
 		val type = typeProvider.findTypeByName(package) as JvmDeclaredType

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/utils/XBaseMethodUtils.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/utils/XBaseMethodUtils.xtend
@@ -11,7 +11,7 @@ import static extension tools.vitruv.dsls.mappings.generator.utils.XBaseMethodFi
 
 class XBaseMethodUtils {
 
-	public static def binaryOperationChain(TypeProvider provider,JvmIdentifiableElement operation, XExpression... expressions) {
+	static def binaryOperationChain(TypeProvider provider,JvmIdentifiableElement operation, XExpression... expressions) {
 		if (expressions.empty) {
 			return XbaseFactory.eINSTANCE.createXBooleanLiteral => [
 				isTrue = true
@@ -28,24 +28,24 @@ class XBaseMethodUtils {
 		return leftExpression
 	}
 	
-	public static def andChain(TypeProvider provider, XExpression... expressions) {
+	static def andChain(TypeProvider provider, XExpression... expressions) {
 		provider.binaryOperationChain(provider.and, expressions)
 	}
 	
-	public static def orChain(TypeProvider provider, XExpression... expressions) {
+	static def orChain(TypeProvider provider, XExpression... expressions) {
 		provider.binaryOperationChain(provider.or, expressions)
 	}
 
-	public static def findTypeReference(TypeProvider provider, MappingParameter parameter) {
+	static def findTypeReference(TypeProvider provider, MappingParameter parameter) {
 		provider.jvmTypeReferenceBuilder.typeRef(provider.findType(parameter))
 	}
 
-	public static def findType(TypeProvider provider, MappingParameter parameter) {
+	static def findType(TypeProvider provider, MappingParameter parameter) {
 		val package = parameter.value.metaclass.instanceTypeName
 		provider.findTypeByName(package) as JvmDeclaredType
 	}
 
-	public static def optionalNotEmpty(TypeProvider provider, XExpression variable) {
+	static def optionalNotEmpty(TypeProvider provider, XExpression variable) {
 		XbaseFactory.eINSTANCE.createXMemberFeatureCall => [
 			explicitOperationCall = true
 			memberCallTarget = variable
@@ -53,7 +53,7 @@ class XBaseMethodUtils {
 		]
 	}
 
-	public static def optionalGet(TypeProvider provider, XExpression variable) {
+	static def optionalGet(TypeProvider provider, XExpression variable) {
 		XbaseFactory.eINSTANCE.createXMemberFeatureCall => [
 			explicitOperationCall = true
 			memberCallTarget = variable
@@ -61,11 +61,11 @@ class XBaseMethodUtils {
 		]
 	}
 
-	public static def notNull(TypeProvider provider, String variable) {
+	static def notNull(TypeProvider provider, String variable) {
 		provider.notNull(provider.variable(variable))
 	}
 
-	public static def notNull(TypeProvider provider, XExpression variable) {
+	static def notNull(TypeProvider provider, XExpression variable) {
 		XbaseFactory.eINSTANCE.createXBinaryOperation => [
 			leftOperand = variable
 			feature = XBaseMethodFinder.tripleNotEquals(provider)

--- a/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/utils/XExpressionParser.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mappings/src/tools/vitruv/dsls/mappings/generator/utils/XExpressionParser.xtend
@@ -14,7 +14,7 @@ class XExpressionParser {
 	val static URI DUMMY_RESOURCE_URI = URI.createURI("dummy:/example."+XBASE_LANGAUGE_EXTENSION)
 	var static Resource dummyResource
 	
-	def public static initParser(XtextResourceSet resourceSet) {
+	def static initParser(XtextResourceSet resourceSet) {
 		XExpressionParser.resourceSet = resourceSet
 		dummyResource = resourceSet.createResource(DUMMY_RESOURCE_URI)
 	}

--- a/bundles/dsls/tools.vitruv.dsls.mirbase.ui/src/tools/vitruv/dsls/mirbase/ui/contentassist/MirBaseProposalProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.mirbase.ui/src/tools/vitruv/dsls/mirbase/ui/contentassist/MirBaseProposalProvider.xtend
@@ -18,7 +18,7 @@ import org.eclipse.xtext.Assignment
 class MirBaseProposalProvider extends AbstractMirBaseProposalProvider {
 	
 	@Inject
-	private MirBaseGrammarAccess grammarAccess;
+	MirBaseGrammarAccess grammarAccess;
 	
 	override completeMetamodelImport_UseQualifiedNames(EObject model, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
 		val realKeyword = "using qualified names";

--- a/bundles/dsls/tools.vitruv.dsls.reactions.ui/src/tools/vitruv/dsls/reactions/ui/contentassist/ReactionsLanguageProposalProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions.ui/src/tools/vitruv/dsls/reactions/ui/contentassist/ReactionsLanguageProposalProvider.xtend
@@ -25,7 +25,7 @@ import tools.vitruv.dsls.reactions.reactionsLanguage.ActionStatement
 class ReactionsLanguageProposalProvider extends AbstractReactionsLanguageProposalProvider {
 
 	@Inject
-	private ReactionsLanguageGrammarAccess grammarAccess;
+	ReactionsLanguageGrammarAccess grammarAccess;
 
 	override completeKeyword(Keyword keyword, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
 		var matchedKeyword = false;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguageRuntimeModule.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguageRuntimeModule.xtend
@@ -23,21 +23,21 @@ import tools.vitruv.dsls.reactions.builder.FluentReactionsLanguageBuilder
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
  */
 class ReactionsLanguageRuntimeModule extends AbstractReactionsLanguageRuntimeModule {
-	public override Class<? extends IGlobalScopeProvider> bindIGlobalScopeProvider() {
+	override Class<? extends IGlobalScopeProvider> bindIGlobalScopeProvider() {
 		return ReactionsLanguageGlobalScopeProvider;
 	}
 
-	public override void configureIScopeProviderDelegate(Binder binder) {
+	override void configureIScopeProviderDelegate(Binder binder) {
 		binder.bind(org.eclipse.xtext.scoping.IScopeProvider)
 		      .annotatedWith(Names.named(org.eclipse.xtext.scoping.impl.AbstractDeclarativeScopeProvider.NAMED_DELEGATE))
 		      .to(ReactionsLanguageScopeProviderDelegate);
 	}
 	
-	public override Class<? extends IQualifiedNameConverter> bindIQualifiedNameConverter() {
+	override Class<? extends IQualifiedNameConverter> bindIQualifiedNameConverter() {
 		return MirBaseQualifiedNameConverter;
 	}
 	
-	public override Class<? extends ILinkingService> bindILinkingService() {
+	override Class<? extends ILinkingService> bindILinkingService() {
 		return ReactionsLinkingService;
 	}
 	

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsFileBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsFileBuilder.xtend
@@ -62,7 +62,7 @@ class FluentReactionsFileBuilder extends FluentReactionElementBuilder {
 }
 
 class MetamodelImportBuilder extends FluentReactionElementBuilder {
-	private MetamodelImport mmImport
+	MetamodelImport mmImport
 
 	new(MetamodelImport mmImport, FluentBuilderContext context) {
 		super(context)

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsSegmentChildBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsSegmentChildBuilder.xtend
@@ -83,7 +83,7 @@ abstract package class FluentReactionsSegmentChildBuilder extends FluentReaction
 		new TypeProvider(delegateTypeProvider, referenceBuilderFactory, this, scopeExpression)
 	}
 
-	def public getJvmOperationRoutineFacade(XExpression codeBlock) {
+	def getJvmOperationRoutineFacade(XExpression codeBlock) {
 		codeBlock.correspondingMethodParameter(REACTION_USER_EXECUTION_ROUTINE_CALL_FACADE_PARAMETER_NAME).featureCall
 	}
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
@@ -570,7 +570,7 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 	}
 
 	static class RoutineCallParameter {
-		private Object argument;
+		Object argument;
 
 		new(String parameter) {
 			this.argument = parameter
@@ -734,7 +734,7 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 		'''routine builder for «routine.name»'''
 	}
 
-	def public getJvmOperation() {
+	def getJvmOperation() {
 		val jvmMethod = context.jvmModelAssociator.getPrimaryJvmElement(routine)
 		if (jvmMethod instanceof JvmOperation) {
 			return jvmMethod

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
@@ -6,13 +6,13 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
 	public static val OVERRIDDEN_REACTIONS_SEGMENT_SEPARATOR = "::";
 	
 	public static val RETRIEVAL_PRECONDITION_METHOD_TARGET = "potentialTarget"
-	private static val ROUTINES_FACADE_NAME = "routinesFacade";
+	static val ROUTINES_FACADE_NAME = "routinesFacade";
 	public static val ROUTINES_FACADE_PARAMETER_NAME = ROUTINES_FACADE_NAME;
 	public static val ROUTINES_FACADE_FIELD_NAME = ROUTINES_FACADE_NAME;
-	private static val USER_INTERACTING_NAME = "userInteractor";
+	static val USER_INTERACTING_NAME = "userInteractor";
 	public static val USER_INTERACTING_PARAMETER_NAME = USER_INTERACTING_NAME;
 	public static val USER_INTERACTING_FIELD_NAME = USER_INTERACTING_NAME;
-	private static val REACTION_EXECUTION_STATE_NAME = "reactionExecutionState";
+	static val REACTION_EXECUTION_STATE_NAME = "reactionExecutionState";
 	public static val REACTION_EXECUTION_STATE_PARAMETER_NAME = REACTION_EXECUTION_STATE_NAME;
 	public static val REACTION_EXECUTION_STATE_FIELD_NAME = REACTION_EXECUTION_STATE_NAME;
 	public static val CHANGE_PARAMETER_NAME = "change";

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/AtomicChangeTypeRepresentation.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/AtomicChangeTypeRepresentation.xtend
@@ -7,8 +7,8 @@ import static tools.vitruv.dsls.reactions.codegen.ReactionsLanguageConstants.*
 import tools.vitruv.framework.change.echange.feature.single.ReplaceSingleValuedFeatureEChange
 import org.eclipse.xtend.lib.annotations.Accessors
 
-public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
-	private static final String TEMPORARY_TYPED_CHANGE_NAME = "_localTypedChange";
+class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
+	static final String TEMPORARY_TYPED_CHANGE_NAME = "_localTypedChange";
 	
 	protected final Class<?> changeType;
 	protected final String affectedElementClassCanonicalName
@@ -32,7 +32,7 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 		this.hasIndex = hasIndex
 	}
 
-	public override Class<?> getChangeType() {
+	override Class<?> getChangeType() {
 		return changeType;
 	}
 
@@ -44,35 +44,35 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 		affectedValueClassCanonicalName
 	}
 
-	public def EStructuralFeature getAffectedFeature() {
+	def EStructuralFeature getAffectedFeature() {
 		return affectedFeature;
 	}
 
-	public def boolean hasAffectedElement() {
+	def boolean hasAffectedElement() {
 		return affectedElementClass !== null;
 	}
 	
-	public def boolean hasAffectedFeature() {
+	def boolean hasAffectedFeature() {
 		return affectedFeature !== null;
 	}
 	
-	public def boolean hasOldValue() {
+	def boolean hasOldValue() {
 		return hasOldValue;
 	}
 
-	public def boolean hasNewValue() {
+	def boolean hasNewValue() {
 		return hasNewValue;
 	}
 	
-	public def boolean hasIndex() {
+	def boolean hasIndex() {
 		return hasIndex;
 	}
 
-	public override getGenericTypeParameters() {
+	override getGenericTypeParameters() {
 		#[affectedElementClassCanonicalName, affectedValueClassCanonicalName].filterNull
 	}
 
-	public override StringConcatenationClient getUntypedChangeTypeRepresentation() {
+	override StringConcatenationClient getUntypedChangeTypeRepresentation() {
 		return '''«changeType»'''
 	}
 
@@ -124,7 +124,7 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 		«ENDIF»
 	'''
 
-	public def Iterable<AccessibleElement> generatePropertiesParameterList() {
+	def Iterable<AccessibleElement> generatePropertiesParameterList() {
 		val result = <AccessibleElement>newArrayList();
 		result.add(new AccessibleElement(name, changeType));
 		if (affectedElementClass !== null) {
@@ -145,7 +145,7 @@ public class AtomicChangeTypeRepresentation extends ChangeTypeRepresentation {
 		return result;
 	}
 
-	public def StringConcatenationClient generatePropertiesAssignmentCode() {
+	def StringConcatenationClient generatePropertiesAssignmentCode() {
 		'''
 			«IF affectedElementClass !== null»
 				«affectedElementClass» «CHANGE_AFFECTED_ELEMENT_ATTRIBUTE» = «name».get«CHANGE_AFFECTED_ELEMENT_ATTRIBUTE.toFirstUpper»();

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeSequenceRepresentation.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeSequenceRepresentation.xtend
@@ -7,31 +7,31 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import tools.vitruv.framework.change.echange.feature.FeatureEChange
 import tools.vitruv.framework.change.echange.root.RootEChange
 
-public class ChangeSequenceRepresentation {
+class ChangeSequenceRepresentation {
 	@Accessors(PUBLIC_GETTER)
-	private List<AtomicChangeTypeRepresentation> atomicChanges;
+	List<AtomicChangeTypeRepresentation> atomicChanges;
 
 	protected new(Iterable<AtomicChangeTypeRepresentation> atomicChanges) {
 		this.atomicChanges = newArrayList;
 		this.atomicChanges += atomicChanges;
 	}
 
-	public def AtomicChangeTypeRepresentation getChange(int number) {
+	def AtomicChangeTypeRepresentation getChange(int number) {
 		if (number >= atomicChanges.size) {
 			throw new IllegalArgumentException();
 		}
 		return atomicChanges.get(number);
 	}
 	
-	public def int getNumberOfChanges() {
+	def int getNumberOfChanges() {
 		return atomicChanges.size;
 	}
 	
-	public def List<AccessibleElement> getFields() {
+	def List<AccessibleElement> getFields() {
 		return atomicChanges.map[accessibleElement];
 	}
 	
-	public def StringConcatenationClient getResetFieldsCode() {
+	def StringConcatenationClient getResetFieldsCode() {
 		'''
 			«FOR atomicChange : atomicChanges»
 				«atomicChange.resetFieldCode»
@@ -48,11 +48,11 @@ public class ChangeSequenceRepresentation {
 		return atomicChanges.last;
 	}
 	
-	public def Iterable<AccessibleElement> generatePropertiesParameterList() {
+	def Iterable<AccessibleElement> generatePropertiesParameterList() {
 		relevantAtomicChange.generatePropertiesParameterList();
 	}
 	
-	public def StringConcatenationClient generatePropertiesAssignmentCode() {
+	def StringConcatenationClient generatePropertiesAssignmentCode() {
 		relevantAtomicChange.generatePropertiesAssignmentCode();
 		
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentation.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentation.xtend
@@ -8,7 +8,7 @@ import org.eclipse.xtend2.lib.StringConcatenationClient
  * changes. The information for the changes are extracted by the {@link ChangeTypeRepresentationExtractor} from 
  * a {@link Trigger} of the reactions language.
  */
-public abstract class ChangeTypeRepresentation {
+abstract class ChangeTypeRepresentation {
 	
 	protected static def mapToNonPrimitiveType(String potentiallyPrimitiveTypeCName) {
 		return primitveToWrapperTypesMap.getOrDefault(potentiallyPrimitiveTypeCName, potentiallyPrimitiveTypeCName)
@@ -26,19 +26,19 @@ public abstract class ChangeTypeRepresentation {
 		void -> Void
 	].map [key.canonicalName -> value.canonicalName])
 
-	public def Class<?> getChangeType();
+	def Class<?> getChangeType();
 
-	public def Iterable<String> getGenericTypeParameters()
+	def Iterable<String> getGenericTypeParameters()
 
-	public def StringConcatenationClient getUntypedChangeTypeRepresentation() {
+	def StringConcatenationClient getUntypedChangeTypeRepresentation() {
 		return '''«changeType»'''
 	}
 
-	public def StringConcatenationClient getTypedChangeTypeRepresentation() {
+	def StringConcatenationClient getTypedChangeTypeRepresentation() {
 		return '''«changeType»«FOR param : genericTypeParameters BEFORE "<" SEPARATOR ", " AFTER ">"»«param»«ENDFOR»'''
 	}
 	
-	public def StringConcatenationClient getChangeTypeRepresentationWithWildcards() {
+	def StringConcatenationClient getChangeTypeRepresentationWithWildcards() {
 		return '''«changeType»«FOR param : genericTypeParameters BEFORE "<" SEPARATOR ", " AFTER ">"»?«ENDFOR»'''
 	}
 

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentationExtractor.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentationExtractor.xtend
@@ -30,19 +30,19 @@ import static extension tools.vitruv.dsls.reactions.codegen.helper.ReactionsLang
 import org.eclipse.emf.ecore.EcorePackage
 
 final class ChangeTypeRepresentationExtractor {
-	private static val CREATE_CHANGE_NAME = "createChange";
-	private static val DELET_CHANGE_NAME = "deleteChange";
-	private static val INSERT_CHANGE_NAME = "insertChange";
-	private static val REMOVE_CHANGE_NAME = "removeChange";
-	private static val REPLACE_CHANGE_NAME = "replaceChange";
-	private static val GENERAL_CHANGE_NAME = "change";
+	static val CREATE_CHANGE_NAME = "createChange";
+	static val DELET_CHANGE_NAME = "deleteChange";
+	static val INSERT_CHANGE_NAME = "insertChange";
+	static val REMOVE_CHANGE_NAME = "removeChange";
+	static val REPLACE_CHANGE_NAME = "replaceChange";
+	static val GENERAL_CHANGE_NAME = "change";
 	
-	public static def dispatch ChangeSequenceRepresentation extractChangeSequenceRepresentation(Trigger trigger) {
+	static def dispatch ChangeSequenceRepresentation extractChangeSequenceRepresentation(Trigger trigger) {
 		val atomicChange = new AtomicChangeTypeRepresentation(GENERAL_CHANGE_NAME, EChange, null, null, false, false, null, false);
 		return new ChangeSequenceRepresentation(#[atomicChange]);
 	}
 	
-	public static def dispatch ChangeSequenceRepresentation extractChangeSequenceRepresentation(ModelAttributeChange modelAttributeChange) {
+	static def dispatch ChangeSequenceRepresentation extractChangeSequenceRepresentation(ModelAttributeChange modelAttributeChange) {
 		var hasOldValue = false;
 		var hasNewValue = false;
 		var hasIndex = false;
@@ -75,7 +75,7 @@ final class ChangeTypeRepresentationExtractor {
 		return new ChangeSequenceRepresentation(#[atomicChange]);
 	}
 			
-	public static def dispatch ChangeSequenceRepresentation extractChangeSequenceRepresentation(ModelElementChange modelElementChange) {
+	static def dispatch ChangeSequenceRepresentation extractChangeSequenceRepresentation(ModelElementChange modelElementChange) {
 		var atomicChanges = newArrayList;
 		if (modelElementChange?.changeType === null) {
 			atomicChanges += new AtomicChangeTypeRepresentation(GENERAL_CHANGE_NAME, EChange, null, null, false, false, null, false);

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ChangePropagationSpecificationClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ChangePropagationSpecificationClassGenerator.xtend
@@ -11,7 +11,7 @@ import static extension tools.vitruv.dsls.reactions.codegen.helper.ClassNamesGen
 import static extension tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageHelper.*
 
 class ChangePropagationSpecificationClassGenerator extends ClassGenerator {
-	private final ReactionsSegment reactionsSegment;
+	final ReactionsSegment reactionsSegment;
 	var JvmGenericType generatedClass;
 	
 	new(ReactionsSegment reactionsSegment, TypesBuilderExtensionProvider typesBuilderExtensionProvider) {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ClassGenerator.xtend
@@ -21,14 +21,14 @@ import tools.vitruv.dsls.reactions.codegen.typesbuilder.TypesBuilderExtensionPro
  * and {@link ClassGenerator#generateBody(JvmGenericType) generateBody} for those steps.
  */
 abstract class ClassGenerator extends TypesBuilderExtensionProvider implements IJvmOperationRegistry {
-	private Map<String, JvmOperation> methodMap;
+	Map<String, JvmOperation> methodMap;
 
 	protected def generateAccessibleElementsParameters(EObject sourceObject,
 		Iterable<AccessibleElement> accessibleElements) {
 			sourceObject.generateMethodInputParameters(accessibleElements)
 	}
 
-	public new(TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
+	new(TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
 		typesBuilderExtensionProvider.copyBuildersTo(this);
 		this.methodMap = new HashMap<String, JvmOperation>();
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ExecutorClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ExecutorClassGenerator.xtend
@@ -13,7 +13,7 @@ import static extension tools.vitruv.dsls.reactions.codegen.helper.ReactionsLang
 import static extension tools.vitruv.dsls.reactions.codegen.helper.ReactionsImportsHelper.*;
 
 class ExecutorClassGenerator extends ClassGenerator {
-	private final ReactionsSegment reactionsSegment;
+	final ReactionsSegment reactionsSegment;
 	var JvmGenericType generatedClass;
 	
 	new(ReactionsSegment reactionsSegment, TypesBuilderExtensionProvider typesBuilderExtensionProvider) {

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/OverriddenRoutinesFacadeClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/OverriddenRoutinesFacadeClassGenerator.xtend
@@ -32,7 +32,7 @@ class OverriddenRoutinesFacadeClassGenerator extends RoutineFacadeClassGenerator
 		this.routinesFacadeNameGenerator = reactionsSegment.getOverriddenRoutinesFacadeClassNameGenerator(relativeImportPath);
 	}
 
-	public override generateEmptyClass() {
+	override generateEmptyClass() {
 		generatedClass = reactionsSegment.toClass(routinesFacadeNameGenerator.qualifiedName) [
 			visibility = JvmVisibility.PUBLIC;
 		]
@@ -69,6 +69,6 @@ class OverriddenRoutinesFacadeClassGenerator extends RoutineFacadeClassGenerator
 	protected override StringConcatenationClient getExtendedConstructorBody() '''
 	'''
 
-	protected override def StringConcatenationClient generateGetOwnRoutinesFacade() '''
+	protected override StringConcatenationClient generateGetOwnRoutinesFacade() '''
 		this._getRoutinesFacadesProvider().getRoutinesFacade(this._getReactionsImportPath().subPathTo("«reactionsSegment.name»"))'''
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
@@ -21,14 +21,14 @@ import tools.vitruv.dsls.common.helper.ClassNameGenerator
 import static extension tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageHelper.*
 
 class ReactionClassGenerator extends ClassGenerator {
-	private static val String CHANCE_COUNTER_VARIABLE = "currentlyMatchedChange";
+	static val String CHANCE_COUNTER_VARIABLE = "currentlyMatchedChange";
 	protected final Reaction reaction
 	protected final ChangeSequenceRepresentation changeSequenceRepresentation
 	protected final boolean hasPreconditionBlock
-	private final ClassNameGenerator reactionClassNameGenerator
-	private final UserExecutionClassGenerator userExecutionClassGenerator
-	private final ClassNameGenerator routinesFacadeClassNameGenerator
-	private var JvmGenericType generatedClass
+	final ClassNameGenerator reactionClassNameGenerator
+	final UserExecutionClassGenerator userExecutionClassGenerator
+	final ClassNameGenerator routinesFacadeClassNameGenerator
+	var JvmGenericType generatedClass
 	
 	new(Reaction reaction, TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
 		super(typesBuilderExtensionProvider);
@@ -44,7 +44,7 @@ class ReactionClassGenerator extends ClassGenerator {
 			reactionClassNameGenerator.qualifiedName + "." + EFFECT_USER_EXECUTION_SIMPLE_NAME);
 	}
 		
-	public override JvmGenericType generateEmptyClass() {
+	override JvmGenericType generateEmptyClass() {
 		userExecutionClassGenerator.generateEmptyClass()
 		generatedClass = reaction.toClass(reactionClassNameGenerator.qualifiedName) [
 			visibility = JvmVisibility.PUBLIC
@@ -145,7 +145,7 @@ class ReactionClassGenerator extends ClassGenerator {
 		];
 	}
 	
-	public def Iterable<String> generateArgumentsForAccesibleElements(Iterable<AccessibleElement> elements) {
+	def Iterable<String> generateArgumentsForAccesibleElements(Iterable<AccessibleElement> elements) {
 		elements.map[name];
 	}
 	

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionElementsCompletionChecker.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionElementsCompletionChecker.xtend
@@ -4,11 +4,11 @@ import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveModelElement
 import org.eclipse.emf.ecore.EClass
 
 class ReactionElementsCompletionChecker {
-	public def boolean isComplete(RetrieveModelElement retrieveElement) {
+	def boolean isComplete(RetrieveModelElement retrieveElement) {
 		return retrieveElement?.correspondenceSource?.code !== null && retrieveElement.metaclass.complete;
 	}
 	
-	public def boolean isComplete(EClass eClass) {
+	def boolean isComplete(EClass eClass) {
 		return eClass?.instanceClass !== null;
 	}
 	

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
@@ -55,7 +55,7 @@ class RoutineClassGenerator extends ClassGenerator {
 	var JvmGenericType generatedClass
 	var JvmGenericType userExecutionClass
 
-	public new(Routine routine, TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
+	new(Routine routine, TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
 		super(typesBuilderExtensionProvider)
 		if (!routine.isComplete) {
 			throw new IllegalArgumentException("incomplete");

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineFacadeClassGenerator.xtend
@@ -35,7 +35,7 @@ class RoutineFacadeClassGenerator extends ClassGenerator {
 		this.routinesFacadeNameGenerator = reactionsSegment.routinesFacadeClassNameGenerator;
 	}
 
-	public override generateEmptyClass() {
+	override generateEmptyClass() {
 		generatedClass = reactionsSegment.toClass(routinesFacadeNameGenerator.qualifiedName) [
 			visibility = JvmVisibility.PUBLIC;
 		]

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/UserExecutionClassGenerator.xtend
@@ -22,8 +22,8 @@ import static tools.vitruv.dsls.reactions.codegen.ReactionsLanguageConstants.*
 import tools.vitruv.dsls.reactions.reactionsLanguage.RetrieveOrRequireAbscenceOfModelElement
 
 class UserExecutionClassGenerator extends ClassGenerator {
-	private val EObject objectMappedToClass;
-	private val String qualifiedClassName;
+	val EObject objectMappedToClass;
+	val String qualifiedClassName;
 	var counterGetTagMethods = 1
 	var counterGetElementMethods = 1
 	var counterGetRetrieveTagMethods = 1
@@ -31,7 +31,7 @@ class UserExecutionClassGenerator extends ClassGenerator {
 	var counterExecuteActionMethods = 1
 	var counterCheckMatcherPreconditionMethods = 1
 	var counterGetCorrespondenceSource = 1
-	private var JvmGenericType generatedClass
+	var JvmGenericType generatedClass
 	
 	new(TypesBuilderExtensionProvider typesBuilderExtensionProvider, EObject objectMappedToClass,
 		String qualifiedClassName) {
@@ -40,7 +40,7 @@ class UserExecutionClassGenerator extends ClassGenerator {
 		this.qualifiedClassName = qualifiedClassName;
 	}
 
-	public def String getQualifiedClassName() {
+	def String getQualifiedClassName() {
 		return qualifiedClassName;
 	}
 

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/AccessibleElement.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/AccessibleElement.xtend
@@ -6,26 +6,26 @@ import org.eclipse.xtext.xbase.jvmmodel.JvmTypeReferenceBuilder
 
 class AccessibleElement {
 	@Accessors(PUBLIC_GETTER)
-	private val String name;
-	private val String fullyQualifiedTypeName;
-	private val List<String> typeParameters;
+	val String name;
+	val String fullyQualifiedTypeName;
+	val List<String> typeParameters;
 	
-	public new(String name, String fullyQualifiedTypeName) {
+	new(String name, String fullyQualifiedTypeName) {
 		this.name = name;
 		this.fullyQualifiedTypeName = fullyQualifiedTypeName;
 		this.typeParameters = newArrayList
 	}
 	
-	public new(String name, String fullyQualifiedTypeName, String... typeParameters) {
+	new(String name, String fullyQualifiedTypeName, String... typeParameters) {
 		this(name, fullyQualifiedTypeName);
 		this.typeParameters += typeParameters;
 	}
 	
-	public new(String name, Class<?> type) {
+	new(String name, Class<?> type) {
 		this(name, type.name)
 	}
 	
-	public def generateTypeRef(@Extension JvmTypeReferenceBuilder typeReferenceBuilder) {
+	def generateTypeRef(@Extension JvmTypeReferenceBuilder typeReferenceBuilder) {
 		typeRef(fullyQualifiedTypeName, typeParameters.map[typeRef])
 	}
 	

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ClassNamesGenerators.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ClassNamesGenerators.xtend
@@ -17,13 +17,13 @@ import tools.vitruv.dsls.common.helper.ClassNameGenerator
 	static val String ROUTINES_FACADE_CLASS_NAME = "RoutinesFacade"
 	static val String ROUTINES_FACADES_PROVIDER_CLASS_NAME = "RoutinesFacadesProvider"
 	
-	public static def String getBasicMirPackageQualifiedName() '''
+	static def String getBasicMirPackageQualifiedName() '''
 		«BASIC_PACKAGE»'''
 	
-	public static def String getBasicReactionsPackageQualifiedName() '''
+	static def String getBasicReactionsPackageQualifiedName() '''
 		«basicMirPackageQualifiedName».«REACTIONS_PACKAGE»'''
 	
-	public static def String getBasicRoutinesPackageQualifiedName() '''
+	static def String getBasicRoutinesPackageQualifiedName() '''
 		«basicMirPackageQualifiedName».«ROUTINES_PACKAGE»'''	
 	
 	private static def String getReactionsPackageQualifiedName(ReactionsSegment reactionSegment) '''
@@ -38,87 +38,87 @@ import tools.vitruv.dsls.common.helper.ClassNameGenerator
 	private static def String getReactionsSegmentPackageName(String reactionSegmentName) '''
 		«reactionSegmentName.toFirstLower»'''
 	
-	public static def ClassNameGenerator getChangePropagationSpecificationClassNameGenerator(ReactionsSegment reactionSegment) {
+	static def ClassNameGenerator getChangePropagationSpecificationClassNameGenerator(ReactionsSegment reactionSegment) {
 		return new ChangePropagationSpecificationClassNameGenerator(reactionSegment);
 	}
 	
-	public static def ClassNameGenerator getExecutorClassNameGenerator(ReactionsSegment reactionSegment) {
+	static def ClassNameGenerator getExecutorClassNameGenerator(ReactionsSegment reactionSegment) {
 		return new ExecutorClassNameGenerator(reactionSegment);
 	}
 	
-	public static def ClassNameGenerator getRoutinesFacadesProviderClassNameGenerator(ReactionsSegment reactionSegment) {
+	static def ClassNameGenerator getRoutinesFacadesProviderClassNameGenerator(ReactionsSegment reactionSegment) {
 		return new RoutinesFacadesProviderClassNameGenerator(reactionSegment);
 	}
 	
-	public static def ClassNameGenerator getRoutinesFacadeClassNameGenerator(ReactionsSegment reactionSegment) {
+	static def ClassNameGenerator getRoutinesFacadeClassNameGenerator(ReactionsSegment reactionSegment) {
 		return new RoutinesFacadeClassNameGenerator(reactionSegment);
 	}
 	
 	// import path relative to reactions segment:
-	public static def ClassNameGenerator getOverriddenRoutinesFacadeClassNameGenerator(ReactionsSegment reactionsSegment, ReactionsImportPath relativeImportPath) {
+	static def ClassNameGenerator getOverriddenRoutinesFacadeClassNameGenerator(ReactionsSegment reactionsSegment, ReactionsImportPath relativeImportPath) {
 		return new OverriddenRoutinesFacadeClassNameGenerator(reactionsSegment, relativeImportPath);
 	}
 	
-	public static def ClassNameGenerator getReactionClassNameGenerator(Reaction reaction) {
+	static def ClassNameGenerator getReactionClassNameGenerator(Reaction reaction) {
 		return new ReactionClassNameGenerator(reaction);
 	}
 	
-	public static def ClassNameGenerator getRoutineClassNameGenerator(Routine routine) {
+	static def ClassNameGenerator getRoutineClassNameGenerator(Routine routine) {
 		return new RoutineClassNameGenerator(routine);
 	}
 	
 	private static class ChangePropagationSpecificationClassNameGenerator implements ClassNameGenerator {
-		private val ReactionsSegment reactionsSegment;
+		val ReactionsSegment reactionsSegment;
 		
-		public new(ReactionsSegment reactionsSegment) {
+		new(ReactionsSegment reactionsSegment) {
 			this.reactionsSegment = reactionsSegment;
 		}
 		
-		public override getSimpleName() '''
+		override getSimpleName() '''
 			«reactionsSegment.name.toFirstUpper»ChangePropagationSpecification'''
 		
-		public override getPackageName() '''
+		override getPackageName() '''
 			«reactionsSegment.reactionsPackageQualifiedName»'''
 	}
 	
 	private static class ExecutorClassNameGenerator implements ClassNameGenerator {
-		private val ReactionsSegment reactionsSegment;
+		val ReactionsSegment reactionsSegment;
 		
-		public new(ReactionsSegment reactionsSegment) {
+		new(ReactionsSegment reactionsSegment) {
 			this.reactionsSegment = reactionsSegment;
 		}
 		
-		public override getSimpleName() '''
+		override getSimpleName() '''
 			«REACTIONS_EXECUTOR_CLASS_NAME»'''
 	
-		public override getPackageName() '''
+		override getPackageName() '''
 			«reactionsSegment.reactionsPackageQualifiedName»'''
 	}
 	
 	private static class RoutinesFacadesProviderClassNameGenerator implements ClassNameGenerator {
-		private val ReactionsSegment reactionSegment;
+		val ReactionsSegment reactionSegment;
 		
-		public new(ReactionsSegment reactionSegment) {
+		new(ReactionsSegment reactionSegment) {
 			this.reactionSegment = reactionSegment;
 		}
 		
-		public override String getSimpleName() '''
+		override String getSimpleName() '''
 			«ROUTINES_FACADES_PROVIDER_CLASS_NAME»'''
 		
-		public override String getPackageName() '''
+		override String getPackageName() '''
 			«basicRoutinesPackageQualifiedName».«reactionSegment.packageName»'''
 	}
 	
 	private static class ReactionClassNameGenerator implements ClassNameGenerator {
-		private val Reaction reaction;
-		public new(Reaction reaction) {
+		val Reaction reaction;
+		new(Reaction reaction) {
 			this.reaction = reaction;
 		}
 		
-		public override String getSimpleName() '''
+		override String getSimpleName() '''
 			«reaction.name.toFirstUpper»Reaction'''
 		
-		public override String getPackageName() {
+		override String getPackageName() {
 			var packageName = reaction.reactionsSegment.reactionsPackageQualifiedName;
 			if (reaction.isOverride) {
 				// not resolving cross-references here to get the overridden reactions segment name,
@@ -130,15 +130,15 @@ import tools.vitruv.dsls.common.helper.ClassNameGenerator
 	}
 	
 	private static class RoutineClassNameGenerator implements ClassNameGenerator {
-		private val Routine routine;
-		public new(Routine routine) {
+		val Routine routine;
+		new(Routine routine) {
 			this.routine = routine;
 		}
 		
-		public override String getSimpleName() '''
+		override String getSimpleName() '''
 			«routine.name.toFirstUpper»Routine'''
 		
-		public override String getPackageName() {
+		override String getPackageName() {
 			var packageName = routine.reactionsSegment.routinesPackageQualifiedName;
 			if (routine.isOverride) {
 				// not resolving cross-references here to get the override import path,
@@ -150,31 +150,31 @@ import tools.vitruv.dsls.common.helper.ClassNameGenerator
 	}
 	
 	private static class RoutinesFacadeClassNameGenerator implements ClassNameGenerator {
-		private val ReactionsSegment reactionsSegment;
-		public new(ReactionsSegment reactionsSegment) {
+		val ReactionsSegment reactionsSegment;
+		new(ReactionsSegment reactionsSegment) {
 			this.reactionsSegment = reactionsSegment;
 		}
 		
-		public override String getSimpleName() '''
+		override String getSimpleName() '''
 			«ROUTINES_FACADE_CLASS_NAME»'''
 		
-		public override String getPackageName() '''
+		override String getPackageName() '''
 			«reactionsSegment.routinesPackageQualifiedName»'''
 	}
 	
 	private static class OverriddenRoutinesFacadeClassNameGenerator implements ClassNameGenerator {
-		private val ReactionsSegment reactionsSegment;
-		private val ReactionsImportPath relativeImportPath;
+		val ReactionsSegment reactionsSegment;
+		val ReactionsImportPath relativeImportPath;
 		
-		public new(ReactionsSegment reactionsSegment, ReactionsImportPath relativeImportPath) {
+		new(ReactionsSegment reactionsSegment, ReactionsImportPath relativeImportPath) {
 			this.reactionsSegment = reactionsSegment;
 			this.relativeImportPath = relativeImportPath;
 		}
 		
-		public override String getSimpleName() '''
+		override String getSimpleName() '''
 			«ROUTINES_FACADE_CLASS_NAME»'''
 		
-		public override String getPackageName() '''
+		override String getPackageName() '''
 			«reactionsSegment.routinesPackageQualifiedName».«relativeImportPath.segments.join(".", [it.reactionsSegmentPackageName])»'''
 	}
 }

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsImportsHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsImportsHelper.xtend
@@ -40,7 +40,7 @@ class ReactionsImportsHelper {
 	 * @return the name of the overridden reactions segment, or <code>null</code> if the given reaction doesn't override any
 	 *         other reaction
 	 */
-	public static def String getParsedOverriddenReactionsSegmentName(Reaction reaction) {
+	static def String getParsedOverriddenReactionsSegmentName(Reaction reaction) {
 		val parsed = reaction.getFeatureNodeText(ReactionsLanguagePackage.Literals.REACTION__OVERRIDDEN_REACTIONS_SEGMENT);
 		if (!parsed.nullOrEmpty) return parsed;
 		return reaction.overriddenReactionsSegment?.name;
@@ -58,7 +58,7 @@ class ReactionsImportsHelper {
 	 * @return the reactions import path consisting of the found segment names, or <code>null</code> if the given routine does
 	 *         not override any other routine
 	 */
-	public static def ReactionsImportPath getParsedOverrideImportPath(Routine routine) {
+	static def ReactionsImportPath getParsedOverrideImportPath(Routine routine) {
 		return routine.overrideImportPath.parsedOverrideImportPath;
 	}
 
@@ -74,7 +74,7 @@ class ReactionsImportsHelper {
 	 * @return the reactions import path consisting of the found segment names, or <code>null</code> if the given routine
 	 *         override path was <code>null</code>
 	 */
-	public static def ReactionsImportPath getParsedOverrideImportPath(RoutineOverrideImportPath routineOverrideImportPath) {
+	static def ReactionsImportPath getParsedOverrideImportPath(RoutineOverrideImportPath routineOverrideImportPath) {
 		if (routineOverrideImportPath === null) return null;
 		// getting the parsed text of each individual segment (instead of the whole import path) to skip hidden tokens in between:
 		val parsedSegments = routineOverrideImportPath.fullPath.map [
@@ -100,7 +100,7 @@ class ReactionsImportsHelper {
 	 * @return the parsed overridden routines import paths
 	 * @see #getParsedOverrideImportPath(Routine)
 	 */
-	public static def Set<ReactionsImportPath> getParsedOverriddenRoutinesImportPaths(ReactionsSegment reactionsSegment) {
+	static def Set<ReactionsImportPath> getParsedOverriddenRoutinesImportPaths(ReactionsSegment reactionsSegment) {
 		return reactionsSegment.overrideRoutines.filter[it.isComplete].map[it.parsedOverrideImportPath].toSet;
 	}
 
@@ -111,7 +111,7 @@ class ReactionsImportsHelper {
 	 * @return <code>true</code> if all imports are resolvable
 	 * @see #isResolvable(ReactionsImport)
 	 */
-	public static def boolean isAllImportsResolvable(ReactionsSegment reactionsSegment) {
+	static def boolean isAllImportsResolvable(ReactionsSegment reactionsSegment) {
 		// getting the imported reactions segment from the reactions import triggers a resolve,
 		// which will only still be a proxy afterwards if it wasn't resolvable
 		return (reactionsSegment.reactionsImports.findFirst[!it.isResolvable] === null);
@@ -131,7 +131,7 @@ class ReactionsImportsHelper {
 	 * @param reactionsImport the reactions import
 	 * @return <code>true</code> if the given import is resolvable
 	 */
-	public static def boolean isResolvable(ReactionsImport reactionsImport) {
+	static def boolean isResolvable(ReactionsImport reactionsImport) {
 		// getting the imported reactions segment from the reactions import triggers a resolve,
 		// which will only still be a proxy afterwards if it wasn't resolvable
 		return (reactionsImport !== null && reactionsImport.importedReactionsSegment !== null && !reactionsImport.importedReactionsSegment.eIsProxy);
@@ -143,7 +143,7 @@ class ReactionsImportsHelper {
 	 * @param <D>
 	 *            the type of the data being passed along
 	 */
-	public static interface ImportHierarchyVisitor<D> {
+	static interface ImportHierarchyVisitor<D> {
 		/**
 		 * Gets called for each reactions segment along the walked import hierarchy.
 		 * 
@@ -185,7 +185,7 @@ class ReactionsImportsHelper {
 	 * @param returnValueFunction the return value function, not <code>null</code>
 	 * @return the return value calculated by the return value function
 	 */
-	public static def <R, D> R walkImportHierarchy(ReactionsSegment rootReactionsSegment, Supplier<D> dataInitializer,
+	static def <R, D> R walkImportHierarchy(ReactionsSegment rootReactionsSegment, Supplier<D> dataInitializer,
 		ImportHierarchyVisitor<D> earlyVisitor, ImportHierarchyVisitor<D> lateVisitor, Predicate<ReactionsImport> importFilter,
 		Function<D, R> returnValueFunction) {
 		checkNotNull(rootReactionsSegment, "rootReactionsSegment is null");
@@ -232,7 +232,7 @@ class ReactionsImportsHelper {
 	 * @param rootReactionsSegment the root reactions segment, not <code>null</code>
 	 * @return all reactions segments in the import hierarchy by their absolute import paths
 	 */
-	public static def Map<ReactionsImportPath, ReactionsSegment> getRoutinesImportHierarchy(ReactionsSegment rootReactionsSegment) {
+	static def Map<ReactionsImportPath, ReactionsSegment> getRoutinesImportHierarchy(ReactionsSegment rootReactionsSegment) {
 		return walkImportHierarchy(rootReactionsSegment,
 			// data initializer:
 			[
@@ -270,7 +270,7 @@ class ReactionsImportsHelper {
 	 * @param rootReactionsSegment the root reactions segment, not <code>null</code>
 	 * @return all reactions segments in the import hierarchy, that contribute reactions, by their absolute import paths
 	 */
-	public static def Map<ReactionsImportPath, ReactionsSegment> getReactionsImportHierarchy(ReactionsSegment rootReactionsSegment) {
+	static def Map<ReactionsImportPath, ReactionsSegment> getReactionsImportHierarchy(ReactionsSegment rootReactionsSegment) {
 		return walkImportHierarchy(rootReactionsSegment,
 			// data initializer:
 			[
@@ -308,7 +308,7 @@ class ReactionsImportsHelper {
 	 * @param rootReactionsSegment the root reactions segment, not <code>null</code>
 	 * @return all included reactions with their absolute import paths
 	 */
-	public static def Map<Reaction, ReactionsImportPath> getIncludedReactions(ReactionsSegment rootReactionsSegment) {
+	static def Map<Reaction, ReactionsImportPath> getIncludedReactions(ReactionsSegment rootReactionsSegment) {
 		return walkImportHierarchy(rootReactionsSegment,
 			// data initializer:
 			[
@@ -364,7 +364,7 @@ class ReactionsImportsHelper {
 	 * @param resolveOverrides whether to replace routines with their overriding routine
 	 * @return all included routines with their absolute import paths
 	 */
-	public static def Map<Routine, ReactionsImportPath> getIncludedRoutines(ReactionsSegment rootReactionsSegment,
+	static def Map<Routine, ReactionsImportPath> getIncludedRoutines(ReactionsSegment rootReactionsSegment,
 		boolean includeRootRoutines, boolean resolveOverrides) {
 		return walkImportHierarchy(rootReactionsSegment,
 			// data initializer:
@@ -437,7 +437,7 @@ class ReactionsImportsHelper {
 	 * @param rootReactionsSegment the root reactions segment, not <code>null</code>
 	 * @return all reactions segments whose routines facades are included, with their absolute import paths
 	 */
-	public static def Map<ReactionsSegment, ReactionsImportPath> getIncludedRoutinesFacades(ReactionsSegment rootReactionsSegment) {
+	static def Map<ReactionsSegment, ReactionsImportPath> getIncludedRoutinesFacades(ReactionsSegment rootReactionsSegment) {
 		return walkImportHierarchy(rootReactionsSegment,
 			// data initializer:
 			[
@@ -484,7 +484,7 @@ class ReactionsImportsHelper {
 	 * @param <T>
 	 *            the type of the return value
 	 */
-	public static interface ImportPathVisitor<T> {
+	static interface ImportPathVisitor<T> {
 		/**
 		 * Gets called for each reactions segment along the walked import path and can abort the walking by returning a
 		 * <code>non-null</code> return value.
@@ -522,7 +522,7 @@ class ReactionsImportsHelper {
 	 *         visitor providing a <code>non-null</code> return value, or if the path does not exist in the import hierarchy of
 	 *         the root reactions segment
 	 */
-	public static def <T> T walkImportPath(ReactionsSegment rootReactionsSegment, ReactionsImportPath relativeImportPath, ImportPathVisitor<T> visitor) {
+	static def <T> T walkImportPath(ReactionsSegment rootReactionsSegment, ReactionsImportPath relativeImportPath, ImportPathVisitor<T> visitor) {
 		checkNotNull(rootReactionsSegment, "rootReactionsSegment is null");
 		checkNotNull(relativeImportPath, "relativeImportPath is null");
 		checkNotNull(visitor, "visitor is null");
@@ -573,7 +573,7 @@ class ReactionsImportsHelper {
 	 * @return the reactions segment at the end of the specified import path, or <code>null</code> if no reactions segment is
 	 *         found for the specified path
 	 */
-	public static def ReactionsSegment getReactionsSegment(ReactionsSegment rootReactionsSegment, ReactionsImportPath relativeImportPath) {
+	static def ReactionsSegment getReactionsSegment(ReactionsSegment rootReactionsSegment, ReactionsImportPath relativeImportPath) {
 		return walkImportPath(rootReactionsSegment, relativeImportPath,
 			[ sourceImport, currentImportPath, currentReactionsSegment, remainingPath |
 				if (remainingPath.isEmpty) {
@@ -604,7 +604,7 @@ class ReactionsImportsHelper {
 	 * @return the first reactions segment that overrides routines of the specified reactions segment, or the overridden
 	 *         reactions segment itself, together with its absolute reactions import path (starting with the root segment)
 	 */
-	public static def Pair<ReactionsImportPath, ReactionsSegment> getRoutinesOverrideRoot(ReactionsSegment rootReactionsSegment,
+	static def Pair<ReactionsImportPath, ReactionsSegment> getRoutinesOverrideRoot(ReactionsSegment rootReactionsSegment,
 		ReactionsImportPath overriddenRoutineImportPath, boolean checkRootReactionsSegment) {
 		return walkImportPath(rootReactionsSegment, overriddenRoutineImportPath,
 			[ sourceImport, currentImportPath, currentReactionsSegment, remainingPath |

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/ReactionsLanguageHelper.xtend
@@ -25,12 +25,12 @@ final class ReactionsLanguageHelper {
 	private new() {
 	}
 
-	public static def dispatch String getXBlockExpressionText(XExpression expression) '''
+	static def dispatch String getXBlockExpressionText(XExpression expression) '''
 	{
 		«NodeModelUtils.getNode(expression).text»
 	}'''
 
-	public static def dispatch String getXBlockExpressionText(XBlockExpression expression) {
+	static def dispatch String getXBlockExpressionText(XBlockExpression expression) {
 		NodeModelUtils.getNode(expression).text;
 	}
 
@@ -38,19 +38,19 @@ final class ReactionsLanguageHelper {
 		element.eAdapters.findFirst [isAdapterForType(ReferenceClassNameAdapter)] as ReferenceClassNameAdapter
 	}
 
-	public static def getJavaClassName(EClassifier eClassifier) {
+	static def getJavaClassName(EClassifier eClassifier) {
 		eClassifier.optionalReferenceAdapter?.qualifiedNameForReference ?: eClassifier.instanceClassName
 	}
 	
-	public static def getRuntimeClassName(EObject element) {
+	static def getRuntimeClassName(EObject element) {
 		element.optionalReferenceAdapter?.qualifiedNameForReference ?: element.class.canonicalName
 	}
 
-	public static def getJavaClassName(MetaclassReference metaclassReference) {
+	static def getJavaClassName(MetaclassReference metaclassReference) {
 		metaclassReference.metaclass.javaClassName;
 	}
 
-	public static def VitruvDomainProvider<?> getProviderForDomain(VitruvDomain domain) {
+	static def VitruvDomainProvider<?> getProviderForDomain(VitruvDomain domain) {
 		return if (VitruvDomainProviderRegistry.hasDomainProvider(domain.name)) {
 			VitruvDomainProviderRegistry.getDomainProvider(domain.name);
 		} else {
@@ -58,11 +58,11 @@ final class ReactionsLanguageHelper {
 		}
 	}
 
-	public static def VitruvDomain getDomainForReference(DomainReference domainReference) {
+	static def VitruvDomain getDomainForReference(DomainReference domainReference) {
 		return getDomainProviderForReference(domainReference).domain;
 	}
 
-	public static def VitruvDomainProvider<?> getDomainProviderForReference(DomainReference domainReference) {
+	static def VitruvDomainProvider<?> getDomainProviderForReference(DomainReference domainReference) {
 		val referencedDomainProvider = if (VitruvDomainProviderRegistry.hasDomainProvider(domainReference.domain)) {
 			VitruvDomainProviderRegistry.getDomainProvider(domainReference.domain)
 		}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/JvmTypesBuilderWithoutAssociations.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/JvmTypesBuilderWithoutAssociations.xtend
@@ -17,10 +17,10 @@ import com.google.inject.Singleton
 @Singleton
 class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	@Inject
-	private TypesFactory typesFactory;
+	TypesFactory typesFactory;
 
 	@Inject
-	private IJvmModelAssociator associator;
+	IJvmModelAssociator associator;
 
 	/**
 	 * Creates a public method with the given name and the given return type and associates it with the given
@@ -38,7 +38,7 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	 * @return a result representing a Java method with the given name, <code>null</code> if sourceElement or name are <code>null</code>.
 	 */
 	/* @Nullable */
-	public def JvmOperation generateUnassociatedMethod( /* @Nullable */ String name, /* @Nullable */ JvmTypeReference returnType, /* @Nullable */ Procedure1<? super JvmOperation> initializer) {
+	def JvmOperation generateUnassociatedMethod( /* @Nullable */ String name, /* @Nullable */ JvmTypeReference returnType, /* @Nullable */ Procedure1<? super JvmOperation> initializer) {
 		if (name === null)
 			return null;
 		val result = typesFactory.createJvmOperation();
@@ -58,7 +58,7 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	 * @return a {@link JvmField} representing a Java field with the given simple name and type.
 	 */
 	/* @Nullable */
-	public def JvmField generateUnassociatedField( /* @Nullable */ String name, /* @Nullable */ JvmTypeReference typeRef) {
+	def JvmField generateUnassociatedField( /* @Nullable */ String name, /* @Nullable */ JvmTypeReference typeRef) {
 		return generateUnassociatedField(name, typeRef, null);
 	}
 
@@ -66,7 +66,7 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	 * Same as {@link #toField(EObject, String, JvmTypeReference)} but with an initializer passed as the last argument.
 	 */
 	/* @Nullable */
-	public def JvmField generateUnassociatedField( /* @Nullable */ String name, /* @Nullable */ JvmTypeReference typeRef, /* @Nullable */ Procedure1<? super JvmField> initializer) {
+	def JvmField generateUnassociatedField( /* @Nullable */ String name, /* @Nullable */ JvmTypeReference typeRef, /* @Nullable */ Procedure1<? super JvmField> initializer) {
 		if (name === null)
 			return null;
 		val result = typesFactory.createJvmField();
@@ -86,7 +86,7 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 	 * @return the target for convenience.
 	 */
 	/* @Nullable */
-	public override <T extends EObject> T associate( /* @Nullable */ EObject sourceElement, /* @Nullable */ T target) {
+	override <T extends EObject> T associate( /* @Nullable */ EObject sourceElement, /* @Nullable */ T target) {
 		if (sourceElement !== null && target !== null && sourceElement.eResource !== null &&
 			isValidSource(sourceElement))
 			associator.associate(sourceElement, target);
@@ -111,14 +111,14 @@ class JvmTypesBuilderWithoutAssociations extends JvmTypesBuilder {
 		return target;
 	}
 
-	public def JvmFormalParameter createParameter(String name, JvmTypeReference typeRef) {
+	def JvmFormalParameter createParameter(String name, JvmTypeReference typeRef) {
 		val result = typesFactory.createJvmFormalParameter();
 		result.setName(name);
 		result.setParameterType(cloneWithProxies(typeRef));
 		return result;
 	}
 
-	public def JvmGenericType generateUnassociatedClass( /* @Nullable */ String name, /* @Nullable */ Procedure1<? super JvmGenericType> initializer) {
+	def JvmGenericType generateUnassociatedClass( /* @Nullable */ String name, /* @Nullable */ Procedure1<? super JvmGenericType> initializer) {
 		val result = createJvmGenericType(name);
 		if (result === null)
 			return null;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
@@ -28,26 +28,26 @@ class ParameterGenerator {
 		_typesBuilder = typesBuilder;
 	}
 	
-	public def JvmFormalParameter generateModelElementParameter(EObject parameterContext, MetaclassReference metaclassReference, String elementName) {
+	def JvmFormalParameter generateModelElementParameter(EObject parameterContext, MetaclassReference metaclassReference, String elementName) {
 		if (metaclassReference?.metaclass !== null) {
 			return parameterContext.generateParameter(elementName, typeRef(metaclassReference.javaClassName))
 		}	
 		return null;
 	}
 	
-	public def JvmFormalParameter generateRoutinesFacadeParameter(EObject parameterContext, ReactionsSegment reactionsSegment) {
+	def JvmFormalParameter generateRoutinesFacadeParameter(EObject parameterContext, ReactionsSegment reactionsSegment) {
 		return generateParameter(parameterContext, ROUTINES_FACADE_PARAMETER_NAME, typeRef(reactionsSegment.routinesFacadeClassNameGenerator.qualifiedName));
 	}
 	
-	public def JvmFormalParameter generateReactionExecutionStateParameter(EObject parameterContext) {
+	def JvmFormalParameter generateReactionExecutionStateParameter(EObject parameterContext) {
 		return generateParameter(parameterContext, REACTION_EXECUTION_STATE_PARAMETER_NAME, ReactionExecutionState);
 	}
 	
-	public def JvmFormalParameter generateUserInteractorParameter(EObject parameterContext) {
+	def JvmFormalParameter generateUserInteractorParameter(EObject parameterContext) {
 		return generateParameter(parameterContext, USER_INTERACTING_PARAMETER_NAME, UserInteractor);
 	}
 	
-	public def generateParameter(EObject context, String parameterName, JvmTypeReference parameterType) {
+	def generateParameter(EObject context, String parameterName, JvmTypeReference parameterType) {
 		if (parameterType === null) {
 			return null;
 		}
@@ -55,11 +55,11 @@ class ParameterGenerator {
 	}
 
 		
-	public def generateParameterFromClasses(EObject context, String parameterName, Class<?> parameterClass, Iterable<String> typeParameterClasses) {
+	def generateParameterFromClasses(EObject context, String parameterName, Class<?> parameterClass, Iterable<String> typeParameterClasses) {
 		return generateParameter(context, parameterName, parameterClass, typeParameterClasses);
 	}
 	
-	public def generateParameter(EObject context, String parameterName, Class<?> parameterClass, String... typeParameterClassNames) {
+	def generateParameter(EObject context, String parameterName, Class<?> parameterClass, String... typeParameterClassNames) {
 		if (parameterClass === null) {
 			return null;
 		}
@@ -71,16 +71,16 @@ class ParameterGenerator {
 		return context.toParameter(parameterName, changeType);
 	}
 	
-	public def Iterable<AccessibleElement> getInputElements(EObject contextObject, Iterable<NamedMetaclassReference> metaclassReferences, Iterable<NamedJavaElement> javaElements) {
+	def Iterable<AccessibleElement> getInputElements(EObject contextObject, Iterable<NamedMetaclassReference> metaclassReferences, Iterable<NamedJavaElement> javaElements) {
 		return metaclassReferences.map[new AccessibleElement(it.name, it.metaclass.mappedInstanceClassCanonicalName)]
 			+ javaElements.map[new AccessibleElement(it.name, it.type.qualifiedName)];
 	}
 	
-	public def Iterable<JvmFormalParameter> generateMethodInputParameters(EObject contextObject, Iterable<NamedMetaclassReference> metaclassReferences, Iterable<NamedJavaElement> javaElements) {
+	def Iterable<JvmFormalParameter> generateMethodInputParameters(EObject contextObject, Iterable<NamedMetaclassReference> metaclassReferences, Iterable<NamedJavaElement> javaElements) {
 		return contextObject.generateMethodInputParameters(contextObject.getInputElements(metaclassReferences, javaElements));
 	}
 	
-	public def Iterable<JvmFormalParameter> generateMethodInputParameters(EObject contextObject, Iterable<AccessibleElement> elements) {
+	def Iterable<JvmFormalParameter> generateMethodInputParameters(EObject contextObject, Iterable<AccessibleElement> elements) {
 		elements.map[toParameter(contextObject, it.name, it.generateTypeRef(_typeReferenceBuilder))]
 	}
 	
@@ -99,7 +99,7 @@ class ParameterGenerator {
 		}
 	}
 	
-	public def JvmFormalParameter generateUntypedChangeParameter(EObject parameterContext) {
+	def JvmFormalParameter generateUntypedChangeParameter(EObject parameterContext) {
 		return parameterContext.generateParameter(CHANGE_PARAMETER_NAME, EChange);
 	}
 	

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/TypesBuilderExtensionProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/TypesBuilderExtensionProvider.xtend
@@ -9,14 +9,14 @@ class TypesBuilderExtensionProvider {
 	protected extension JvmAnnotationReferenceBuilder _annotationTypesBuilder; 
 	protected extension ParameterGenerator _parameterGenerator;
 	
-	public def void setBuilders(JvmTypesBuilderWithoutAssociations typesBuilder, JvmTypeReferenceBuilder typeReferenceBuilder, JvmAnnotationReferenceBuilder annotationReferenceBuilder) {
+	def void setBuilders(JvmTypesBuilderWithoutAssociations typesBuilder, JvmTypeReferenceBuilder typeReferenceBuilder, JvmAnnotationReferenceBuilder annotationReferenceBuilder) {
 		this._typesBuilder = typesBuilder;
 		this._typeReferenceBuilder = typeReferenceBuilder;
 		this._annotationTypesBuilder = annotationReferenceBuilder;
 		this._parameterGenerator = new ParameterGenerator(typeReferenceBuilder, typesBuilder);
 	}
 	
-	public def copyBuildersTo(TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
+	def copyBuildersTo(TypesBuilderExtensionProvider typesBuilderExtensionProvider) {
 		typesBuilderExtensionProvider._typesBuilder = _typesBuilder;
 		typesBuilderExtensionProvider._typeReferenceBuilder = _typeReferenceBuilder;
 		typesBuilderExtensionProvider._annotationTypesBuilder = _annotationTypesBuilder;

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/linking/ReactionsLinkingService.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/linking/ReactionsLinkingService.xtend
@@ -21,10 +21,10 @@ import org.eclipse.emf.ecore.EcorePackage
  * Uses <code>EPackage.Registry</code> to deresolve URIs.
  */
 class ReactionsLinkingService extends DefaultLinkingService {
-	private static final Logger log = Logger.getLogger(typeof(ReactionsLinkingService));
+	static final Logger log = Logger.getLogger(typeof(ReactionsLinkingService));
 	
 	@Inject
-	private IValueConverterService valueConverterService;
+	IValueConverterService valueConverterService;
 	
 	override getLinkedObjects(EObject context, EReference ref, INode node) throws IllegalNodeException {
 		if (ref.getEType.equals(EcorePackage.Literals.EPACKAGE))

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/util/ReactionsLanguageUtil.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/util/ReactionsLanguageUtil.xtend
@@ -25,7 +25,7 @@ final class ReactionsLanguageUtil {
 	 * @param reactionsSegment the reactions segment
 	 * @return the formatted representation of the metamodel pair
 	 */
-	public static def String getFormattedMetamodelPair(ReactionsSegment reactionsSegment) {
+	static def String getFormattedMetamodelPair(ReactionsSegment reactionsSegment) {
 		val sourceDomainName = reactionsSegment.fromDomain?.domain;
 		val targetDomainName = reactionsSegment.toDomain?.domain;
 		return "(" + sourceDomainName + ", " + targetDomainName + ")";
@@ -41,7 +41,7 @@ final class ReactionsLanguageUtil {
 	 * @param reactionsSegment the reactions segment
 	 * @return the formatted reactions segment name
 	 */
-	public static def String getFormattedName(ReactionsSegment reactionsSegment) {
+	static def String getFormattedName(ReactionsSegment reactionsSegment) {
 		return reactionsSegment.name.formattedReactionsSegmentName;
 	}
 
@@ -53,7 +53,7 @@ final class ReactionsLanguageUtil {
 	 * @param reactionsSegmentName the reactions segment name
 	 * @return the formatted reactions segment name
 	 */
-	public static def String getFormattedReactionsSegmentName(String reactionsSegmentName) {
+	static def String getFormattedReactionsSegmentName(String reactionsSegmentName) {
 		return reactionsSegmentName.toFirstLower;
 	}
 
@@ -67,7 +67,7 @@ final class ReactionsLanguageUtil {
 	 * @param reaction the reaction
 	 * @return the formatted reaction name
 	 */
-	public static def String getFormattedName(Reaction reaction) {
+	static def String getFormattedName(Reaction reaction) {
 		return reaction.name.toFirstUpper;
 	}
 
@@ -84,7 +84,7 @@ final class ReactionsLanguageUtil {
 	 * @param reaction the reaction
 	 * @return the qualified name
 	 */
-	public static def String getQualifiedName(Reaction reaction) {
+	static def String getQualifiedName(Reaction reaction) {
 		var String reactionsSegmentName;
 		if (reaction.isOverride) {
 			reactionsSegmentName = reaction.overriddenReactionsSegment?.name;
@@ -104,7 +104,7 @@ final class ReactionsLanguageUtil {
 	 * @param reaction the reaction
 	 * @return the formatted full name
 	 */
-	public static def String getDisplayName(Reaction reaction) {
+	static def String getDisplayName(Reaction reaction) {
 		if (reaction.isOverride) {
 			return reaction.qualifiedName;
 		} else {
@@ -122,7 +122,7 @@ final class ReactionsLanguageUtil {
 	 * @param routine the routine
 	 * @return the formatted routine name
 	 */
-	public static def String getFormattedName(Routine routine) {
+	static def String getFormattedName(Routine routine) {
 		return routine.name.toFirstLower;
 	}
 
@@ -139,7 +139,7 @@ final class ReactionsLanguageUtil {
 	 * @param routine the routine
 	 * @return the qualified name
 	 */
-	public static def String getQualifiedName(Routine routine) {
+	static def String getQualifiedName(Routine routine) {
 		var String reactionsSegmentName;
 		if (routine.isOverride) {
 			reactionsSegmentName = routine.overrideImportPath.reactionsSegment?.name;
@@ -160,7 +160,7 @@ final class ReactionsLanguageUtil {
 	 * 
 	 * @see #getFullyQualifiedName(Routine, ReactionsImportPath)
 	 */
-	public static def String getFullyQualifiedName(Routine routine) {
+	static def String getFullyQualifiedName(Routine routine) {
 		return routine.getFullyQualifiedName(null);
 	}
 
@@ -183,7 +183,7 @@ final class ReactionsLanguageUtil {
 	 * @param importPath the import path leading to the reactions segment containing the routine, or <code>null</code> or empty
 	 * @return the fully qualified name
 	 */
-	public static def String getFullyQualifiedName(Routine routine, ReactionsImportPath importPath) {
+	static def String getFullyQualifiedName(Routine routine, ReactionsImportPath importPath) {
 		val reactionsSegmentName = routine.reactionsSegment.name;
 		val importPathSpecified = (importPath !== null && !importPath.isEmpty);
 		var String fullyQualifiedName = "";
@@ -215,7 +215,7 @@ final class ReactionsLanguageUtil {
 	 * @param routine the routine
 	 * @return the formatted full name
 	 */
-	public static def String getDisplayName(Routine routine) {
+	static def String getDisplayName(Routine routine) {
 		if (routine.isOverride) {
 			return routine.fullyQualifiedName;
 		} else {
@@ -233,7 +233,7 @@ final class ReactionsLanguageUtil {
 	 * @param reaction the reaction
 	 * @return <code>true</code> if the given reaction is a regular reaction
 	 */
-	public static def isRegular(Reaction reaction) {
+	static def isRegular(Reaction reaction) {
 		return !reaction.isOverride;
 	}
 
@@ -243,7 +243,7 @@ final class ReactionsLanguageUtil {
 	 * @param reaction the reaction
 	 * @return <code>true</code> if the given reaction overrides another reaction
 	 */
-	public static def isOverride(Reaction reaction) {
+	static def isOverride(Reaction reaction) {
 		// check if overridden reactions segment is set, without resolving the cross-reference:
 		return reaction.eIsSet(ReactionsLanguagePackage.Literals.REACTION__OVERRIDDEN_REACTIONS_SEGMENT);
 	}
@@ -255,7 +255,7 @@ final class ReactionsLanguageUtil {
 	 * @return the regular reactions
 	 * @see #isRegular(Reaction)
 	 */
-	public static def getRegularReactions(ReactionsSegment reactionsSegment) {
+	static def getRegularReactions(ReactionsSegment reactionsSegment) {
 		return reactionsSegment.reactions.filter[isRegular];
 	}
 
@@ -266,7 +266,7 @@ final class ReactionsLanguageUtil {
 	 * @return the reactions overriding other reactions
 	 * @see #isOverride(Reaction)
 	 */
-	public static def getOverrideReactions(ReactionsSegment reactionsSegment) {
+	static def getOverrideReactions(ReactionsSegment reactionsSegment) {
 		return reactionsSegment.reactions.filter[isOverride];
 	}
 
@@ -280,7 +280,7 @@ final class ReactionsLanguageUtil {
 	 * @param routine the routine
 	 * @return <code>true</code> if the given routine is a regular routine
 	 */
-	public static def isRegular(Routine routine) {
+	static def isRegular(Routine routine) {
 		return !routine.isOverride;
 	}
 
@@ -290,7 +290,7 @@ final class ReactionsLanguageUtil {
 	 * @param routine the routine
 	 * @return <code>true</code> if the given routine overrides another routine
 	 */
-	public static def isOverride(Routine routine) {
+	static def isOverride(Routine routine) {
 		return (routine.overrideImportPath !== null);
 	}
 
@@ -301,7 +301,7 @@ final class ReactionsLanguageUtil {
 	 * @return the regular routines
 	 * @see #isRegular(Routine)
 	 */
-	public static def getRegularRoutines(ReactionsSegment reactionsSegment) {
+	static def getRegularRoutines(ReactionsSegment reactionsSegment) {
 		return reactionsSegment.routines.filter[isRegular];
 	}
 
@@ -312,7 +312,7 @@ final class ReactionsLanguageUtil {
 	 * @return the routines overriding other routines
 	 * @see #isOverride(Routine)
 	 */
-	public static def getOverrideRoutines(ReactionsSegment reactionsSegment) {
+	static def getOverrideRoutines(ReactionsSegment reactionsSegment) {
 		return reactionsSegment.routines.filter[isOverride];
 	}
 
@@ -325,7 +325,7 @@ final class ReactionsLanguageUtil {
 	 * @param routineOverrideImportPath the routine override import path, can be <code>null</code>
 	 * @return the corresponding reactions import path, or <code>null</code> if the given routine override import path was <code>null</code>
 	 */
-	public static def ReactionsImportPath toReactionsImportPath(RoutineOverrideImportPath routineOverrideImportPath) {
+	static def ReactionsImportPath toReactionsImportPath(RoutineOverrideImportPath routineOverrideImportPath) {
 		if (routineOverrideImportPath === null) return null;
 		val fullPathSegments = routineOverrideImportPath.fullPath.map [
 			val segment = it.reactionsSegment;
@@ -347,7 +347,7 @@ final class ReactionsLanguageUtil {
 	 * @param routineOverrideImportPath the routine override import path, can be <code>null</code>
 	 * @return the segments of the full routine override import path, or <code>null</code> if the given routine override import path was <code>null</code>
 	 */
-	public static def List<RoutineOverrideImportPath> getFullPath(RoutineOverrideImportPath routineOverrideImportPath) {
+	static def List<RoutineOverrideImportPath> getFullPath(RoutineOverrideImportPath routineOverrideImportPath) {
 		if (routineOverrideImportPath === null) return null;
 		val pathSegments = new ArrayList<RoutineOverrideImportPath>();
 		var currentPath = routineOverrideImportPath;

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/operators/AttributeOperand.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/operators/AttributeOperand.xtend
@@ -6,8 +6,8 @@ import org.eclipse.emf.ecore.EStructuralFeature
 
 class AttributeOperand {
 
-	private val EObject object
-	private val EStructuralFeature feature
+	val EObject object
+	val EStructuralFeature feature
 
 	new(EObject object, EStructuralFeature feature) {
 		Preconditions.checkNotNull(object, "Object is null!")
@@ -16,11 +16,11 @@ class AttributeOperand {
 		this.feature = feature
 	}
 
-	public def getObject() {
+	def getObject() {
 		return object
 	}
 
-	public def getFeature() {
+	def getFeature() {
 		return feature
 	}
 }

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.mappings/src/tools/vitruv/extensions/dslsruntime/mappings/impl/SetMultimapElementsRegistry.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.mappings/src/tools/vitruv/extensions/dslsruntime/mappings/impl/SetMultimapElementsRegistry.xtend
@@ -36,7 +36,7 @@ class SetMultimapElementsRegistry implements IElementsRegistry {
 		}
 	}
 	
-	override def <C extends EObject> void removeElement(Class<C> clazz, C element) {
+	override <C extends EObject> void removeElement(Class<C> clazz, C element) {
 		val wasMapped = elementsMap.remove(clazz, element)
 		if (!wasMapped) {
 			throw new IllegalStateException('''Cannot deregister the element '«element»' for the mapping '«mappingName»'

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractReactionRealization.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractReactionRealization.xtend
@@ -8,11 +8,11 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import tools.vitruv.framework.userinteraction.UserInteractor
 
 abstract class AbstractReactionRealization extends CallHierarchyHaving implements IReactionRealization {
-	private val AbstractRepairRoutinesFacade routinesFacade;
+	val AbstractRepairRoutinesFacade routinesFacade;
 	protected UserInteractor userInteractor;
 	protected ReactionExecutionState executionState;
 	
-	public new(AbstractRepairRoutinesFacade routinesFacade) {
+	new(AbstractRepairRoutinesFacade routinesFacade) {
 		this.routinesFacade = routinesFacade;
 	}
 	

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractReactionsExecutor.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractReactionsExecutor.xtend
@@ -11,10 +11,10 @@ import tools.vitruv.framework.util.command.ResourceAccess
 import java.util.List
 
 abstract class AbstractReactionsExecutor extends AbstractEChangePropagationSpecification {
-	private final static val LOGGER = Logger.getLogger(AbstractReactionsExecutor);
+	static val LOGGER = Logger.getLogger(AbstractReactionsExecutor);
 
-	private val RoutinesFacadesProvider routinesFacadesProvider;
-	private List<IReactionRealization> reactions;
+	val RoutinesFacadesProvider routinesFacadesProvider;
+	List<IReactionRealization> reactions;
 
 	new(VitruvDomain sourceDomain, VitruvDomain targetDomain) {
 		super(sourceDomain, targetDomain);
@@ -31,11 +31,11 @@ abstract class AbstractReactionsExecutor extends AbstractEChangePropagationSpeci
 		this.reactions += reaction;
 	}
 
-	public override doesHandleChange(EChange change, CorrespondenceModel correspondenceModel) {
+	override doesHandleChange(EChange change, CorrespondenceModel correspondenceModel) {
 		return true
 	}
 
-	public override propagateChange(EChange change, CorrespondenceModel correspondenceModel,
+	override propagateChange(EChange change, CorrespondenceModel correspondenceModel,
 		ResourceAccess resourceAccess) {
 		LOGGER.trace("Call relevant reactions from " + sourceDomain.name + " to " + targetDomain.name);
 		for (reaction : reactions) {

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutineRealization.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutineRealization.xtend
@@ -19,13 +19,13 @@ import tools.vitruv.framework.util.command.ResourceAccess
 import tools.vitruv.framework.util.datatypes.VURI
 
 abstract class AbstractRepairRoutineRealization extends CallHierarchyHaving implements RepairRoutine, ReactionElementsHandler {
-	private val AbstractRepairRoutinesFacade routinesFacade;
-	private extension val ReactionExecutionState executionState;
+	val AbstractRepairRoutinesFacade routinesFacade;
+	extension val ReactionExecutionState executionState;
 
 	@Delegate
-	private val ReactionElementsHandler _reactionElementsHandler;
+	val ReactionElementsHandler _reactionElementsHandler;
 
-	public new(AbstractRepairRoutinesFacade routinesFacade, ReactionExecutionState executionState, CallHierarchyHaving calledBy) {
+	new(AbstractRepairRoutinesFacade routinesFacade, ReactionExecutionState executionState, CallHierarchyHaving calledBy) {
 		super(calledBy);
 		this.routinesFacade = routinesFacade;
 		this.executionState = executionState;
@@ -85,7 +85,7 @@ abstract class AbstractRepairRoutineRealization extends CallHierarchyHaving impl
 		return retrievedElement;
 	}
 
-	public override boolean applyRoutine() {
+	override boolean applyRoutine() {
 		// capture the current routines facade execution state:
 		val facadeExecutionState = routinesFacade._getExecutionState().capture();
 		// set the reaction execution state and caller to use for all following routine calls:
@@ -102,7 +102,7 @@ abstract class AbstractRepairRoutineRealization extends CallHierarchyHaving impl
 
 	protected abstract def boolean executeRoutine() throws IOException;
 
-	public static class UserExecution extends Loggable {
+	static class UserExecution extends Loggable {
 		protected final extension ReactionExecutionState executionState
 
 		new(ReactionExecutionState executionState) {

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutinesFacade.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutinesFacade.xtend
@@ -9,13 +9,13 @@ import tools.vitruv.extensions.dslsruntime.reactions.structure.ReactionsImportPa
  */
 abstract class AbstractRepairRoutinesFacade extends Loggable {
 	// used by concrete implementations to request routines facades of executed routines: 
-	private val RoutinesFacadesProvider routinesFacadesProvider;
+	val RoutinesFacadesProvider routinesFacadesProvider;
 	// absolute path inside the import hierarchy to the segment this routines facade belongs to, never null:
-	private val ReactionsImportPath reactionsImportPath;
+	val ReactionsImportPath reactionsImportPath;
 	// shared execution state among all routines facades in the import hierarchy:
-	private val RoutinesFacadeExecutionState executionState;
+	val RoutinesFacadeExecutionState executionState;
 
-	public new(RoutinesFacadesProvider routinesFacadesProvider, ReactionsImportPath reactionsImportPath, RoutinesFacadeExecutionState executionState) {
+	new(RoutinesFacadesProvider routinesFacadesProvider, ReactionsImportPath reactionsImportPath, RoutinesFacadeExecutionState executionState) {
 		this.routinesFacadesProvider = routinesFacadesProvider;
 		this.reactionsImportPath = reactionsImportPath;
 		this.executionState = executionState;

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRoutinesFacadesProvider.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRoutinesFacadesProvider.xtend
@@ -14,11 +14,11 @@ import static com.google.common.base.Preconditions.*
  */
 abstract class AbstractRoutinesFacadesProvider implements RoutinesFacadesProvider {
 
-	private val RoutinesFacadeExecutionState sharedRoutinesFacadeExecutionState = new RoutinesFacadeExecutionState();
+	val RoutinesFacadeExecutionState sharedRoutinesFacadeExecutionState = new RoutinesFacadeExecutionState();
 	// the routines facades that were created so far:
-	private val Map<ReactionsImportPath, AbstractRepairRoutinesFacade> routinesFacades = new HashMap<ReactionsImportPath, AbstractRepairRoutinesFacade>();
+	val Map<ReactionsImportPath, AbstractRepairRoutinesFacade> routinesFacades = new HashMap<ReactionsImportPath, AbstractRepairRoutinesFacade>();
 
-	public new() {
+	new() {
 	}
 
 	// creates the specified routines facade:

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/CorrespondenceFailHandler.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/CorrespondenceFailHandler.xtend
@@ -7,5 +7,5 @@ interface CorrespondenceFailHandler {
 	/** 
 	 * Returns whether the execution shall be continued or not 
 	 */
-	public def boolean handle(Iterable<? extends EObject> foundObjects, EObject sourceElement, Class<?> expectedType, UserInteractor userInteractor);
+	def boolean handle(Iterable<? extends EObject> foundObjects, EObject sourceElement, Class<?> expectedType, UserInteractor userInteractor);
 }

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/IReactionRealization.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/IReactionRealization.xtend
@@ -2,6 +2,6 @@ package tools.vitruv.extensions.dslsruntime.reactions
 
 import tools.vitruv.framework.change.echange.EChange
 
-public interface IReactionRealization {
-	public def void applyEvent(EChange change, ReactionExecutionState executionState);
+interface IReactionRealization {
+	def void applyEvent(EChange change, ReactionExecutionState executionState);
 }

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/ReactionElementsHandler.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/ReactionElementsHandler.xtend
@@ -3,9 +3,9 @@ package tools.vitruv.extensions.dslsruntime.reactions
 import org.eclipse.emf.ecore.EObject
 
 interface ReactionElementsHandler {
-	public def void addCorrespondenceBetween(EObject firstElement, EObject secondElement, String tag);
-	public def void removeCorrespondenceBetween(EObject firstElement, EObject secondElement, String tag);
-	public def void deleteObject(EObject element);
-	public def void registerObjectUnderModification(EObject element);
-	public def void postprocessElements();
+	def void addCorrespondenceBetween(EObject firstElement, EObject secondElement, String tag);
+	def void removeCorrespondenceBetween(EObject firstElement, EObject secondElement, String tag);
+	def void deleteObject(EObject element);
+	def void registerObjectUnderModification(EObject element);
+	def void postprocessElements();
 }

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/ReactionsExecutor.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/ReactionsExecutor.xtend
@@ -6,5 +6,5 @@ import tools.vitruv.framework.change.echange.EChange
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 interface ReactionsExecutor {
-	public def List<Command> generateCommandsForEvent(EChange change, CorrespondenceModel correspondenceModel);
+	def List<Command> generateCommandsForEvent(EChange change, CorrespondenceModel correspondenceModel);
 }

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/RepairRoutine.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/RepairRoutine.xtend
@@ -1,5 +1,5 @@
 package tools.vitruv.extensions.dslsruntime.reactions
 
 interface RepairRoutine {
-	public def boolean applyRoutine();
+	def boolean applyRoutine();
 }

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/RoutinesFacadeExecutionState.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/RoutinesFacadeExecutionState.xtend
@@ -9,10 +9,10 @@ import tools.vitruv.extensions.dslsruntime.reactions.structure.CallHierarchyHavi
  */
 class RoutinesFacadeExecutionState {
 
-	private var ReactionExecutionState reactionExecutionState = null;
-	private var CallHierarchyHaving caller = null;
+	var ReactionExecutionState reactionExecutionState = null;
+	var CallHierarchyHaving caller = null;
 
-	public new() {
+	new() {
 	}
 
 	private new(ReactionExecutionState reactionExecutionState, CallHierarchyHaving caller) {
@@ -20,30 +20,30 @@ class RoutinesFacadeExecutionState {
 		this.caller = caller;
 	}
 
-	public def ReactionExecutionState getReactionExecutionState() {
+	def ReactionExecutionState getReactionExecutionState() {
 		return reactionExecutionState;
 	}
 
-	public def CallHierarchyHaving getCaller() {
+	def CallHierarchyHaving getCaller() {
 		return caller;
 	}
 
-	public def void setExecutionState(ReactionExecutionState reactionExecutionState, CallHierarchyHaving caller) {
+	def void setExecutionState(ReactionExecutionState reactionExecutionState, CallHierarchyHaving caller) {
 		this.reactionExecutionState = reactionExecutionState;
 		this.caller = caller;
 	}
 
-	public def void reset() {
+	def void reset() {
 		this.setExecutionState(null, null);
 	}
 
 	// creates a snapshot of the current execution state:
-	public def RoutinesFacadeExecutionState capture() {
+	def RoutinesFacadeExecutionState capture() {
 		return new RoutinesFacadeExecutionState(reactionExecutionState, caller);
 	}
 
 	// restores a previously captured execution state:
-	public def void restore(RoutinesFacadeExecutionState executionState) {
+	def void restore(RoutinesFacadeExecutionState executionState) {
 		this.setExecutionState(executionState.reactionExecutionState, executionState.caller);
 	}
 }

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/RoutinesFacadesProvider.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/RoutinesFacadesProvider.xtend
@@ -18,5 +18,5 @@ interface RoutinesFacadesProvider {
 	 * @throws IllegalArgumentException if the specified import path is not valid (for ex. does not exist in the import hierarchy)
 	 * @throws ClassCastException if the specified routines facade type is not applicable to the actually returned routines facade
 	 */
-	public def <T extends AbstractRepairRoutinesFacade> T getRoutinesFacade(ReactionsImportPath reactionsImportPath);
+	def <T extends AbstractRepairRoutinesFacade> T getRoutinesFacade(ReactionsImportPath reactionsImportPath);
 }

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/correspondenceFailHandler/CorrespondenceFailCustomDialog.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/correspondenceFailHandler/CorrespondenceFailCustomDialog.xtend
@@ -5,10 +5,10 @@ import tools.vitruv.framework.userinteraction.UserInteractor
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
 class CorrespondenceFailCustomDialog extends AbstractCorrespondenceFailHandler {
-	private final boolean abortEffect;
-	private final String message;
+	final boolean abortEffect;
+	final String message;
 	
-	public new(boolean abortEffect, String message) {
+	new(boolean abortEffect, String message) {
 		this.abortEffect = abortEffect;
 		this.message = message;
 	}

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/correspondenceFailHandler/CorrespondenceFailDefaultDialog.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/correspondenceFailHandler/CorrespondenceFailDefaultDialog.xtend
@@ -5,9 +5,9 @@ import tools.vitruv.framework.userinteraction.UserInteractor
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
 class CorrespondenceFailDefaultDialog extends AbstractCorrespondenceFailHandler {
-	private final boolean abortEffect;
+	final boolean abortEffect;
 	
-	public new(boolean abortEffect) {
+	new(boolean abortEffect) {
 		this.abortEffect = abortEffect;
 	}
 	

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/correspondenceFailHandler/CorrespondenceFailDoNothing.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/correspondenceFailHandler/CorrespondenceFailDoNothing.xtend
@@ -4,9 +4,9 @@ import org.eclipse.emf.ecore.EObject
 import tools.vitruv.framework.userinteraction.UserInteractor
 
 class CorrespondenceFailDoNothing extends AbstractCorrespondenceFailHandler {
-	private final boolean abortEffect;
+	final boolean abortEffect;
 	
-	public new(boolean abortEffect) {
+	new(boolean abortEffect) {
 		this.abortEffect = abortEffect;
 	}
 	

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/effects/ReactionElementsHandlerImpl.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/effects/ReactionElementsHandlerImpl.xtend
@@ -9,11 +9,11 @@ import org.apache.log4j.Logger
 import tools.vitruv.extensions.dslsruntime.reactions.ReactionElementsHandler
 
 class ReactionElementsHandlerImpl implements ReactionElementsHandler {
-	private static val logger = Logger.getLogger(ReactionElementsHandlerImpl);
+	static val logger = Logger.getLogger(ReactionElementsHandlerImpl);
 	
-	private final CorrespondenceModel correspondenceModel;
+	final CorrespondenceModel correspondenceModel;
 	
-	public new(CorrespondenceModel correspondenceModel) {
+	new(CorrespondenceModel correspondenceModel) {
 		this.correspondenceModel = correspondenceModel;
 	}
 	

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/PersistenceHelper.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/PersistenceHelper.xtend
@@ -7,10 +7,10 @@ import org.eclipse.emf.common.util.URI
 import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil
 import tools.vitruv.framework.util.VitruviusConstants
 
-public final class PersistenceHelper {
+final class PersistenceHelper {
 	private new() {}
 	
-	public static def EObject getModelRoot(EObject modelObject) {
+	static def EObject getModelRoot(EObject modelObject) {
 		var result = modelObject;
 		while (result.eContainer() !== null) {
 			result = result.eContainer();
@@ -61,7 +61,7 @@ public final class PersistenceHelper {
 		return baseURI.appendSegments(newModelFileSegments);
 	}
 
-	public static def URI getURIFromSourceResourceFolder(EObject source, String relativePath) {
+	static def URI getURIFromSourceResourceFolder(EObject source, String relativePath) {
 		val baseURI = getURIOfElementResourceFolder(source);
 		return baseURI.appendPathToURI(relativePath);
 	}
@@ -77,7 +77,7 @@ public final class PersistenceHelper {
 	 * 
 	 * @returns the {@link URI} of the folder within the project of the given element
 	 */
-	public static def URI getURIFromSourceProjectFolder(EObject source, String relativePath) {
+	static def URI getURIFromSourceProjectFolder(EObject source, String relativePath) {
 		val baseURI = getURIOfElementProject(source);
 		return baseURI.appendPathToURI(relativePath);
 	}

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/ReactionsCorrespondenceHelper.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/helper/ReactionsCorrespondenceHelper.xtend
@@ -19,21 +19,21 @@ final class ReactionsCorrespondenceHelper {
 		return correspondenceModel.getEditableView(ReactionsCorrespondenceModelViewFactory.instance);
 	}
 
-	public static def removeCorrespondencesBetweenElements(CorrespondenceModel correspondenceModel,
+	static def removeCorrespondencesBetweenElements(CorrespondenceModel correspondenceModel,
 		EObject source, EObject target, String tag) {
 		logger.trace("Removing correspondence between " + source + " and " + target + " with tag: " + tag);
 		val correspondenceModelView = correspondenceModel.reactionsView;
 		correspondenceModelView.removeCorrespondencesBetween(#[source], #[target], tag);
 	}
 
-	public static def removeCorrespondencesOfObject(CorrespondenceModel correspondenceModel,
+	static def removeCorrespondencesOfObject(CorrespondenceModel correspondenceModel,
 		EObject source) {
 		logger.trace("Removing correspondences of object " + source);
 		val correspondenceModelView = correspondenceModel.reactionsView;
 		correspondenceModelView.removeCorrespondencesFor(#[source], null);
 	}
 
-	public static def ReactionsCorrespondence addCorrespondence(
+	static def ReactionsCorrespondence addCorrespondence(
 		CorrespondenceModel correspondenceModel, EObject source, EObject target, String tag) {
 		logger.trace("Adding correspondence between " + source + " and " + target + " with tag: " + tag);
 		val correspondence = correspondenceModel.reactionsView.
@@ -42,13 +42,13 @@ final class ReactionsCorrespondenceHelper {
 		return correspondence;
 	}
 
-	public static def <T> Iterable<T> getCorrespondingObjectsOfType(
+	static def <T> Iterable<T> getCorrespondingObjectsOfType(
 		CorrespondenceModel correspondenceModel, EObject source, String expectedTag,
 		Class<T> type) {
 			return correspondenceModel.reactionsView.getCorrespondingEObjects(#[source], expectedTag).flatten.filter(type);
 	}
 
-	public static def <T> List<T> getCorrespondingModelElements(EObject sourceElement, Class<T> affectedElementClass,
+	static def <T> List<T> getCorrespondingModelElements(EObject sourceElement, Class<T> affectedElementClass,
 		String expectedTag, Function1<T, Boolean> preconditionMethod, CorrespondenceModel correspondenceModel) {
 		if (sourceElement === null) {
 			return #[];

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/structure/CallHierarchyHaving.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/structure/CallHierarchyHaving.xtend
@@ -1,21 +1,21 @@
 package tools.vitruv.extensions.dslsruntime.reactions.structure
 
 class CallHierarchyHaving extends Loggable {
-	private val CallHierarchyHaving calledBy;
+	val CallHierarchyHaving calledBy;
 	
-	public new() {
+	new() {
 		calledBy = null;
 	}
 	
-	public new (CallHierarchyHaving calledBy) {
+	new (CallHierarchyHaving calledBy) {
 		this.calledBy = calledBy;
 	}
 	
-	public def CallHierarchyHaving getCalledBy() {
+	def CallHierarchyHaving getCalledBy() {
 		return calledBy;
 	}
 	
-	public def String getCalledByString() {
+	def String getCalledByString() {
 		return '''(«this.class.simpleName»)«IF calledBy !== null» called by «calledBy.calledByString»«ENDIF»''';
 	}
 }

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/structure/Loggable.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/structure/Loggable.xtend
@@ -3,9 +3,9 @@ package tools.vitruv.extensions.dslsruntime.reactions.structure
 import org.apache.log4j.Logger
 
 class Loggable {
-	private val Logger LOGGER;
+	val Logger LOGGER;
 	
-	public new() {
+	new() {
 		LOGGER = Logger.getLogger(this.class);
 	}
 	

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/structure/ReactionsImportPath.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/structure/ReactionsImportPath.xtend
@@ -19,7 +19,7 @@ class ReactionsImportPath {
 	 * The separator used between path segments in the String representation of {@link ReactionsImportPath ReactionsImportPaths}.
 	 */
 	public static final String PATH_STRING_SEPARATOR = ".";
-	private static final Pattern PATH_STRING_SEPARATOR_PATTERN = Pattern.compile(Pattern.quote(PATH_STRING_SEPARATOR));
+	static final Pattern PATH_STRING_SEPARATOR_PATTERN = Pattern.compile(Pattern.quote(PATH_STRING_SEPARATOR));
 
 	/**
 	 * Creates a {@link ReactionsImportPath} from the given path String.
@@ -27,7 +27,7 @@ class ReactionsImportPath {
 	 * @param pathString the pathString
 	 * @return the reactions import path
 	 */
-	public static def ReactionsImportPath fromPathString(String pathString) {
+	static def ReactionsImportPath fromPathString(String pathString) {
 		if (pathString.isNullOrEmpty) return EMPTY_PATH;
 		val pathSegments = PATH_STRING_SEPARATOR_PATTERN.split(pathString, -1);
 		return create(pathSegments);
@@ -35,25 +35,25 @@ class ReactionsImportPath {
 
 	// construction:
 
-	public static def ReactionsImportPath create(Iterable<String> pathSegments) {
+	static def ReactionsImportPath create(Iterable<String> pathSegments) {
 		if (pathSegments.isNullOrEmpty) return EMPTY_PATH;
 		return new ReactionsImportPath(pathSegments);
 	}
 
-	public static def ReactionsImportPath create(String... pathSegments) {
+	static def ReactionsImportPath create(String... pathSegments) {
 		return create(pathSegments as Iterable<String>);
 	}
 
-	public static def ReactionsImportPath create(Iterable<String> parentPath, String... pathSegments) {
+	static def ReactionsImportPath create(Iterable<String> parentPath, String... pathSegments) {
 		return create(parentPath, pathSegments as Iterable<String>);
 	}
 
-	public static def ReactionsImportPath create(Iterable<String> parentPath, Iterable<String> pathSegments) {
+	static def ReactionsImportPath create(Iterable<String> parentPath, Iterable<String> pathSegments) {
 		return create((parentPath ?: #[]) + (pathSegments ?: #[]));
 	}
 
 	// the names of the reactions segments along the path:
-	private val List<String> segments; // immutable, can be empty, does not contain null
+	val List<String> segments; // immutable, can be empty, does not contain null
 
 	private new(Iterable<String> pathSegments) {
 		checkNotNull(pathSegments, "pathSegments is null");
@@ -65,7 +65,7 @@ class ReactionsImportPath {
 	 * 
 	 * @return an unmodifiable view on the segments of this import path, can be empty
 	 */
-	public def List<String> getSegments() {
+	def List<String> getSegments() {
 		return segments;
 	}
 
@@ -74,7 +74,7 @@ class ReactionsImportPath {
 	 * 
 	 * @return the number of segments this import path consists of
 	 */
-	public def int getLength() {
+	def int getLength() {
 		return segments.size();
 	}
 
@@ -83,7 +83,7 @@ class ReactionsImportPath {
 	 * 
 	 * @return <code>true</code> if this import path is empty
 	 */
-	public def boolean isEmpty() {
+	def boolean isEmpty() {
 		return (this.length == 0);
 	}
 
@@ -93,7 +93,7 @@ class ReactionsImportPath {
 	 * @param index the index
 	 * @return the path segment at the specified index
 	 */
-	public def String getSegment(int index) {
+	def String getSegment(int index) {
 		return segments.get(index);
 	}
 
@@ -102,7 +102,7 @@ class ReactionsImportPath {
 	 * 
 	 * @return the last path segment
 	 */
-	public def String getLastSegment() {
+	def String getLastSegment() {
 		return segments.get(segments.size() - 1);
 	}
 
@@ -111,7 +111,7 @@ class ReactionsImportPath {
 	 * 
 	 * @return the first path segment
 	 */
-	public def String getFirstSegment() {
+	def String getFirstSegment() {
 		return segments.get(0);
 	}
 
@@ -121,7 +121,7 @@ class ReactionsImportPath {
 	 * @param pathSegments the path segments to append, can be <code>null</code>
 	 * @return the resulting reactions import path
 	 */
-	public def ReactionsImportPath append(String... pathSegments) {
+	def ReactionsImportPath append(String... pathSegments) {
 		return this.append(pathSegments as Iterable<String>);
 	}
 
@@ -131,7 +131,7 @@ class ReactionsImportPath {
 	 * @param pathSegments the path segments to append, can be <code>null</code>
 	 * @return the resulting reactions import path
 	 */
-	public def ReactionsImportPath append(Iterable<String> pathSegments) {
+	def ReactionsImportPath append(Iterable<String> pathSegments) {
 		return ReactionsImportPath.create(this.segments, pathSegments);
 	}
 
@@ -141,7 +141,7 @@ class ReactionsImportPath {
 	 * @param path the path to append, can be <code>null</code>
 	 * @return the resulting reactions import path
 	 */
-	public def ReactionsImportPath append(ReactionsImportPath path) {
+	def ReactionsImportPath append(ReactionsImportPath path) {
 		return ReactionsImportPath.create(this.segments, path?.segments);
 	}
 
@@ -151,7 +151,7 @@ class ReactionsImportPath {
 	 * @param pathSegments the path segments to prepend, can be <code>null</code>
 	 * @return the resulting reactions import path
 	 */
-	public def ReactionsImportPath prepend(String... pathSegments) {
+	def ReactionsImportPath prepend(String... pathSegments) {
 		return this.prepend(pathSegments as Iterable<String>);
 	}
 
@@ -161,7 +161,7 @@ class ReactionsImportPath {
 	 * @param pathSegments the path segments to prepend, can be <code>null</code>
 	 * @return the resulting reactions import path
 	 */
-	public def ReactionsImportPath prepend(Iterable<String> pathSegments) {
+	def ReactionsImportPath prepend(Iterable<String> pathSegments) {
 		return ReactionsImportPath.create(pathSegments, this.segments);
 	}
 
@@ -171,7 +171,7 @@ class ReactionsImportPath {
 	 * @param path the path to prepend, can be <code>null</code>
 	 * @return the resulting reactions import path
 	 */
-	public def ReactionsImportPath prepend(ReactionsImportPath path) {
+	def ReactionsImportPath prepend(ReactionsImportPath path) {
 		return ReactionsImportPath.create(path?.segments, this.segments);
 	}
 
@@ -180,7 +180,7 @@ class ReactionsImportPath {
 	 * 
 	 * @return the resulting reactions import path, can be empty
 	 */
-	public def ReactionsImportPath getParent() {
+	def ReactionsImportPath getParent() {
 		val parentPath = segments.take(length - 1);
 		return ReactionsImportPath.create(parentPath);
 	}
@@ -190,7 +190,7 @@ class ReactionsImportPath {
 	 * 
 	 * @return the resulting reactions import path, can be empty
 	 */
-	public def ReactionsImportPath relativeToRoot() {
+	def ReactionsImportPath relativeToRoot() {
 		val tailPath = segments.tail;
 		return ReactionsImportPath.create(tailPath);
 	}
@@ -200,7 +200,7 @@ class ReactionsImportPath {
 	 * 
 	 * @return the resulting reactions import path, or an empty path if the specified segment is not contained or the last segment of this path
 	 */
-	public def ReactionsImportPath relativeTo(String pathSegment) {
+	def ReactionsImportPath relativeTo(String pathSegment) {
 		val index = segments.indexOf(pathSegment);
 		if (index == -1 || index == (length - 1)) {
 			// segment is not contained or the last segment of the path:
@@ -215,7 +215,7 @@ class ReactionsImportPath {
 	 * 
 	 * @return the resulting reactions import path, or an empty path if the specified segment is not contained in this path
 	 */
-	public def ReactionsImportPath subPathTo(String pathSegment) {
+	def ReactionsImportPath subPathTo(String pathSegment) {
 		val index = segments.indexOf(pathSegment);
 		if (index == -1) {
 			// segment is not contained in this path:
@@ -230,19 +230,19 @@ class ReactionsImportPath {
 	 * 
 	 * @return the String representation of this import path
 	 */
-	public def String getPathString() {
+	def String getPathString() {
 		return segments.join(PATH_STRING_SEPARATOR);
 	}
 
-	public override String toString() {
+	override String toString() {
 		return "ReactionsImportPath=" + this.pathString;
 	}
 
-	public override int hashCode() {
+	override int hashCode() {
 		return segments.hashCode();
 	}
 
-	public override boolean equals(Object obj) {
+	override boolean equals(Object obj) {
 		if (this === obj) return true;
 		if (obj === null) return false;
 		if (!(obj instanceof ReactionsImportPath)) return false;

--- a/bundles/framework/tools.vitruv.framework.applications/src/tools/vitruv/framework/applications/VitruvApplicationsRegistry.xtend
+++ b/bundles/framework/tools.vitruv.framework.applications/src/tools/vitruv/framework/applications/VitruvApplicationsRegistry.xtend
@@ -26,14 +26,14 @@ class VitruvApplicationsRegistry {
 	 * 
 	 * @param application - the {@link VitruvApplication} to add, must not be null
 	 */
-	public def addApplication(VitruvApplication application) {
+	def addApplication(VitruvApplication application) {
 		if (application === null) {
 			throw new IllegalArgumentException("Application must not be null")
 		}
 		applications += application;
 	}
 	
-	public def getApplications() {
+	def getApplications() {
 		if (!initialized) {
 			applications += allApplicationsFromExtensionPoint
 			initialized = true

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/EChangeIdManager.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/EChangeIdManager.xtend
@@ -46,7 +46,7 @@ class EChangeIdManager {
 		}
 	}
 
-	public def boolean isCreateChange(EObjectAddedEChange<?> addedEChange) {
+	def boolean isCreateChange(EObjectAddedEChange<?> addedEChange) {
 		// We do not check the containment of the reference, because an element may be inserted into a non-containment
 		// reference before inserting it into a containment reference so that the create change has to be added
 		// for the inserting into the non-containment reference

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringAtomicEChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringAtomicEChangeFactory.xtend
@@ -35,7 +35,7 @@ import tools.vitruv.framework.change.echange.feature.UnsetFeature
  * Can be used by any transformation that creates change models.
  */
 class TypeInferringAtomicEChangeFactory {
-	private static TypeInferringAtomicEChangeFactory instance
+	static TypeInferringAtomicEChangeFactory instance
 
 	protected new() {
 	}
@@ -44,7 +44,7 @@ class TypeInferringAtomicEChangeFactory {
 	 * Get the singleton instance of the factory.
 	 * @return The singleton instance.
 	 */
-	def public static TypeInferringAtomicEChangeFactory getInstance() {
+	def static TypeInferringAtomicEChangeFactory getInstance() {
 		if (instance === null) {
 			instance = new TypeInferringAtomicEChangeFactory()
 		}

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringCompoundEChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/TypeInferringCompoundEChangeFactory.xtend
@@ -7,7 +7,7 @@ import org.eclipse.emf.ecore.resource.Resource
 
 class TypeInferringCompoundEChangeFactory {
 	protected TypeInferringAtomicEChangeFactory atomicFactory
-	private static TypeInferringCompoundEChangeFactory instance
+	static TypeInferringCompoundEChangeFactory instance
 
 	protected new(TypeInferringAtomicEChangeFactory atomicFactory) {
 		this.atomicFactory = atomicFactory
@@ -17,7 +17,7 @@ class TypeInferringCompoundEChangeFactory {
 	 * Get the singleton instance of the factory.
 	 * @return The singleton instance.
 	 */
-	def public static TypeInferringCompoundEChangeFactory getInstance() {
+	def static TypeInferringCompoundEChangeFactory getInstance() {
 		if (instance === null) {
 			instance = new TypeInferringCompoundEChangeFactory(TypeInferringAtomicEChangeFactory.instance)
 		}

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/command/RemoveAtCommand.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/command/RemoveAtCommand.xtend
@@ -11,11 +11,11 @@ import org.eclipse.emf.edit.domain.EditingDomain
  * Command which is used to remove a entry of a EList at a specific index.
  * Only single objects are supported.
  */
-public class RemoveAtCommand extends RemoveCommand {
+class RemoveAtCommand extends RemoveCommand {
 	/**
 	 * Index at which the value is removed in the list.
 	 */
-	var private int index;
+	var int index;
 
 	/**
 	 * Constructor for a RemoveAtCommand, which removes an entry of an EList feature at a specific index.
@@ -46,15 +46,15 @@ public class RemoveAtCommand extends RemoveCommand {
 	 * Returns the index at which the value will be removed.
 	 * @return The index
 	 */
-	def public int getIndex() {
+	def int getIndex() {
 		return this.index;
 	}
 
-	override public void doExecute() {
+	override void doExecute() {
 		ownerList.remove(index);
 	}
 
-	override public boolean prepare() {
+	override boolean prepare() {
 		var result = super.prepare() && 0 <= index && index < ownerList.size() && (collection.size() == 1);
 		if (!result) {
 			return false;
@@ -67,7 +67,7 @@ public class RemoveAtCommand extends RemoveCommand {
 		throw new UnsupportedOperationException();
 	}
 
-	override public void doRedo() {
+	override void doRedo() {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/EChangeUnresolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/EChangeUnresolver.xtend
@@ -19,14 +19,14 @@ import tools.vitruv.framework.change.echange.eobject.CreateEObject
 /**
  * Utility class to unresolve a given EChange.
  */
-public class EChangeUnresolver {
+class EChangeUnresolver {
 	private new() {}
 	
 	/**
 	 * Unresolves the attributes of the {@link RootEChange} class.
 	 * @param The RootEChange.
 	 */
-	def static public unresolveRootEChange(RootEChange change) {
+	def static unresolveRootEChange(RootEChange change) {
 		change.resource = null
 	}
 	
@@ -34,7 +34,7 @@ public class EChangeUnresolver {
 	 * Unresolves the attributes of the {@link FeatureEChange} class.
 	 * @param The FeatureEChange.
 	 */
-	def static public <A extends EObject, F extends EStructuralFeature> void unresolveFeatureEChange(FeatureEChange<A,F> change) {
+	def static <A extends EObject, F extends EStructuralFeature> void unresolveFeatureEChange(FeatureEChange<A,F> change) {
 		change.affectedEObject = null
 	}
 	
@@ -42,7 +42,7 @@ public class EChangeUnresolver {
 	 * Unresolves the attributes of the {@link EObjectAddedEChange} class.
 	 * @param The EObjectAddedEChange.
 	 */
-	def static public <T extends EObject> void unresolveEObjectAddedEChange(EObjectAddedEChange<T> change) {
+	def static <T extends EObject> void unresolveEObjectAddedEChange(EObjectAddedEChange<T> change) {
 		change.newValue = null
 	}	
 
@@ -50,7 +50,7 @@ public class EChangeUnresolver {
 	 * Unresolves the attributes of the {@link EObjectExistenceEChange} class.
 	 * @param The EObjectExistenceEChange.
 	 */	
-	def static public <T extends EObject> void unresolveEObjectExistenceEChange(EObjectExistenceEChange<T> change) {
+	def static <T extends EObject> void unresolveEObjectExistenceEChange(EObjectExistenceEChange<T> change) {
 		change.affectedEObject = null
 	}
 	
@@ -58,11 +58,11 @@ public class EChangeUnresolver {
 	 * Unresolves the attributes of the {@link EObjectSubtractedEChange} class.
 	 * @param The EObjectSubtractedEChange.
 	 */	
-	def static public <T extends EObject> void unresolveEObjectSubtractedEChange(EObjectSubtractedEChange<T> change) {
+	def static <T extends EObject> void unresolveEObjectSubtractedEChange(EObjectSubtractedEChange<T> change) {
 		change.oldValue = null
 	}
 
-	def dispatch static public void unresolve(EChange change) {
+	def dispatch static void unresolve(EChange change) {
 		// Do nothing
 	}
 
@@ -70,7 +70,7 @@ public class EChangeUnresolver {
 	 * Dispatch method for {@link InsertRootEObject} to unresolve it.
 	 * @param change The InsertRootEObject.
 	 */	
-	def dispatch public static void unresolve(InsertRootEObject<EObject> change) {
+	def dispatch static void unresolve(InsertRootEObject<EObject> change) {
 		change.unresolveRootEChange
 		change.newValue = null
 	}	
@@ -78,7 +78,7 @@ public class EChangeUnresolver {
 	 * Dispatch method for {@link RemoveRootEObject} to unresolve it.
 	 * @param change The RemoveRootEObject.
 	 */
-	def dispatch public static void unresolve(RemoveRootEObject<EObject> change) {
+	def dispatch static void unresolve(RemoveRootEObject<EObject> change) {
 		change.unresolveRootEChange
 		change.oldValue = null
 	}
@@ -86,14 +86,14 @@ public class EChangeUnresolver {
 	 * Dispatch method for {@link CreateEObject} to unresolve it.
 	 * @param change The CreateEObject change.
 	 */	
-	def dispatch public static void unresolve(CreateEObject<EObject> change) {
+	def dispatch static void unresolve(CreateEObject<EObject> change) {
 		change.unresolveEObjectExistenceEChange
 	}
 	/**
 	 * Dispatch method for {@link DeleteEObject} to unresolve it.
 	 * @param change The DeleteEObject change.
 	 */	
-	def dispatch public static void unresolve(DeleteEObject<EObject> change) {
+	def dispatch static void unresolve(DeleteEObject<EObject> change) {
 		change.unresolveEObjectExistenceEChange
 		change.consequentialRemoveChanges.forEach[unresolve];
 	}
@@ -102,7 +102,7 @@ public class EChangeUnresolver {
 	 * Dispatch method for {@link ReplaceSingleValuedEReference} to unresolve it.
 	 * @param change The ReplaceSingleValuedEReference.
 	 */	
-	def dispatch public static void unresolve(ReplaceSingleValuedEReference<EObject, EObject> change) {
+	def dispatch static void unresolve(ReplaceSingleValuedEReference<EObject, EObject> change) {
 		change.unresolveEObjectAddedEChange
 		change.unresolveEObjectSubtractedEChange
 		change.unresolveFeatureEChange
@@ -112,7 +112,7 @@ public class EChangeUnresolver {
 	 * Dispatch method for {@link InsertEReference} to unresolve it.
 	 * @param change The InsertEReference.
 	 */	
-	def dispatch public static void unresolve(InsertEReference<EObject, EObject> change) {
+	def dispatch static void unresolve(InsertEReference<EObject, EObject> change) {
 		change.unresolveEObjectAddedEChange
 		change.unresolveFeatureEChange		
 	}
@@ -121,7 +121,7 @@ public class EChangeUnresolver {
 	 * Dispatch method for {@link RemoveEReference} to unresolve it.
 	 * @param change The RemoveEReference.
 	 */	
-	def dispatch public static void unresolve(RemoveEReference<EObject, EObject> change) {
+	def dispatch static void unresolve(RemoveEReference<EObject, EObject> change) {
 		change.unresolveEObjectSubtractedEChange
 		change.unresolveFeatureEChange		
 	}
@@ -130,7 +130,7 @@ public class EChangeUnresolver {
 	 * Dispatch method for {@link FeatureEChange} to unresolve it.
 	 * @param change The FeatureEChange.
 	 */
-	def dispatch public static void unresolve(FeatureEChange<EObject, EStructuralFeature> change) {
+	def dispatch static void unresolve(FeatureEChange<EObject, EStructuralFeature> change) {
 		change.unresolveFeatureEChange
 	}
 	

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/ResolutionChecker.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/resolve/ResolutionChecker.xtend
@@ -11,39 +11,39 @@ import tools.vitruv.framework.change.echange.root.InsertRootEObject
 import tools.vitruv.framework.change.echange.root.RemoveRootEObject
 
 class ResolutionChecker {
-	public static def dispatch isResolved(EChange echange) {
+	static def dispatch isResolved(EChange echange) {
 		return true;
 	}
 	
-	public static def dispatch isResolved(EObjectExistenceEChange<?> existenceChange) {
+	static def dispatch isResolved(EObjectExistenceEChange<?> existenceChange) {
 		return (existenceChange.getAffectedEObject() !== null &&
 			!existenceChange.getAffectedEObject().eIsProxy());// && 
 			//existenceChange.getStagingArea() !== null);
 	}
 	
-	public static def dispatch isResolved(FeatureEChange<?,?> featureChange) {
+	static def dispatch isResolved(FeatureEChange<?,?> featureChange) {
 		return featureChange.isFeatureChangeResolved;
 	}
 	
-	public static def isFeatureChangeResolved(FeatureEChange<?,?> featureChange) {
+	static def isFeatureChangeResolved(FeatureEChange<?,?> featureChange) {
 		return (featureChange.getAffectedEObject() !== null &&
 			!featureChange.getAffectedEObject().eIsProxy() && 
 			featureChange.getAffectedFeature() !== null);
 	}
 	
-	public static def dispatch isResolved(InsertEReference<?,?> insertEReferenceChange) {
+	static def dispatch isResolved(InsertEReference<?,?> insertEReferenceChange) {
 		return (insertEReferenceChange.newValue === null
 			|| ! insertEReferenceChange.newValue.eIsProxy)
 			&& insertEReferenceChange.featureChangeResolved;	
 	}
 	
-	public static def dispatch isResolved(RemoveEReference<?,?> removeEReferenceChange) {
+	static def dispatch isResolved(RemoveEReference<?,?> removeEReferenceChange) {
 		return (removeEReferenceChange.oldValue === null
 			|| ! removeEReferenceChange.oldValue.eIsProxy)
 			&& removeEReferenceChange.featureChangeResolved;	
 	}
 	
-	public static def dispatch isResolved(ReplaceSingleValuedEReference<?,?> replaceSingleValuedEReferenceChange) {
+	static def dispatch isResolved(ReplaceSingleValuedEReference<?,?> replaceSingleValuedEReferenceChange) {
 		return (replaceSingleValuedEReferenceChange.oldValue === null
 			|| ! replaceSingleValuedEReferenceChange.oldValue.eIsProxy)
 			&& (replaceSingleValuedEReferenceChange.newValue === null
@@ -51,21 +51,21 @@ class ResolutionChecker {
 			&& replaceSingleValuedEReferenceChange.featureChangeResolved;	
 	}
 	
-	public static def dispatch isResolved(RootEChange rootChange) {
+	static def dispatch isResolved(RootEChange rootChange) {
 		return rootChange.isRootChangeResolved;
 	}
 	
-	public static def isRootChangeResolved(RootEChange rootChange) {
+	static def isRootChangeResolved(RootEChange rootChange) {
 		return rootChange.resource !== null;
 	}
 	
-	public static def dispatch isResolved(InsertRootEObject<?> insertRootChange) {
+	static def dispatch isResolved(InsertRootEObject<?> insertRootChange) {
 		return insertRootChange.newValue !== null &&
 			!insertRootChange.newValue.eIsProxy && 
 			insertRootChange.isRootChangeResolved;
 	}
 	
-	public static def dispatch isResolved(RemoveRootEObject<?> removeRootChange) {
+	static def dispatch isResolved(RemoveRootEObject<?> removeRootChange) {
 		return removeRootChange.oldValue !== null &&
 			!removeRootChange.oldValue.eIsProxy && 
 			removeRootChange.isRootChangeResolved;

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/ApplyEChangeSwitch.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/ApplyEChangeSwitch.xtend
@@ -9,7 +9,7 @@ import java.util.List
  * private methods and to provide a clean EChange interface, the apply 
  * method for applying forward and backward is placed in this utility class.
  */
-public class ApplyEChangeSwitch {
+class ApplyEChangeSwitch {
 	private new() {}
 	
 	/**
@@ -21,7 +21,7 @@ public class ApplyEChangeSwitch {
 	 * @throws IllegalStateException	The change is already resolved.
 	 * @throws RunTimeException			The change could not be applied.
 	 */
-	def public static boolean applyEChange(EChange change, boolean applyForward) {
+	def static boolean applyEChange(EChange change, boolean applyForward) {
 		if (!change.isResolved) {
 			throw new IllegalStateException("The EChange is not resolved.")
 		}

--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/util/EChangeUtil.xtend
@@ -26,7 +26,7 @@ class EChangeUtil {
 	 * @param object The EObject.
 	 * @return The editing domain of the object.
 	 */
-	public static def EditingDomain getEditingDomain(EObject object) {
+	static def EditingDomain getEditingDomain(EObject object) {
 		val ed = AdapterFactoryEditingDomain.getEditingDomainFor(object)
 		if (ed === null) {
 			return new AdapterFactoryEditingDomain(new ComposedAdapterFactory(), new BasicCommandStack());
@@ -34,7 +34,7 @@ class EChangeUtil {
 		return ed
 	}
 	
-	public static def boolean alreadyContainsObject(EObject affectedEObject, EReference feature, EObject value) {
+	static def boolean alreadyContainsObject(EObject affectedEObject, EReference feature, EObject value) {
 		if (!affectedEObject.eClass.EAllStructuralFeatures.contains(feature)) {
 			throw new IllegalStateException("Given object " + affectedEObject + " does not contain reference " + feature);
 		}
@@ -62,7 +62,7 @@ class EChangeUtil {
 	 * @return 	The ID attribute value of the given {@link EObject} or <code>null</code> 
 	 * 			if it has no ID attribute or if it is marked as <code>derived</code>.
 	 */
-	public static def String getID(EObject eObject) {
+	static def String getID(EObject eObject) {
 		val idAttribute = eObject.eClass.EIDAttribute
 		if (idAttribute !== null && !idAttribute.derived) {
 			return EcoreUtil.getID(eObject);
@@ -71,35 +71,35 @@ class EChangeUtil {
 	}
 	
 	
-	public static def dispatch isContainmentRemoval(EChange change) {
+	static def dispatch isContainmentRemoval(EChange change) {
 		return false;
 	}
 	
-	public static def dispatch isContainmentRemoval(ReplaceSingleValuedEReference<?,?> change) {
+	static def dispatch isContainmentRemoval(ReplaceSingleValuedEReference<?,?> change) {
 		return change.affectedFeature.containment && change.oldValueID !== null && change.oldValueID !== change.newValueID;
 	}
 	
-	public static def dispatch isContainmentRemoval(RemoveEReference<?,?> change) {
+	static def dispatch isContainmentRemoval(RemoveEReference<?,?> change) {
 		return change.affectedFeature.containment;
 	}
 	
-	public static def dispatch isContainmentRemoval(RemoveRootEObject<?> change) {
+	static def dispatch isContainmentRemoval(RemoveRootEObject<?> change) {
 		return true;
 	}
 	
-	public static def dispatch isContainmentInsertion(EChange change) {
+	static def dispatch isContainmentInsertion(EChange change) {
 		return false;
 	}
 	
-	public static def dispatch isContainmentInsertion(AdditiveReferenceEChange<?,?> change) {
+	static def dispatch isContainmentInsertion(AdditiveReferenceEChange<?,?> change) {
 		return change.affectedFeature.containment && change.newValueID !== null;
 	}
 	
-	public static def dispatch isContainmentInsertion(RemoveRootEObject<?> change) {
+	static def dispatch isContainmentInsertion(RemoveRootEObject<?> change) {
 		return true;
 	}
 	
-	public static def dispatch isContainmentInsertion(InsertRootEObject<?> change) {
+	static def dispatch isContainmentInsertion(InsertRootEObject<?> change) {
 		return true;
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/ChangePropagationSpecificationProvider.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/ChangePropagationSpecificationProvider.xtend
@@ -4,5 +4,5 @@ import java.util.List
 import tools.vitruv.framework.domains.VitruvDomain
 
 interface ChangePropagationSpecificationProvider extends Iterable<ChangePropagationSpecification> {
-	public def List<ChangePropagationSpecification> getChangePropagationSpecifications(VitruvDomain sourceDomain);
+	def List<ChangePropagationSpecification> getChangePropagationSpecifications(VitruvDomain sourceDomain);
 }

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/ChangePropagationSpecificationRepository.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/ChangePropagationSpecificationRepository.xtend
@@ -7,13 +7,13 @@ import java.util.ArrayList
 import tools.vitruv.framework.domains.VitruvDomain
 
 class ChangePropagationSpecificationRepository implements ChangePropagationSpecificationProvider {
-	private Map<VitruvDomain, List<ChangePropagationSpecification>> metamodelToPropagationSpecifications;
+	Map<VitruvDomain, List<ChangePropagationSpecification>> metamodelToPropagationSpecifications;
 
-	public new() {
+	new() {
 		metamodelToPropagationSpecifications = new HashMap<VitruvDomain, List<ChangePropagationSpecification>>();
 	}
 	
-	public override List<ChangePropagationSpecification> getChangePropagationSpecifications(VitruvDomain sourceDomain) {
+	override List<ChangePropagationSpecification> getChangePropagationSpecifications(VitruvDomain sourceDomain) {
 		val result = new ArrayList<ChangePropagationSpecification>();
 		if (metamodelToPropagationSpecifications.containsKey(sourceDomain)) {
 			result.addAll(metamodelToPropagationSpecifications.get(sourceDomain));
@@ -21,7 +21,7 @@ class ChangePropagationSpecificationRepository implements ChangePropagationSpeci
 		return result;
 	}
 	
-	public def void putChangePropagationSpecification(ChangePropagationSpecification changePropagationSpecification) {
+	def void putChangePropagationSpecification(ChangePropagationSpecification changePropagationSpecification) {
 		val changedDomain = changePropagationSpecification.sourceDomain;
 		if (!this.metamodelToPropagationSpecifications.containsKey(changedDomain)) {
 			this.metamodelToPropagationSpecifications.put(changedDomain, new ArrayList<ChangePropagationSpecification>());

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/AbstractChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/AbstractChangePropagationSpecification.xtend
@@ -8,10 +8,10 @@ import java.util.List
 import org.eclipse.emf.ecore.EObject
 
 abstract class AbstractChangePropagationSpecification implements ChangePropagationSpecification {
-	private val List<ChangePropagationObserver> propagationObserver;
-	private var UserInteractor userInteractor;
-	private var VitruvDomain sourceDomain;
-	private var VitruvDomain targetDomain;
+	val List<ChangePropagationObserver> propagationObserver;
+	var UserInteractor userInteractor;
+	var VitruvDomain sourceDomain;
+	var VitruvDomain targetDomain;
 	
 	new(VitruvDomain sourceDomain, VitruvDomain targetDomain) {
 		setVitruvDomains(sourceDomain, targetDomain);

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/AbstractEChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/AbstractEChangePropagationSpecification.xtend
@@ -8,7 +8,7 @@ import tools.vitruv.framework.domains.VitruvDomain
 import tools.vitruv.framework.util.command.ResourceAccess
 
 abstract class AbstractEChangePropagationSpecification extends AbstractChangePropagationSpecification {
-	private final static val LOGGER = Logger.getLogger(AbstractEChangePropagationSpecification);
+	static val LOGGER = Logger.getLogger(AbstractEChangePropagationSpecification);
 
 	new(VitruvDomain sourceDomain, VitruvDomain targetDomain) {
 		super(sourceDomain, targetDomain);

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeChangePropagationSpecification.xtend
@@ -14,12 +14,12 @@ import tools.vitruv.framework.util.command.ResourceAccess
 import org.eclipse.xtend.lib.annotations.Accessors
 
 abstract class CompositeChangePropagationSpecification extends AbstractChangePropagationSpecification implements ChangePropagationObserver {
-	private static val logger = Logger.getLogger(CompositeChangePropagationSpecification);
+	static val logger = Logger.getLogger(CompositeChangePropagationSpecification);
 
 	@Accessors(PROTECTED_GETTER)
-	private val List<ChangePropagationSpecification> changePreprocessors;
+	val List<ChangePropagationSpecification> changePreprocessors;
 	@Accessors(PROTECTED_GETTER)
-	private val List<ChangePropagationSpecification> changeMainprocessors;
+	val List<ChangePropagationSpecification> changeMainprocessors;
 
 	new(VitruvDomain sourceDomain, VitruvDomain targetDomain) {
 		super(sourceDomain, targetDomain);

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeDecomposingChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeDecomposingChangePropagationSpecification.xtend
@@ -15,7 +15,7 @@ import org.apache.log4j.Logger
  * 
  */
 class CompositeDecomposingChangePropagationSpecification extends CompositeChangePropagationSpecification {
-	private static val logger = Logger.getLogger(CompositeDecomposingChangePropagationSpecification);
+	static val logger = Logger.getLogger(CompositeDecomposingChangePropagationSpecification);
 
 	new(VitruvDomain sourceDomain, VitruvDomain targetDomain) {
 		super(sourceDomain, targetDomain)

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/PropagatedChange.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/PropagatedChange.xtend
@@ -5,8 +5,8 @@ import tools.vitruv.framework.uuid.UuidResolver
 
 @Data
 class PropagatedChange {
-	private val VitruviusChange originalChange;
-	private val VitruviusChange consequentialChanges;
+	val VitruviusChange originalChange;
+	val VitruviusChange consequentialChanges;
 	
 	override toString() '''
 	Original change:

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChangeFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/VitruviusChangeFactory.xtend
@@ -15,36 +15,36 @@ import tools.vitruv.framework.change.description.impl.ConcreteChangeWithUriImpl
 import java.util.List
 
 class VitruviusChangeFactory {
-	private static val logger = Logger.getLogger(VitruviusChangeFactory);
-	private static VitruviusChangeFactory instance;
+	static val logger = Logger.getLogger(VitruviusChangeFactory);
+	static VitruviusChangeFactory instance;
 	
-	public enum FileChangeKind {
+	enum FileChangeKind {
 		Create,
 		Delete		
 	}
 	
 	private new() {}
 	
-	public static def VitruviusChangeFactory getInstance() {
+	static def VitruviusChangeFactory getInstance() {
 		if (instance === null) {
 			instance = new VitruviusChangeFactory();
 		}
 		return instance;
 	}
 	
-	public def ConcreteChange createConcreteApplicableChange(EChange change) {
+	def ConcreteChange createConcreteApplicableChange(EChange change) {
 		return new ConcreteApplicableChangeImpl(change);
 	}
 	
-	public def ConcreteChange createConcreteChange(EChange change) {
+	def ConcreteChange createConcreteChange(EChange change) {
 		return new ConcreteChangeImpl(change);
 	}
 	
-	public def ConcreteChange createConcreteChangeWithVuri(EChange change, VURI vuri) {
+	def ConcreteChange createConcreteChangeWithVuri(EChange change, VURI vuri) {
 		return new ConcreteChangeWithUriImpl(vuri, change);
 	}
 	
-	public def List<ConcreteChange> createFileChange(FileChangeKind kind, Resource changedFileResource) {
+	def List<ConcreteChange> createFileChange(FileChangeKind kind, Resource changedFileResource) {
 		if (kind == FileChangeKind.Create) {
 			return generateFileCreateChange(changedFileResource).map[new ConcreteChangeImpl(it)];
 		} else {
@@ -52,19 +52,19 @@ class VitruviusChangeFactory {
 		}
 	}
 	
-	public def CompositeContainerChange createCompositeContainerChange() {
+	def CompositeContainerChange createCompositeContainerChange() {
 		return new CompositeContainerChangeImpl();
 	}
 	
-	public def CompositeTransactionalChange createCompositeTransactionalChange() {
+	def CompositeTransactionalChange createCompositeTransactionalChange() {
 		return new CompositeTransactionalChangeImpl();
 	}
 	
-	public def TransactionalChange createEmptyChange(VURI vuri) {
+	def TransactionalChange createEmptyChange(VURI vuri) {
 		return new EmptyChangeImpl(vuri);
 	}
 	
-	public def CompositeContainerChange createCompositeChange(Iterable<? extends VitruviusChange> innerChanges) {
+	def CompositeContainerChange createCompositeChange(Iterable<? extends VitruviusChange> innerChanges) {
 		val compositeChange = new CompositeContainerChangeImpl();
 		for (innerChange : innerChanges) {
 			compositeChange.addChange(innerChange);
@@ -72,7 +72,7 @@ class VitruviusChangeFactory {
 		return compositeChange;
 	}
 	
-	public def <T extends VitruviusChange> T clone(T originalChange) {
+	def <T extends VitruviusChange> T clone(T originalChange) {
 		return new ChangeCloner().clone(originalChange) as T;
 	}
 		

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractConcreteChange.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/AbstractConcreteChange.xtend
@@ -21,9 +21,9 @@ import org.eclipse.emf.ecore.util.EcoreUtil
 import tools.vitruv.framework.change.description.VitruviusChange
 
 abstract class AbstractConcreteChange implements ConcreteChange {
-	private static val logger = Logger.getLogger(AbstractConcreteChange);
-	private var EChange eChange;
-	private List<UserInteractionBase> userInteractions;
+	static val logger = Logger.getLogger(AbstractConcreteChange);
+	var EChange eChange;
+	List<UserInteractionBase> userInteractions;
 
 	new(EChange eChange) {
 		this.eChange = eChange;

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/CompositeTransactionalChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/CompositeTransactionalChangeImpl.xtend
@@ -9,7 +9,7 @@ import java.util.List
 import java.util.ArrayList
 
 class CompositeTransactionalChangeImpl extends AbstractCompositeChangeImpl<TransactionalChange> implements CompositeTransactionalChange {
-	private List<UserInteractionBase> userInteractions = new ArrayList<UserInteractionBase>;
+	List<UserInteractionBase> userInteractions = new ArrayList<UserInteractionBase>;
 	
 	override removeChange(TransactionalChange change) {
 		if (change !== null && this.changes.contains(change)) {

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteApplicableChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteApplicableChangeImpl.xtend
@@ -14,9 +14,9 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
 import tools.vitruv.framework.change.description.VitruviusChange
 
 class ConcreteApplicableChangeImpl extends ConcreteChangeImpl {
-	private var VURI vuri;
+	var VURI vuri;
 
-	public new(EChange eChange) {
+	new(EChange eChange) {
 		super(eChange);
 		tryToSetUri;
 	}

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteChangeImpl.xtend
@@ -3,11 +3,11 @@ package tools.vitruv.framework.change.description.impl
 import tools.vitruv.framework.change.echange.EChange
 
 class ConcreteChangeImpl extends AbstractConcreteChange {
-    public new(EChange eChange) {
+    new(EChange eChange) {
 		super(eChange);
     }
 
-    public override String toString() {
+    override String toString() {
         return this.class.getSimpleName() + ", VURI: " + this.URI + "\n	EChange: " + this.EChange;
     }
 

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteChangeWithUriImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteChangeWithUriImpl.xtend
@@ -4,9 +4,9 @@ import tools.vitruv.framework.util.datatypes.VURI
 import tools.vitruv.framework.change.echange.EChange
 
 class ConcreteChangeWithUriImpl extends ConcreteChangeImpl {
-	private val VURI vuri;
+	val VURI vuri;
 	
-	public new (VURI vuri, EChange eChange) {
+	new (VURI vuri, EChange eChange) {
 		super(eChange);
 		this.vuri = vuri;
 	}

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/EmptyChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/EmptyChangeImpl.xtend
@@ -7,7 +7,7 @@ import tools.vitruv.framework.change.interaction.UserInteractionBase
 import tools.vitruv.framework.change.description.VitruviusChange
 
 class EmptyChangeImpl implements TransactionalChange {
-	private val VURI vuri;
+	val VURI vuri;
 
 	new(VURI vuri) {
 		this.vuri = vuri;

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/EMFModelChangeTransformationUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/preparation/EMFModelChangeTransformationUtil.xtend
@@ -21,7 +21,7 @@ import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.EObje
  * A utility class providing extension methods for transforming change descriptions to change models.
  * 
  */
-public class EMFModelChangeTransformationUtil {
+class EMFModelChangeTransformationUtil {
 	def static List<EChange> createAdditiveCreateChangesForValue(EObject eObject, EReference reference) {
 		return createAdditiveEChangeForReferencedObject(eObject, reference, true)
 	}

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/AtomicEmfChangeRecorder.xtend
@@ -182,7 +182,7 @@ class AtomicEmfChangeRecorder {
 		return createdObjects;
 	}
 
-	public def List<TransactionalChange> getChanges() {
+	def List<TransactionalChange> getChanges() {
 		return changes;
 	}
 

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationRecorder.xtend
@@ -26,11 +26,11 @@ import org.eclipse.xtend.lib.annotations.Data
  * an appropriate delete change.
  */
 class NotificationRecorder implements Adapter {
-	private Set<Notifier> rootObjects;
-	private boolean isRecording = false
+	Set<Notifier> rootObjects;
+	boolean isRecording = false
 	List<EChange> changes;
 	List<CompositeTransactionalChange> resultChanges;
-	private val EChangeIdManager idManager
+	val EChangeIdManager idManager
 	
 	new (EChangeIdManager idManager) {
 		this.idManager = idManager;	

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationToEChangeConverter.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/NotificationToEChangeConverter.xtend
@@ -22,7 +22,7 @@ import org.eclipse.emf.ecore.EStructuralFeature
  * @author Heiko Klare
  */
 final class NotificationToEChangeConverter {
-	private EChangeIdManager eChangeIdManager;
+	EChangeIdManager eChangeIdManager;
 
 	new(EChangeIdManager eChangeeChangeIdManager) {
 		this.eChangeIdManager = eChangeeChangeIdManager;
@@ -98,7 +98,7 @@ final class NotificationToEChangeConverter {
 		return #[]
 	}
 		
-	public def createDeleteChange(EObjectSubtractedEChange<?> change) {
+	def createDeleteChange(EObjectSubtractedEChange<?> change) {
 		val deleteChange = TypeInferringAtomicEChangeFactory.instance.createDeleteEObjectChange(change.oldValue);
 		eChangeIdManager.setOrGenerateIds(deleteChange);
 		deleteChange.consequentialRemoveChanges += recursiveRemoval(change.oldValue);

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelFactory.xtend
@@ -8,12 +8,12 @@ import org.eclipse.emf.ecore.resource.Resource
 import tools.vitruv.framework.correspondence.impl.InternalCorrespondenceModelImpl
 import tools.vitruv.framework.util.command.CommandCreatorAndExecutor
 
-public final class CorrespondenceModelFactory {
-	private static CorrespondenceModelFactory instance;
+final class CorrespondenceModelFactory {
+	static CorrespondenceModelFactory instance;
 	
 	private new() {	}
 	
-	public static def getInstance() {
+	static def getInstance() {
 		if (instance === null) {
 			instance = new CorrespondenceModelFactory();
 		}
@@ -21,7 +21,7 @@ public final class CorrespondenceModelFactory {
 		return instance;
 	}
 	
-	public def createCorrespondenceModel(TuidResolver tuidResolver, UuidResolver uuidResolver, CommandCreatorAndExecutor modelCommandExecutor,
+	def createCorrespondenceModel(TuidResolver tuidResolver, UuidResolver uuidResolver, CommandCreatorAndExecutor modelCommandExecutor,
 		VitruvDomainRepository domainRepository, VURI correspondencesVURI, Resource correspondencesResource) {
 		return new InternalCorrespondenceModelImpl(tuidResolver, uuidResolver, modelCommandExecutor, domainRepository, correspondencesVURI, correspondencesResource);
 	}

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceModelUtil.xtend
@@ -23,7 +23,7 @@ class CorrespondenceModelUtil {
 	 *         no correspondences.
 	 */
 	// FIXME ML is this method correct? Is there some cool Xtend feature which makes this method shorter? 
-	def public static Set<EObject> getCorrespondingEObjects(CorrespondenceModelView<?> ci, EObject eObject) {
+	def static Set<EObject> getCorrespondingEObjects(CorrespondenceModelView<?> ci, EObject eObject) {
 		val correspondingEObjects = ci.getCorrespondingEObjects(eObject.toList)
 		val eObjects = Sets.newHashSet
 		correspondingEObjects.forEach(list|eObjects.addAll(list))
@@ -39,7 +39,7 @@ class CorrespondenceModelUtil {
 	 * @param b
 	 * @return
 	 */
-	def public static Correspondence claimUniqueCorrespondence(CorrespondenceModelView<Correspondence> ci,
+	def static Correspondence claimUniqueCorrespondence(CorrespondenceModelView<Correspondence> ci,
 		EObject eObject) {
 		return ci.getCorrespondences(eObject.toList).claimOne
 	}
@@ -52,12 +52,12 @@ class CorrespondenceModelUtil {
 	 *            the object for which correspondences are to be returned
 	 * @return the correspondences for the specified object
 	 */
-	def public static Set<Correspondence> claimCorrespondences(CorrespondenceModelView<?> ci,
+	def static Set<Correspondence> claimCorrespondences(CorrespondenceModelView<?> ci,
 		EObject eObject) {
 		return ci.getCorrespondences(eObject.toList).claimNotEmpty as Set<Correspondence>
 	}
 
-	def public static Correspondence createAndAddCorrespondence(CorrespondenceModel ci, EObject a, EObject b) {
+	def static Correspondence createAndAddCorrespondence(CorrespondenceModel ci, EObject a, EObject b) {
 		return ci.createAndAddCorrespondence(a.toList, b.toList, null)
 	}
 
@@ -73,7 +73,7 @@ class CorrespondenceModelUtil {
 	 * @return the corresponding object of the specified type for the specified object if there is
 	 *         exactly one corresponding object of this type
 	 */
-	def public static <T, U extends Correspondence> Set<T> getCorrespondingEObjectsByType(CorrespondenceModelView<U> ci,
+	def static <T, U extends Correspondence> Set<T> getCorrespondingEObjectsByType(CorrespondenceModelView<U> ci,
 		EObject eObject, Class<T> type) {
 		// return getCorrespondingEObjects(ci, eObject).filter[eObj | type.isInstance(eObj)].toSet
 		val Set<T> retSet = Sets.newHashSet

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceProviding.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/CorrespondenceProviding.java
@@ -1,7 +1,5 @@
 package tools.vitruv.framework.correspondence;
 
-import tools.vitruv.framework.correspondence.CorrespondenceModel;
-
 public interface CorrespondenceProviding {
     CorrespondenceModel getCorrespondenceModel();
 }

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/GenericCorrespondenceModel.java
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/GenericCorrespondenceModel.java
@@ -4,8 +4,6 @@ import java.util.List;
 
 import org.eclipse.emf.ecore.EObject;
 
-import tools.vitruv.framework.correspondence.Correspondence;
-import tools.vitruv.framework.correspondence.CorrespondenceModel;
 import tools.vitruv.framework.util.datatypes.URIHaving;
 
 /**

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/CorrespondenceModelViewImpl.xtend
@@ -13,19 +13,19 @@ import java.util.function.Predicate
 
 class CorrespondenceModelViewImpl<T extends Correspondence> implements CorrespondenceModelView<T> {
 	@Accessors(PROTECTED_GETTER)
-	private final InternalCorrespondenceModel correspondenceModelDelegate;
+	final InternalCorrespondenceModel correspondenceModelDelegate;
 	@Accessors(PROTECTED_GETTER)
-	private final Class<T> correspondenceType;
-	private final Supplier<T> correspondenceCreator
+	final Class<T> correspondenceType;
+	final Supplier<T> correspondenceCreator
 	
 	@Accessors(PROTECTED_GETTER)
-	private final Predicate<T> defaultCorrespondenceFilter;
+	final Predicate<T> defaultCorrespondenceFilter;
 	 
-	public new(Class<T> correspondenceType, InternalCorrespondenceModel correspondenceModel) {
+	new(Class<T> correspondenceType, InternalCorrespondenceModel correspondenceModel) {
 		this(correspondenceType, correspondenceModel, null)
 	}
 
-	public new(Class<T> correspondenceType, InternalCorrespondenceModel correspondenceModel,
+	new(Class<T> correspondenceType, InternalCorrespondenceModel correspondenceModel,
 		Supplier<T> correspondenceCreator) {
 		this.correspondenceType = correspondenceType;
 		this.defaultCorrespondenceFilter =  [true];

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
@@ -342,7 +342,7 @@ class InternalCorrespondenceModelImpl extends ModelInstance implements InternalC
 		return correspondences.correspondences
 	}
 
-	private Iterable<Pair<List<Tuid>, Set<Correspondence>>> tuidUpdateData;
+	Iterable<Pair<List<Tuid>, Set<Correspondence>>> tuidUpdateData;
 
 	/**
 	 * Removes the current entries in the

--- a/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruvDomainProviderRegistry.xtend
+++ b/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruvDomainProviderRegistry.xtend
@@ -16,7 +16,7 @@ import org.apache.log4j.Logger
  */
 class VitruvDomainProviderRegistry {
 
-	private static val LOGGER = Logger.getLogger(VitruvDomainProviderRegistry)
+	static val LOGGER = Logger.getLogger(VitruvDomainProviderRegistry)
 
 	private new() {
 	}

--- a/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruviusProjectBuilderApplicator.xtend
+++ b/bundles/framework/tools.vitruv.framework.metamodel/src/tools/vitruv/framework/domains/VitruviusProjectBuilderApplicator.xtend
@@ -15,13 +15,13 @@ class VitruviusProjectBuilderApplicator {
 	public static final String ARGUMENT_VMODEL_NAME = "virtualModelName";
 	public static final String ARGUMENT_FILE_EXTENSIONS = "fileExtensions";
 	
-	private val String builderId;
+	val String builderId;
 	
-	public new(String builderId) {
+	new(String builderId) {
 		this.builderId = builderId;
 	}
 	
-	public def void addToProject(IProject project, File vmodelFolder, List<String> fileExtensions) {
+	def void addToProject(IProject project, File vmodelFolder, List<String> fileExtensions) {
         if (project !== null) {
             try {
             	val IProjectDescription description = project.getDescription();
@@ -69,7 +69,7 @@ class VitruviusProjectBuilderApplicator {
     }
 	
 	
-	public def void removeBuilderFromProject(IProject project) {
+	def void removeBuilderFromProject(IProject project) {
         if (project !== null) {
             try {
                 val IProjectDescription description = project.getDescription();
@@ -92,7 +92,7 @@ class VitruviusProjectBuilderApplicator {
         }
     }
     
-	public def boolean hasBuilder(IProject project) {
+	def boolean hasBuilder(IProject project) {
         try {
             for (buildSpec : project.getDescription().getBuildSpec()) {
                 if (this.builderId.equals(buildSpec.getBuilderName())) {
@@ -105,7 +105,7 @@ class VitruviusProjectBuilderApplicator {
         return false;
     }
     
-    public def String getBuilderId() {
+    def String getBuilderId() {
     	return builderId;
     }
 }

--- a/bundles/framework/tools.vitruv.framework.tuid/src-test/tools/vitruv/framework/tuid/TuidTest.java
+++ b/bundles/framework/tools.vitruv.framework.tuid/src-test/tools/vitruv/framework/tuid/TuidTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import tools.vitruv.framework.tuid.Tuid;
 import tools.vitruv.framework.util.VitruviusConstants;
 
 public class TuidTest {

--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/HierarchicalTuidCalculatorAndResolver.java
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/HierarchicalTuidCalculatorAndResolver.java
@@ -6,7 +6,6 @@ import java.util.LinkedList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 
-import tools.vitruv.framework.tuid.TuidCalculatorAndResolverBase;
 import tools.vitruv.framework.util.VitruviusConstants;
 
 /**

--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/Tuid.xtend
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/Tuid.xtend
@@ -53,7 +53,7 @@ final class Tuid implements Serializable {
 		SEGMENTS = generateForwardHashedBackwardLinkedTree();
 	}
 
-	public def updateTuid(EObject newObject) {
+	def updateTuid(EObject newObject) {
 		TuidManager.instance.updateTuid(this, newObject);
 	}
 

--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/Tuid4Serialization.java
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/Tuid4Serialization.java
@@ -3,8 +3,6 @@ package tools.vitruv.framework.tuid;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
-import tools.vitruv.framework.tuid.Tuid;
-
 /**
  * Class that is only used to serialize and deserialize Tuids.
  * @author kramerm

--- a/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidManager.xtend
+++ b/bundles/framework/tools.vitruv.framework.tuid/src/tools/vitruv/framework/tuid/TuidManager.xtend
@@ -8,43 +8,43 @@ import org.apache.log4j.Logger
 import java.util.Set
 
 final class TuidManager {
-	private static val logger = Logger.getLogger(TuidManager);
-	private static val instance = new TuidManager();
-	private val Set<TuidCalculator> tuidCalculator;
-	private val Set<TuidUpdateListener> tuidUpdateListener;
-	private val Map<EObject, Tuid> tuidUpdateCache = new HashMap<EObject, Tuid>();
+	static val logger = Logger.getLogger(TuidManager);
+	static val instance = new TuidManager();
+	val Set<TuidCalculator> tuidCalculator;
+	val Set<TuidUpdateListener> tuidUpdateListener;
+	val Map<EObject, Tuid> tuidUpdateCache = new HashMap<EObject, Tuid>();
 	
 	private new() {
 		this.tuidCalculator = newHashSet();
 		this.tuidUpdateListener = newHashSet();
 	}
 	
-	public static def TuidManager getInstance() {
+	static def TuidManager getInstance() {
 		// This class is a singleton for now. We will probably change that decision later 
 		return instance;
 	}
 	
-	public def void addTuidUpdateListener(TuidUpdateListener updateListener) {
+	def void addTuidUpdateListener(TuidUpdateListener updateListener) {
 		if (updateListener !== null) {
 			tuidUpdateListener += updateListener;
 		}
 	}
 	
-	public def removeTuidUpdateListener(TuidUpdateListener updateListener) {
+	def removeTuidUpdateListener(TuidUpdateListener updateListener) {
 		tuidUpdateListener.remove(updateListener);
 	}
 	
-	public def void addTuidCalculator(TuidCalculator calculator) {
+	def void addTuidCalculator(TuidCalculator calculator) {
 		if (calculator !== null) {
 			tuidCalculator += calculator;
 		}
 	}
 	
-	public def removeTuidCalculator(TuidCalculator calculator) {
+	def removeTuidCalculator(TuidCalculator calculator) {
 		tuidCalculator.remove(calculator);
 	}
 	
-	public def reinitialize() {
+	def reinitialize() {
 		flushRegisteredObjectsUnderModification();
 		Tuid.reinitialize();
 	}
@@ -75,17 +75,17 @@ final class TuidManager {
 		}
 	}
 	
-	def public registerObjectUnderModification(EObject objectUnderModification) {
+	def registerObjectUnderModification(EObject objectUnderModification) {
 		if (objectUnderModification.hasTuidCalculator && !tuidUpdateCache.containsKey(objectUnderModification)) {
 			tuidUpdateCache.put(objectUnderModification, objectUnderModification.calculateTuid);
 		}
 	}
 	
-	def public flushRegisteredObjectsUnderModification() {
+	def flushRegisteredObjectsUnderModification() {
 		tuidUpdateCache.clear();
 	}
 	
-	public def updateTuidsOfRegisteredObjects() {
+	def updateTuidsOfRegisteredObjects() {
 		for (object : tuidUpdateCache.keySet) {
 			val oldTuid = tuidUpdateCache.get(object);
 			if (hasTuidCalculator(object)) {
@@ -98,7 +98,7 @@ final class TuidManager {
 		}
 	}
 	
-	def public updateTuid(EObject oldObject, EObject newObject) {
+	def updateTuid(EObject oldObject, EObject newObject) {
 		if (oldObject.hasTuidCalculator && newObject.hasTuidCalculator) {
 			val oldTuid = oldObject.calculateTuid;
 			val newTuid = newObject.calculateTuid;
@@ -106,7 +106,7 @@ final class TuidManager {
 		}
 	}
 	
-	def public updateTuid(Tuid oldTuid, EObject newObject) {
+	def updateTuid(Tuid oldTuid, EObject newObject) {
 		if (newObject.hasTuidCalculator) {
 			oldTuid.updateTuid(newObject.calculateTuid);
 		}

--- a/bundles/framework/tools.vitruv.framework.ui.monitorededitor/src/tools/vitruv/framework/ui/monitorededitor/VitruviusProjectBuilder.xtend
+++ b/bundles/framework/tools.vitruv.framework.ui.monitorededitor/src/tools/vitruv/framework/ui/monitorededitor/VitruviusProjectBuilder.xtend
@@ -15,13 +15,13 @@ import java.io.File
 import tools.vitruv.framework.domains.VitruviusProjectBuilderApplicator
 
 abstract class VitruviusProjectBuilder extends IncrementalProjectBuilder {
-	private static final Logger logger = Logger.getLogger(VitruviusProjectBuilder.getSimpleName())
+	static final Logger logger = Logger.getLogger(VitruviusProjectBuilder.getSimpleName())
 	
-	private Set<String> monitoredFileTypes
-	private VirtualModel virtualModel;
-	private boolean initialized
+	Set<String> monitoredFileTypes
+	VirtualModel virtualModel;
+	boolean initialized
 	
-	public new() {
+	new() {
 		this.initialized = false;
 		this.monitoredFileTypes = new HashSet<String>();
 	}

--- a/bundles/framework/tools.vitruv.framework.ui.vsum/src/tools/vitruv/framework/ui/vsum/util/ProjectCreator.xtend
+++ b/bundles/framework/tools.vitruv.framework.ui.vsum/src/tools/vitruv/framework/ui/vsum/util/ProjectCreator.xtend
@@ -3,13 +3,13 @@ package tools.vitruv.framework.ui.vsum.util
 import static edu.kit.ipd.sdq.commons.util.org.eclipse.core.resources.IProjectUtil.*
 
 class ProjectCreator {
-	private val String projectName;
+	val String projectName;
 	
 	new(String projectName) {
 		this.projectName = projectName;
 	}
 	
-	public def void createProject() {
+	def void createProject() {
 		createJavaProject(projectName);
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.ui.vsum/src/tools/vitruv/framework/ui/vsum/util/VitruvInstanceCreator.xtend
+++ b/bundles/framework/tools.vitruv.framework.ui.vsum/src/tools/vitruv/framework/ui/vsum/util/VitruvInstanceCreator.xtend
@@ -15,9 +15,9 @@ import tools.vitruv.framework.vsum.VirtualModelImpl
 import tools.vitruv.framework.userinteraction.UserInteractionFactory
 
 class VitruvInstanceCreator {
-	private final Map<IProject, ? extends Set<VitruvDomain>> projectToDomains;
-	private final Iterable<VitruvApplication> applications;
-	private final String name;
+	final Map<IProject, ? extends Set<VitruvDomain>> projectToDomains;
+	final Iterable<VitruvApplication> applications;
+	final String name;
 	
 	new(String name, Map<IProject, Set<VitruvDomain>> projectToDomains, Iterable<VitruvApplication> applications) {
 		this.projectToDomains = projectToDomains;
@@ -25,7 +25,7 @@ class VitruvInstanceCreator {
 		this.name = name;
 	}
 	
-	public def void createVsumProject() {
+	def void createVsumProject() {
 		TuidManager.instance.reinitialize();
         val virtualModel = createVirtualModel(name);
         for (project : projectToDomains.keySet) {

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/DecoratingInteractionResultProvider.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/DecoratingInteractionResultProvider.xtend
@@ -8,7 +8,7 @@ import org.eclipse.xtend.lib.annotations.Accessors
  */
 abstract class DecoratingInteractionResultProvider implements InteractionResultProvider {
 	@Accessors(PUBLIC_GETTER)
-	private final InteractionResultProvider decoratedInteractionResultProvider;
+	final InteractionResultProvider decoratedInteractionResultProvider;
 
 	new(InteractionResultProvider decoratedInteractionResultProvider) {
 		this.decoratedInteractionResultProvider = decoratedInteractionResultProvider;

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/PredefinedInteractionResultProvider.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/PredefinedInteractionResultProvider.xtend
@@ -18,5 +18,5 @@ abstract class PredefinedInteractionResultProvider extends DecoratingInteraction
 	 * 
 	 * @param interactions - the interaction results to use
 	 */
-	public abstract def void addUserInteractions(UserInteractionBase... interactions);
+	abstract def void addUserInteractions(UserInteractionBase... interactions);
 }

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/UserInteractionOptions.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/UserInteractionOptions.xtend
@@ -5,7 +5,7 @@ package tools.vitruv.framework.userinteraction
  * 
  * @author Heiko Klare
  */
-public final class UserInteractionOptions {
+final class UserInteractionOptions {
 
 	private new() {
 	}

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/BaseInteractionBuilder.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/BaseInteractionBuilder.xtend
@@ -26,11 +26,11 @@ import tools.vitruv.framework.userinteraction.types.BaseInteraction
  * @author Dominik Klooz
  * @author Heiko Klare
  */
-@Accessors public abstract class BaseInteractionBuilder<V, I extends BaseInteraction<?>, T extends InteractionBuilder<V, T>> implements InteractionBuilder<V, T> {
+@Accessors abstract class BaseInteractionBuilder<V, I extends BaseInteraction<?>, T extends InteractionBuilder<V, T>> implements InteractionBuilder<V, T> {
 	@Accessors(PROTECTED_GETTER)
-	private final InteractionFactory interactionFactory
+	final InteractionFactory interactionFactory
 	@Accessors(PROTECTED_GETTER)
-	private I interactionToBuild;
+	I interactionToBuild;
 	@Accessors(NONE)
 	Iterable<UserInteractionListener> userInteractionListener;
 

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/ConfirmationInteractionBuilderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/ConfirmationInteractionBuilderImpl.xtend
@@ -17,7 +17,7 @@ import tools.vitruv.framework.userinteraction.builder.ConfirmationInteractionBui
  * @author Dominik Klooz
  * @author Heiko Klare
  */
-public class ConfirmationInteractionBuilderImpl extends BaseInteractionBuilder<Boolean, ConfirmationInteraction, OptionalSteps> implements ConfirmationInteractionBuilder, OptionalSteps {
+class ConfirmationInteractionBuilderImpl extends BaseInteractionBuilder<Boolean, ConfirmationInteraction, OptionalSteps> implements ConfirmationInteractionBuilder, OptionalSteps {
 	new(InteractionFactory interactionFactory, Iterable<UserInteractionListener> userInteractionListener) {
 		super(interactionFactory, userInteractionListener)
 	}

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/MultipleChoiceMultiSelectionInteractionBuilderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/MultipleChoiceMultiSelectionInteractionBuilderImpl.xtend
@@ -12,7 +12,7 @@ import tools.vitruv.framework.userinteraction.builder.MultipleChoiceMultiSelecti
  * @author Dominik Klooz
  * @author Heiko Klare
  */
-public class MultipleChoiceMultiSelectionInteractionBuilderImpl extends MultipleChoiceSelectionInteractionBuilderBaseImpl<Collection<Integer>, MultipleChoiceMultipleSelectionInteraction> implements MultipleChoiceMultiSelectionInteractionBuilder {
+class MultipleChoiceMultiSelectionInteractionBuilderImpl extends MultipleChoiceSelectionInteractionBuilderBaseImpl<Collection<Integer>, MultipleChoiceMultipleSelectionInteraction> implements MultipleChoiceMultiSelectionInteractionBuilder {
 
 	new(InteractionFactory interactionFactory, Iterable<UserInteractionListener> userInteractionListener) {
 		super(interactionFactory, userInteractionListener)

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/MultipleChoiceSelectionInteractionBuilderBaseImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/MultipleChoiceSelectionInteractionBuilderBaseImpl.xtend
@@ -16,7 +16,7 @@ import tools.vitruv.framework.userinteraction.types.InteractionFactory
  * @author Dominik Klooz
  * @author Heiko Klare
  */
-public abstract class MultipleChoiceSelectionInteractionBuilderBaseImpl<T, I extends MultipleChoiceSelectionInteraction<?>> extends BaseInteractionBuilder<T, I, OptionalSteps<T>> implements MultipleChoiceSelectionInteractionBuilder<T>, ChoicesStep<T>, OptionalSteps<T> {
+abstract class MultipleChoiceSelectionInteractionBuilderBaseImpl<T, I extends MultipleChoiceSelectionInteraction<?>> extends BaseInteractionBuilder<T, I, OptionalSteps<T>> implements MultipleChoiceSelectionInteractionBuilder<T>, ChoicesStep<T>, OptionalSteps<T> {
 	new(InteractionFactory interactionFactory, Iterable<UserInteractionListener> userInteractionListener) {
 		super(interactionFactory, userInteractionListener)
 	}

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/MultipleChoiceSingleSelectionInteractionBuilderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/MultipleChoiceSingleSelectionInteractionBuilderImpl.xtend
@@ -15,7 +15,7 @@ import tools.vitruv.framework.userinteraction.types.MultipleChoiceSingleSelectio
  * @author Dominik Klooz
  * @author Heiko Klare
  */
-public class MultipleChoiceSingleSelectionInteractionBuilderImpl extends MultipleChoiceSelectionInteractionBuilderBaseImpl<Integer, MultipleChoiceSingleSelectionInteraction> implements MultipleChoiceSingleSelectionInteractionBuilder {
+class MultipleChoiceSingleSelectionInteractionBuilderImpl extends MultipleChoiceSelectionInteractionBuilderBaseImpl<Integer, MultipleChoiceSingleSelectionInteraction> implements MultipleChoiceSingleSelectionInteractionBuilder {
 
 	new(InteractionFactory interactionFactory, Iterable<UserInteractionListener> userInteractionListener) {
 		super(interactionFactory, userInteractionListener)

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/NotificationInteractionBuilderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/NotificationInteractionBuilderImpl.xtend
@@ -17,7 +17,7 @@ import tools.vitruv.framework.userinteraction.UserInteractionListener
  * @author Dominik Klooz
  * @author Heiko Klare
  */
-public class NotificationInteractionBuilderImpl extends BaseInteractionBuilder<Void, NotificationInteraction, OptionalSteps> implements NotificationInteractionBuilder, OptionalSteps {
+class NotificationInteractionBuilderImpl extends BaseInteractionBuilder<Void, NotificationInteraction, OptionalSteps> implements NotificationInteractionBuilder, OptionalSteps {
 
 	new(InteractionFactory interactionFactory, Iterable<UserInteractionListener> userInteractionListener) {
 		super(interactionFactory, userInteractionListener)
@@ -30,7 +30,7 @@ public class NotificationInteractionBuilderImpl extends BaseInteractionBuilder<V
 		return this
 	}
 
-	override def startInteraction() {
+	override startInteraction() {
 		val result = interactionToBuild.startInteraction();
 		notifyUserInputReceived(result);
 		return null // notifications do not have any form of user input

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/TextInputInteractionBuilderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/builder/impl/TextInputInteractionBuilderImpl.xtend
@@ -22,7 +22,7 @@ import tools.vitruv.framework.userinteraction.types.InteractionFactory
  * @author Dominik Klooz
  * @author Heiko Klare
  */
-public class TextInputInteractionBuilderImpl extends BaseInteractionBuilder<String, TextInputInteraction, OptionalSteps> implements TextInputInteractionBuilder, OptionalSteps {
+class TextInputInteractionBuilderImpl extends BaseInteractionBuilder<String, TextInputInteraction, OptionalSteps> implements TextInputInteractionBuilder, OptionalSteps {
 	new(InteractionFactory interactionFactory, Iterable<UserInteractionListener> userInteractionListener) {
 		super(interactionFactory, userInteractionListener)
 	}

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/ConfirmationDialogWindow.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/ConfirmationDialogWindow.xtend
@@ -16,10 +16,10 @@ import org.eclipse.swt.widgets.Shell
  * @author Heiko Klare
  */
 class ConfirmationDialogWindow extends BaseDialogWindow {
-	private boolean confirmed = false
-	private final String positiveButtonText;
-	private final String negativeButtonText;
-	private final String cancelButtonText;
+	boolean confirmed = false
+	final String positiveButtonText;
+	final String negativeButtonText;
+	final String cancelButtonText;
 
 	new(Shell parent, WindowModality windowModality, String title, String message, String positiveButtonText,
 		String negativeButtonText, String cancelButtonText) {

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/MultipleChoiceSelectionDialogWindow.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/MultipleChoiceSelectionDialogWindow.xtend
@@ -21,12 +21,12 @@ import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
  * @author Heiko Klare
  */
 class MultipleChoiceSelectionDialogWindow extends BaseDialogWindow {
-	private final boolean multiple;
-	private final Iterable<String> choices;
-	private List<Button> choiceButtons
-	private final String positiveButtonText;
-	private final String cancelButtonText;
-	private Iterable<Integer> selectedChoices;
+	final boolean multiple;
+	final Iterable<String> choices;
+	List<Button> choiceButtons
+	final String positiveButtonText;
+	final String cancelButtonText;
+	Iterable<Integer> selectedChoices;
 
 	new(Shell parent, WindowModality windowModality, String title, String message, String positiveButtonText,
 		String cancelButtonText, boolean multiple, Iterable<String> choices) {
@@ -93,7 +93,7 @@ class MultipleChoiceSelectionDialogWindow extends BaseDialogWindow {
 		close()
 	}
 
-	public def Iterable<Integer> getSelectedChoices() {
+	def Iterable<Integer> getSelectedChoices() {
 		return selectedChoices
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/NotificationDialogWindow.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/NotificationDialogWindow.xtend
@@ -17,8 +17,8 @@ import tools.vitruv.framework.userinteraction.UserInteractionOptions.Notificatio
  * @author Heiko Klare
  */
 class NotificationDialogWindow extends BaseDialogWindow {
-	private final NotificationType notificationType;
-	private final String positiveButtonText;
+	final NotificationType notificationType;
+	final String positiveButtonText;
 
 	new(Shell parent, WindowModality windowModality, String title, String message, String positiveButtonText,
 		NotificationType notificationType) {

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/TextInputDialogWindow.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/dialogs/TextInputDialogWindow.xtend
@@ -23,13 +23,13 @@ import org.eclipse.jface.fieldassist.FieldDecorationRegistry
  * @author Heiko Klare
  */
 class TextInputDialogWindow extends BaseDialogWindow {
-	private Text inputField
-	private ControlDecoration inputDecorator
-	private InputFieldType inputFieldType
-	private final InputValidator inputValidator;
-	private final String positiveButtonText;
-	private final String cancelButtonText;
-	private String input = "";
+	Text inputField
+	ControlDecoration inputDecorator
+	InputFieldType inputFieldType
+	final InputValidator inputValidator;
+	final String positiveButtonText;
+	final String cancelButtonText;
+	String input = "";
 	
 	new(Shell parent, WindowModality windowModality, String title, String message, String positiveButtonText,
 		String cancelButtonText, InputValidator inputValidator) {
@@ -111,7 +111,7 @@ class TextInputDialogWindow extends BaseDialogWindow {
 		close()
 	}
 
-	public def String getInputText() {
+	def String getInputText() {
 		return input
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/DialogInteractionResultProviderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/DialogInteractionResultProviderImpl.xtend
@@ -19,8 +19,8 @@ import tools.vitruv.framework.userinteraction.InteractionResultProvider
  * @author Heiko Klare
  */
 class DialogInteractionResultProviderImpl implements InteractionResultProvider {
-	private final Shell parentShell;
-	private final Display display;
+	final Shell parentShell;
+	final Display display;
 
 	new() {
 		this.display = if (PlatformUI.isWorkbenchRunning()) PlatformUI.getWorkbench().getDisplay() else PlatformUI.

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/PredefinedInteractionMatcher.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/PredefinedInteractionMatcher.xtend
@@ -18,13 +18,13 @@ import java.util.Collections
  * @author Heiko Klare
  */
 class PredefinedInteractionMatcher {
-	private List<UserInteractionBase> userInteractions = newArrayList()
+	List<UserInteractionBase> userInteractions = newArrayList()
 
 	new() {
 		this.userInteractions = new ArrayList<UserInteractionBase>();
 	}
 
-	public def void addInteraction(UserInteractionBase interaction) {
+	def void addInteraction(UserInteractionBase interaction) {
 		userInteractions += interaction;
 	}
 

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/PredefinedInteractionResultProviderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/PredefinedInteractionResultProviderImpl.xtend
@@ -14,8 +14,8 @@ import tools.vitruv.framework.userinteraction.PredefinedInteractionResultProvide
  * request is found.
  * @author Heiko Klare
  */
-public class PredefinedInteractionResultProviderImpl extends PredefinedInteractionResultProvider {
-	private final PredefinedInteractionMatcher predefinedInteractionMatcher;
+class PredefinedInteractionResultProviderImpl extends PredefinedInteractionResultProvider {
+	final PredefinedInteractionMatcher predefinedInteractionMatcher;
 
 	/**
 	 * Instantiates a new provider.
@@ -29,7 +29,7 @@ public class PredefinedInteractionResultProviderImpl extends PredefinedInteracti
 		this.predefinedInteractionMatcher = new PredefinedInteractionMatcher();
 	}
 
-	public override void addUserInteractions(UserInteractionBase... interactions) {
+	override void addUserInteractions(UserInteractionBase... interactions) {
 		interactions.forEach[predefinedInteractionMatcher.addInteraction(it)]
 	}
 

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/PredefinedThinktimeSimulatingInteractionResultProviderImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/PredefinedThinktimeSimulatingInteractionResultProviderImpl.xtend
@@ -13,12 +13,12 @@ import tools.vitruv.framework.userinteraction.InteractionResultProvider
  * 
  * @author Heiko Klare
  */
-public class PredefinedThinktimeSimulatingInteractionResultProviderImpl extends PredefinedInteractionResultProviderImpl {
-	private static final Logger logger = Logger.getLogger(PredefinedThinktimeSimulatingInteractionResultProviderImpl);
-	private final Random random;
-	private final int minWaittime;
-	private final int maxWaittime;
-	private final int waitTimeRange;
+class PredefinedThinktimeSimulatingInteractionResultProviderImpl extends PredefinedInteractionResultProviderImpl {
+	static final Logger logger = Logger.getLogger(PredefinedThinktimeSimulatingInteractionResultProviderImpl);
+	final Random random;
+	final int minWaittime;
+	final int maxWaittime;
+	final int waitTimeRange;
 
 	/**
 	 * {@inheritDoc}

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/UserInteractorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/impl/UserInteractorImpl.xtend
@@ -27,10 +27,10 @@ import tools.vitruv.framework.userinteraction.DecoratingInteractionResultProvide
  * @author Heiko Klare
  */
 class UserInteractorImpl implements InternalUserInteractor {
-	private WindowModality defaultWindowModality = WindowModality.MODELESS;
-	private final List<UserInteractionListener> userInteractionListener;
-	private InteractionResultProvider interactionResultProvider;
-	private InteractionFactory interactionFactory;
+	WindowModality defaultWindowModality = WindowModality.MODELESS;
+	final List<UserInteractionListener> userInteractionListener;
+	InteractionResultProvider interactionResultProvider;
+	InteractionFactory interactionFactory;
 
 	new(InteractionResultProvider interactionResultProvider) {
 		if (interactionResultProvider === null) {
@@ -46,23 +46,23 @@ class UserInteractorImpl implements InternalUserInteractor {
 		this.defaultWindowModality = defaultWindowModality;
 	}
 
-	public override NotificationInteractionBuilder getNotificationDialogBuilder() {
+	override NotificationInteractionBuilder getNotificationDialogBuilder() {
 		return new NotificationInteractionBuilderImpl(interactionFactory, userInteractionListener);
 	}
 
-	public override ConfirmationInteractionBuilder getConfirmationDialogBuilder() {
+	override ConfirmationInteractionBuilder getConfirmationDialogBuilder() {
 		return new ConfirmationInteractionBuilderImpl(interactionFactory, userInteractionListener);
 	}
 
-	public override TextInputInteractionBuilder getTextInputDialogBuilder() {
+	override TextInputInteractionBuilder getTextInputDialogBuilder() {
 		return new TextInputInteractionBuilderImpl(interactionFactory, userInteractionListener);
 	}
 
-	public override MultipleChoiceSingleSelectionInteractionBuilder getSingleSelectionDialogBuilder() {
+	override MultipleChoiceSingleSelectionInteractionBuilder getSingleSelectionDialogBuilder() {
 		return new MultipleChoiceSingleSelectionInteractionBuilderImpl(interactionFactory, userInteractionListener);
 	}
 
-	public override MultipleChoiceMultiSelectionInteractionBuilder getMultiSelectionDialogBuilder() {
+	override MultipleChoiceMultiSelectionInteractionBuilder getMultiSelectionDialogBuilder() {
 		return new MultipleChoiceMultiSelectionInteractionBuilderImpl(interactionFactory, userInteractionListener);
 	}
 

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/BaseInteraction.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/BaseInteraction.xtend
@@ -14,13 +14,13 @@ import tools.vitruv.framework.userinteraction.InteractionResultProvider
  */
 abstract class BaseInteraction<T extends UserInteractionBase> {
 	@Accessors(PROTECTED_GETTER)
-	private final InteractionResultProvider interactionResultProvider;
-	private String title
-	private String message
-	private String positiveButtonText = "Yes"
-	private String negativeButtonText = "No"
-	private String cancelButtonText = "Cancel"
-	private WindowModality windowModality
+	final InteractionResultProvider interactionResultProvider;
+	String title
+	String message
+	String positiveButtonText = "Yes"
+	String negativeButtonText = "No"
+	String cancelButtonText = "Cancel"
+	WindowModality windowModality
 
 	protected new(InteractionResultProvider interactionResultProvider, WindowModality windowModality, String title,
 		String message) {

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/ConfirmationInteraction.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/ConfirmationInteraction.xtend
@@ -12,8 +12,8 @@ import tools.vitruv.framework.userinteraction.InteractionResultProvider
  * @author Heiko Klare
  */
 class ConfirmationInteraction extends BaseInteraction<ConfirmationUserInteraction> {
-	private static val DEFAULT_TITLE = "Please Confirm";
-	private static val DEFAULT_MESSAGE = "";
+	static val DEFAULT_TITLE = "Please Confirm";
+	static val DEFAULT_MESSAGE = "";
 
 	protected new(InteractionResultProvider interactionResultProvider, WindowModality windowModality) {
 		super(interactionResultProvider, windowModality, DEFAULT_TITLE, DEFAULT_MESSAGE)

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/InteractionFactoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/InteractionFactoryImpl.xtend
@@ -9,9 +9,9 @@ import tools.vitruv.framework.userinteraction.InteractionResultProvider
  * 
  * @author Heiko Klare
  */
-public class InteractionFactoryImpl implements InteractionFactory {
-	private final InteractionResultProvider interactionResultProvider;
-	private final WindowModality windowModality;
+class InteractionFactoryImpl implements InteractionFactory {
+	final InteractionResultProvider interactionResultProvider;
+	final WindowModality windowModality;
 
 	new(InteractionResultProvider interactionResultProvider, WindowModality windowModality) {
 		this.windowModality = windowModality;

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/MultipleChoiceSelectionInteraction.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/MultipleChoiceSelectionInteraction.xtend
@@ -14,11 +14,11 @@ import java.util.List
  * @author Heiko Klare
  */
 abstract class MultipleChoiceSelectionInteraction<I extends MultipleChoiceSelectionInteractionBase> extends BaseInteraction<I> {
-	private static val DEFAULT_TITLE = "Please Select";
-	private static val DEFAULT_MESSAGE = "";
+	static val DEFAULT_TITLE = "Please Select";
+	static val DEFAULT_MESSAGE = "";
 
 	@Accessors(PROTECTED_GETTER)
-	private final List<String> choices
+	final List<String> choices
 
 	protected new(InteractionResultProvider interactionResultProvider, WindowModality windowModality) {
 		super(interactionResultProvider, windowModality, DEFAULT_TITLE, DEFAULT_MESSAGE)
@@ -26,7 +26,7 @@ abstract class MultipleChoiceSelectionInteraction<I extends MultipleChoiceSelect
 		this.choices = new ArrayList<String>();
 	}
 
-	public def void addChoice(String choice) {
+	def void addChoice(String choice) {
 		this.choices += choice;
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/NotificationInteraction.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/NotificationInteraction.xtend
@@ -12,10 +12,10 @@ import tools.vitruv.framework.userinteraction.InteractionResultProvider
  * @author Dominik Klooz
  * @author Heiko Klare
  */
-public class NotificationInteraction extends BaseInteraction<NotificationUserInteraction> {
-	private static val DEFAULT_TITLE = "NOTIFICATION";
-	private static val DEFAULT_MESSAGE = "";
-	private NotificationType notificationType;
+class NotificationInteraction extends BaseInteraction<NotificationUserInteraction> {
+	static val DEFAULT_TITLE = "NOTIFICATION";
+	static val DEFAULT_MESSAGE = "";
+	NotificationType notificationType;
 
 	protected new(InteractionResultProvider interactionResultProvider, WindowModality windowModality) {
 		super(interactionResultProvider, windowModality, DEFAULT_TITLE, DEFAULT_MESSAGE)

--- a/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/TextInputInteraction.xtend
+++ b/bundles/framework/tools.vitruv.framework.userinteracting/src/tools/vitruv/framework/userinteraction/types/TextInputInteraction.xtend
@@ -13,11 +13,11 @@ import tools.vitruv.framework.userinteraction.UserInteractionOptions.InputValida
  * @author Dominik Klooz
  * @author Heiko Klare
  */
-public class TextInputInteraction extends BaseInteraction<FreeTextUserInteraction> {
-	private static val DEFAULT_TITLE = "Input Text";
-	private static val DEFAULT_MESSAGE = "";
-	private InputValidator inputValidator
-	private InputFieldType inputFieldType
+class TextInputInteraction extends BaseInteraction<FreeTextUserInteraction> {
+	static val DEFAULT_TITLE = "Input Text";
+	static val DEFAULT_MESSAGE = "";
+	InputValidator inputValidator
+	InputFieldType inputFieldType
 
 	public static final InputValidator NUMBERS_ONLY_INPUT_VALIDATOR = new InputValidator() {
 		override getInvalidInputMessage(String input) { "Only numbers are allowed as input" }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -216,7 +216,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		return uuid;
 	}
 
-	public override String generateUuidWithoutCreate(EObject eObject) {
+	override String generateUuidWithoutCreate(EObject eObject) {
 		val uuid = generateUuid(eObject);
 		// Register UUID globally for third party elements that are statically accessible and are never created.
 		// Since this is called in the moment when an element gets created, the object can only be globally resolved

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/PropagatedChangeListener.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/PropagatedChangeListener.xtend
@@ -11,7 +11,7 @@ import tools.vitruv.framework.domains.VitruvDomain;
  *
  * @author Andreas Loeffler
  */
-public interface PropagatedChangeListener {
+interface PropagatedChangeListener {
 
     /**
      * Whenever changes are made, they must are posted to this method.

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelConfiguration.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelConfiguration.xtend
@@ -7,11 +7,11 @@ import tools.vitruv.framework.change.processing.ChangePropagationSpecification
 import tools.vitruv.framework.domains.VitruvDomain
 
 class VirtualModelConfiguration {
-	private static val logger = Logger.getLogger(VirtualModelConfiguration);
-	private val List<VitruvDomain> metamodels;
-	private val List<ChangePropagationSpecification> changePropagationSpecifications;
+	static val logger = Logger.getLogger(VirtualModelConfiguration);
+	val List<VitruvDomain> metamodels;
+	val List<ChangePropagationSpecification> changePropagationSpecifications;
 	
-	public new() {
+	new() {
 		this.metamodels = new ArrayList();
 		this.changePropagationSpecifications = new ArrayList();
 	}
@@ -34,7 +34,7 @@ class VirtualModelConfiguration {
 		return true;
 	}
 	
-	public def void addMetamodel(VitruvDomain metamodel) {
+	def void addMetamodel(VitruvDomain metamodel) {
 		if (!checkForMetamodelConflict(metamodel)) {
 			throw new IllegalArgumentException("Given metamodel defines nsURI or file extension that another metamodel already defines");
 		}
@@ -54,18 +54,18 @@ class VirtualModelConfiguration {
 		return true;
 	}
 	
-	public def void addChangePropagationSpecification(ChangePropagationSpecification changePropagationSpecification) {
+	def void addChangePropagationSpecification(ChangePropagationSpecification changePropagationSpecification) {
 		if (!checkForTransformerConflict(changePropagationSpecification)) {
 			throw new IllegalArgumentException("Given propagation specification is defined for metamodel pair which another specification already defines");
 		}
 		changePropagationSpecifications += changePropagationSpecification;	
 	}
 	
-	public def Iterable<VitruvDomain> getMetamodels() {
+	def Iterable<VitruvDomain> getMetamodels() {
 		return metamodels;
 	}
 	
-	public def Iterable<ChangePropagationSpecification> getChangePropagationSpecifications() {
+	def Iterable<ChangePropagationSpecification> getChangePropagationSpecifications() {
 		return changePropagationSpecifications;
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelConfigurationBuilder.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelConfigurationBuilder.xtend
@@ -4,38 +4,38 @@ import tools.vitruv.framework.change.processing.ChangePropagationSpecification
 import tools.vitruv.framework.domains.VitruvDomain
 
 class VirtualModelConfigurationBuilder {
-	private val VirtualModelConfiguration modelConfiguration;
+	val VirtualModelConfiguration modelConfiguration;
 	
-	public new() {
+	new() {
 		this.modelConfiguration = new VirtualModelConfiguration();	
 	}
 	
-	public def static VirtualModelConfigurationBuilder create() {
+	def static VirtualModelConfigurationBuilder create() {
 		return new VirtualModelConfigurationBuilder();
 	}
 	
-	public def VirtualModelConfigurationBuilder addDomains(VitruvDomain... domains) {
+	def VirtualModelConfigurationBuilder addDomains(VitruvDomain... domains) {
 		domains.forEach[addDomain];
 		return this;
 	}
 	
-	public def VirtualModelConfigurationBuilder addDomain(VitruvDomain metamodel) {
+	def VirtualModelConfigurationBuilder addDomain(VitruvDomain metamodel) {
 		modelConfiguration.addMetamodel(metamodel);
 		return this;
 	}
 	
-	public def VirtualModelConfigurationBuilder addChangePropagationSpecifications(ChangePropagationSpecification... changePropagationSpecifications) {
+	def VirtualModelConfigurationBuilder addChangePropagationSpecifications(ChangePropagationSpecification... changePropagationSpecifications) {
 		changePropagationSpecifications.forEach[addChangePropagationSpecification];
 		return this;
 	}
 	
-	public def VirtualModelConfigurationBuilder addChangePropagationSpecification(ChangePropagationSpecification changePropagationSpecification) {
+	def VirtualModelConfigurationBuilder addChangePropagationSpecification(ChangePropagationSpecification changePropagationSpecification) {
 		modelConfiguration.addChangePropagationSpecification(changePropagationSpecification);
 		return this;
 	}
 
 	// TODO HK Generate here to avoid that the configuration gets modified by further calls to the builder afterwards	
-	public def VirtualModelConfiguration toConfiguration() {
+	def VirtualModelConfiguration toConfiguration() {
 		return modelConfiguration;
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
@@ -27,21 +27,21 @@ import org.apache.log4j.Logger
 import org.eclipse.emf.common.util.URI
 
 class VirtualModelImpl implements InternalVirtualModel {
-	private static val Logger LOGGER = Logger.getLogger(VirtualModelImpl.name)
-	private val ResourceRepositoryImpl resourceRepository
-	private val ModelRepositoryImpl modelRepository
-	private val VitruvDomainRepository metamodelRepository
-	private val ChangePropagator changePropagator
-	private val ChangePropagationSpecificationProvider changePropagationSpecificationProvider
-	private val File folder
-	private val extension ChangeDomainExtractor changeDomainExtractor
+	static val Logger LOGGER = Logger.getLogger(VirtualModelImpl.name)
+	val ResourceRepositoryImpl resourceRepository
+	val ModelRepositoryImpl modelRepository
+	val VitruvDomainRepository metamodelRepository
+	val ChangePropagator changePropagator
+	val ChangePropagationSpecificationProvider changePropagationSpecificationProvider
+	val File folder
+	val extension ChangeDomainExtractor changeDomainExtractor
 
 	/**
 	 * A list of {@link PropagatedChangeListener}s that are informed of all changes made
 	 */
-	private val List<PropagatedChangeListener> propagatedChangeListeners
+	val List<PropagatedChangeListener> propagatedChangeListeners
 
-	public new(File folder, InternalUserInteractor userInteractor, VirtualModelConfiguration modelConfiguration) {
+	new(File folder, InternalUserInteractor userInteractor, VirtualModelConfiguration modelConfiguration) {
 		this.folder = folder
 		this.metamodelRepository = new VitruvDomainRepositoryImpl()
 		for (metamodel : modelConfiguration.metamodels) {

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelManager.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelManager.xtend
@@ -4,19 +4,19 @@ import java.util.Map
 import java.io.File
 
 final class VirtualModelManager {
-	private Map<File, InternalVirtualModel> folderToVirtualModelMap;
+	Map<File, InternalVirtualModel> folderToVirtualModelMap;
 	
-	private static val instance = new VirtualModelManager();
+	static val instance = new VirtualModelManager();
 	
 	private new() {
 		this.folderToVirtualModelMap = newHashMap();
 	}
 	
-	public static def getInstance() {
+	static def getInstance() {
 		return instance;
 	}
 	
-	public def getVirtualModel(File folder) {
+	def getVirtualModel(File folder) {
 		if (folderToVirtualModelMap.containsKey(folder)) {
 			return folderToVirtualModelMap.get(folder);
 		} else {
@@ -31,7 +31,7 @@ final class VirtualModelManager {
 		}
 	}
 	
-	public def putVirtualModel(InternalVirtualModel model) {
+	def putVirtualModel(InternalVirtualModel model) {
 		folderToVirtualModelMap.put(model.folder, model);
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/helper/ChangeDomainExtractor.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/helper/ChangeDomainExtractor.xtend
@@ -7,7 +7,7 @@ import org.eclipse.emf.ecore.EObject
 import tools.vitruv.framework.domains.repository.VitruvDomainRepository
 
 class ChangeDomainExtractor {
-	private VitruvDomainRepository domainRepository;
+	VitruvDomainRepository domainRepository;
 	
 	new(VitruvDomainRepository domainRepository) {
 		this.domainRepository = domainRepository;
@@ -19,7 +19,7 @@ class ChangeDomainExtractor {
 	 * @param changes The propagation result
 	 * @return The target domain, null if none could be determined
 	 */
-	def public getTargetDomain(List<PropagatedChange> changes) {
+	def getTargetDomain(List<PropagatedChange> changes) {
 		if (changes === null) return null;
 
 		return getDomain(changes.map[consequentialChanges]);
@@ -31,7 +31,7 @@ class ChangeDomainExtractor {
 	 * @param changes The propagation result
 	 * @return The source domain, null if none could be determined
 	 */
-	def public getSourceDomain(List<PropagatedChange> changes) {
+	def getSourceDomain(List<PropagatedChange> changes) {
 		if (changes === null) return null;
 
 		return getDomain(changes.map[originalChange]);

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -41,7 +41,7 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 	final ModelRepositoryImpl modelRepository;
 	final List<EObject> objectsCreatedDuringPropagation;
 	final InternalUserInteractor userInteractor;
-	private final Collection<UserInteractionBase> userInteractions = new LinkedList();
+	final Collection<UserInteractionBase> userInteractions = new LinkedList();
 
 	new(ModelRepository resourceRepository, ChangePropagationSpecificationProvider changePropagationProvider,
 		VitruvDomainRepository metamodelRepository, CorrespondenceProviding correspondenceProviding,

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangedResourcesTracker.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangedResourcesTracker.xtend
@@ -9,8 +9,8 @@ import tools.vitruv.framework.change.echange.eobject.EObjectSubtractedEChange
 import org.eclipse.emf.ecore.EObject
 
 package class ChangedResourcesTracker {
-	private final Set<Resource> sourceModelResources;
-	private final Set<Resource> involvedModelResources;
+	final Set<Resource> sourceModelResources;
+	final Set<Resource> involvedModelResources;
 	
 	new() {
 		this.sourceModelResources = newHashSet();
@@ -18,7 +18,7 @@ package class ChangedResourcesTracker {
 	}
 
 
-	public def void addSourceResourceOfChange(TransactionalChange change) {
+	def void addSourceResourceOfChange(TransactionalChange change) {
 		val atomicChanges = change.getEChanges
 		val involvedObjects = atomicChanges.map[
 			if (it instanceof FeatureEChange<?,?>) it.affectedEObject 
@@ -27,14 +27,14 @@ package class ChangedResourcesTracker {
 		sourceModelResources += involvedObjects.map[eResource].filterNull.toList;
 	}
 	
-	public def void addInvolvedModelResource(Resource resource) {
+	def void addInvolvedModelResource(Resource resource) {
 		if (resource === null) {
 			return;
 		}
 		this.involvedModelResources += resource;
 	}
 	
-	public def void markNonSourceResourceAsChanged() {
+	def void markNonSourceResourceAsChanged() {
 		// Some models are not marked as modified although they were actually modified by the consistency preservation
 		// Therefore, we have to mark them as modified manually
 		

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ModelRepositoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ModelRepositoryImpl.xtend
@@ -11,7 +11,7 @@ import org.eclipse.emf.ecore.change.impl.ChangeDescriptionImpl
 import tools.vitruv.framework.uuid.UuidGeneratorAndResolver
 
 class ModelRepositoryImpl {
-	private val logger = Logger.getLogger(ModelRepositoryImpl);
+	val logger = Logger.getLogger(ModelRepositoryImpl);
 	val Set<EObject> rootElements;
 	val Map<EObject, AtomicEmfChangeRecorder> rootToRecorder;
 	var boolean isRecording = false;
@@ -23,7 +23,7 @@ class ModelRepositoryImpl {
 		rootToRecorder = new HashMap<EObject, AtomicEmfChangeRecorder>();
 	}
 	
-	public def void addRootElement(EObject rootElement) {
+	def void addRootElement(EObject rootElement) {
 		if (rootElements.contains(rootElement)) {
 			return;
 		}
@@ -37,7 +37,7 @@ class ModelRepositoryImpl {
 		}
 	}
 	
-	public def void cleanupRootElements() {
+	def void cleanupRootElements() {
 		val elementsToRemove = newArrayList() 
 		for (rootElement : rootElements) {
 			if (rootElement.eContainer !== null && !(rootElement.eContainer instanceof ChangeDescriptionImpl)) {
@@ -51,7 +51,7 @@ class ModelRepositoryImpl {
 		];
 	}
 	
-	public def void cleanupRootElementsWithoutResource() {
+	def void cleanupRootElementsWithoutResource() {
 		val elementsToRemove = newArrayList() 
 		for (rootElement : rootElements) {
 			if (rootElement.eResource === null) {
@@ -65,14 +65,14 @@ class ModelRepositoryImpl {
 		];
 	}
 	
-	public def void startRecording() {
+	def void startRecording() {
 		for (root : rootElements) {
 			startRecordingForElement(root)
 		}
 		isRecording = true;
 	}
 	
-	public def endRecording() {
+	def endRecording() {
 		val result = newArrayList();
 		for (root : rootToRecorder.keySet) {
 			rootToRecorder.get(root).endRecording();

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/TuidResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/TuidResolverImpl.xtend
@@ -10,10 +10,10 @@ import org.eclipse.emf.ecore.util.EcoreUtil
 import tools.vitruv.framework.vsum.ModelRepository
 
 class TuidResolverImpl implements tools.vitruv.framework.tuid.TuidResolver{
-	private val VitruvDomainRepository domainRepository;
-	private val ModelRepository modelRepository;
+	val VitruvDomainRepository domainRepository;
+	val ModelRepository modelRepository;
 
-	public new(VitruvDomainRepository domainRepository, ModelRepository modelRepository) {
+	new(VitruvDomainRepository domainRepository, ModelRepository modelRepository) {
 		this.domainRepository = domainRepository;
 		this.modelRepository = modelRepository;
 	}

--- a/tests/demo/tools.vitruv.demo.applications.familiespersons.families2persons.tests/src/tools/vitruv/applications/familiespersons/families2Persons/test/AbstractFamiliesToPersonsTest.xtend
+++ b/tests/demo/tools.vitruv.demo.applications.familiespersons.families2persons.tests/src/tools/vitruv/applications/familiespersons/families2Persons/test/AbstractFamiliesToPersonsTest.xtend
@@ -10,8 +10,8 @@ import org.apache.log4j.Logger
 import org.apache.log4j.Level
 
 abstract class AbstractFamiliesToPersonsTest extends VitruviusApplicationTest {
-	private static val MODEL_FILE_EXTENSION = "families";
-	private static val MODEL_NAME = "model";
+	static val MODEL_FILE_EXTENSION = "families";
+	static val MODEL_NAME = "model";
 	
 	private def String getProjectModelPath(String modelName) {
 		"model/" + modelName + "." + MODEL_FILE_EXTENSION;

--- a/tests/demo/tools.vitruv.demo.applications.familiespersons.families2persons.tests/src/tools/vitruv/applications/familiespersons/families2Persons/test/FamiliesPersonsTest.xtend
+++ b/tests/demo/tools.vitruv.demo.applications.familiespersons.families2persons.tests/src/tools/vitruv/applications/familiespersons/families2Persons/test/FamiliesPersonsTest.xtend
@@ -7,26 +7,26 @@ import static org.junit.Assert.*
 import edu.kit.ipd.sdq.metamodels.persons.Person
 
 class FamiliesPersonsTest extends AbstractFamiliesToPersonsTest {
-	private static val FAMILY_NAME = "Mustermann";
-	private static val FIRST_NAME_FATHER = "Max";
-	private static val FIRST_NAME_SON = "Sohn";
-	private static val FIRST_NAME_DAUGHTER = "Tochter";
-	private static val FIRST_NAME_MOTHER = "Erika"
-	private static val PERSONS_PATH = "model/persons.persons";
+	static val FAMILY_NAME = "Mustermann";
+	static val FIRST_NAME_FATHER = "Max";
+	static val FIRST_NAME_SON = "Sohn";
+	static val FIRST_NAME_DAUGHTER = "Tochter";
+	static val FIRST_NAME_MOTHER = "Erika"
+	static val PERSONS_PATH = "model/persons.persons";
 
 	@Test
-	public def void testCreateFamilyRegister() {
+	def void testCreateFamilyRegister() {
 		val familyRegister = FamiliesFactory.eINSTANCE.createFamilyRegister
 		saveAndSynchronizeChanges(familyRegister);
 		assertModelExists(PERSONS_PATH);
 	}
 
 	@Test
-	public def void testDeleteFamilyRegister() {
+	def void testDeleteFamilyRegister() {
 	}
 
 	@Test
-	public def void testCreateFamilyFather() {
+	def void testCreateFamilyFather() {
 		val family = FamiliesFactory.eINSTANCE.createFamily();
 		family.lastName = FAMILY_NAME;
 		rootElement.families.add(family);
@@ -40,7 +40,7 @@ class FamiliesPersonsTest extends AbstractFamiliesToPersonsTest {
 	}
 
 	@Test
-	public def void testCreateFamilySon() {
+	def void testCreateFamilySon() {
 		val family = FamiliesFactory.eINSTANCE.createFamily();
 		family.lastName = FAMILY_NAME;
 		rootElement.families.add(family);
@@ -54,7 +54,7 @@ class FamiliesPersonsTest extends AbstractFamiliesToPersonsTest {
 	}
 
 	@Test
-	public def void testCreateFamilyMother() {
+	def void testCreateFamilyMother() {
 		val family = FamiliesFactory.eINSTANCE.createFamily();
 		family.lastName = FAMILY_NAME;
 		rootElement.families.add(family);
@@ -68,7 +68,7 @@ class FamiliesPersonsTest extends AbstractFamiliesToPersonsTest {
 	}
 
 	@Test
-	public def void testCreateFamilyDaughter() {
+	def void testCreateFamilyDaughter() {
 		val family = FamiliesFactory.eINSTANCE.createFamily();
 		family.lastName = FAMILY_NAME;
 		rootElement.families.add(family);
@@ -82,7 +82,7 @@ class FamiliesPersonsTest extends AbstractFamiliesToPersonsTest {
 	}
 
 	@Test
-	public def void testDeleteMember() {
+	def void testDeleteMember() {
 		val family = FamiliesFactory.eINSTANCE.createFamily();
 		family.lastName = FAMILY_NAME;
 		rootElement.families.add(family);
@@ -99,7 +99,7 @@ class FamiliesPersonsTest extends AbstractFamiliesToPersonsTest {
 	}
 
 	@Test
-	public def void testChangeFirstName() {
+	def void testChangeFirstName() {
 		val family = FamiliesFactory.eINSTANCE.createFamily();
 		family.lastName = FAMILY_NAME;
 		rootElement.families.add(family);
@@ -117,6 +117,6 @@ class FamiliesPersonsTest extends AbstractFamiliesToPersonsTest {
 	}
 
 	@Test
-	public def void testChangeLastName() {
+	def void testChangeLastName() {
 	}
 }

--- a/tests/demo/tools.vitruv.demo.applications.familiespersons.persons2families.tests/src/tools/vitruv/application/familiespersons/persons2families/test/AbstractPersonsToFamiliesTest.xtend
+++ b/tests/demo/tools.vitruv.demo.applications.familiespersons.persons2families.tests/src/tools/vitruv/application/familiespersons/persons2families/test/AbstractPersonsToFamiliesTest.xtend
@@ -8,8 +8,8 @@ import edu.kit.ipd.sdq.metamodels.persons.PersonsFactory
 import tools.vitruv.applications.familiespersons.persons2families.PersonsToFamiliesChangePropagationSpecification
 
 abstract class AbstractPersonsToFamiliesTest extends VitruviusApplicationTest {
-	private static val MODEL_FILE_EXTENSION = "persons";
-	private static val MODEL_NAME = "model";
+	static val MODEL_FILE_EXTENSION = "persons";
+	static val MODEL_NAME = "model";
 	
 	private def String getProjectModelPath(String modelName) {
 		"model/" + modelName + "." + MODEL_FILE_EXTENSION;

--- a/tests/demo/tools.vitruv.demo.applications.familiespersons.persons2families.tests/src/tools/vitruv/application/familiespersons/persons2families/test/PersonsToFamiliesTest.xtend
+++ b/tests/demo/tools.vitruv.demo.applications.familiespersons.persons2families.tests/src/tools/vitruv/application/familiespersons/persons2families/test/PersonsToFamiliesTest.xtend
@@ -7,13 +7,13 @@ import static org.junit.Assert.*
 
 
 class PersonsToFamiliesTest extends AbstractPersonsToFamiliesTest{
-	private static val MALE_PERSON_NAME = "Max Mustermann";
-	private static val SECOND_MALE_PERSON_NAME = "Bernd Mustermann";
-	private static val FEMALE_PERSON_NAME = "Erika Mustermann";
-	private static val FAMILIES_PATH = "model/families.families";
+	static val MALE_PERSON_NAME = "Max Mustermann";
+	static val SECOND_MALE_PERSON_NAME = "Bernd Mustermann";
+	static val FEMALE_PERSON_NAME = "Erika Mustermann";
+	static val FAMILIES_PATH = "model/families.families";
 
 	@Test
-	public def void testCreateMalePerson() {
+	def void testCreateMalePerson() {
 		val malePerson = PersonsFactory.eINSTANCE.createMale();
 		malePerson.fullName = MALE_PERSON_NAME;
 		rootElement.persons.add(malePerson);
@@ -22,19 +22,19 @@ class PersonsToFamiliesTest extends AbstractPersonsToFamiliesTest{
 	}
 	
 	@Test
-	public def void testCreatePersonRegister(){
+	def void testCreatePersonRegister(){
 		val personRegister = PersonsFactory.eINSTANCE.createPersonRegister
 		saveAndSynchronizeChanges(personRegister);
 		assertModelExists(FAMILIES_PATH);
 	}
 	
 	@Test
-	public def void testDeletePersonRegister(){
+	def void testDeletePersonRegister(){
 		
 	}
 	
 	@Test
-	public def void testCreateMale(){
+	def void testCreateMale(){
 		val person = PersonsFactory.eINSTANCE.createMale
 		person.fullName = MALE_PERSON_NAME
 		rootElement.persons.add(person)
@@ -43,7 +43,7 @@ class PersonsToFamiliesTest extends AbstractPersonsToFamiliesTest{
 	}
 	
 	@Test
-	public def void testCreateFemale(){
+	def void testCreateFemale(){
 		val person = PersonsFactory.eINSTANCE.createFemale
 		person.fullName = FEMALE_PERSON_NAME
 		rootElement.persons.add(person)
@@ -52,7 +52,7 @@ class PersonsToFamiliesTest extends AbstractPersonsToFamiliesTest{
 	}
 	
 	@Test
-	public def void testChangeFirstName(){
+	def void testChangeFirstName(){
 		val person = PersonsFactory.eINSTANCE.createMale
 		person.fullName = MALE_PERSON_NAME
 		rootElement.persons.add(person)

--- a/tests/dsls/tools.vitruv.dsls.mappings.addressesXrecipients.tests/src/tools/vitruv/dsls/mappings/addressesXrecipients/tests/AddressesXRecipientsTestSuite.java
+++ b/tests/dsls/tools.vitruv.dsls.mappings.addressesXrecipients.tests/src/tools/vitruv/dsls/mappings/addressesXrecipients/tests/AddressesXRecipientsTestSuite.java
@@ -4,9 +4,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import tools.vitruv.dsls.mappings.addressesXrecipients.tests.AddressesXRecipientsL2RTest;
-import tools.vitruv.dsls.mappings.addressesXrecipients.tests.AddressesXRecipientsR2LTest;
-
 @RunWith(Suite.class)
 @SuiteClasses({AddressesXRecipientsL2RTest.class, AddressesXRecipientsR2LTest.class})
 public class AddressesXRecipientsTestSuite {

--- a/tests/dsls/tools.vitruv.dsls.mappings.tests/src/tools/vitruv/dsls/mappings/tests/MappingParameterGraphTraverserTest.xtend
+++ b/tests/dsls/tools.vitruv.dsls.mappings.tests/src/tools/vitruv/dsls/mappings/tests/MappingParameterGraphTraverserTest.xtend
@@ -22,12 +22,12 @@ import static org.junit.Assert.fail
 import org.apache.log4j.Logger
 
 class MappingParameterGraphTraverserTest {
-	private static Logger LOGGER = Logger.getLogger(MappingParameterGraphTraverserTest)
+	static Logger LOGGER = Logger.getLogger(MappingParameterGraphTraverserTest)
 	
-	private List<String> parameter
-	private List<FeatureConditionGenerator> inConditions
-	private MappingParameterGraphTraverser traverser
-	private Map<String, EStructuralFeature> testFeatures = // extension is the only not containment reference
+	List<String> parameter
+	List<FeatureConditionGenerator> inConditions
+	MappingParameterGraphTraverser traverser
+	Map<String, EStructuralFeature> testFeatures = // extension is the only not containment reference
 	#{'cFA' -> testFeature('ownedOperation'), 'cFB' -> testFeature('nestedClassifier'), 'cFC' ->
 		testFeature('ownedReception'), 'ncF' -> testFeature('extension')}
 

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
@@ -19,10 +19,10 @@ import tools.vitruv.framework.change.description.PropagatedChange
 import tools.vitruv.framework.change.description.VitruviusChange
 
 class BidirectionalExecutionTests extends AbstractAllElementTypesReactionsTests {
-	private static val TEST_SOURCE_MODEL_NAME = "EachTestModelSource";
-	private static val TEST_TARGET_MODEL_NAME = "EachTestModelTarget";
+	static val TEST_SOURCE_MODEL_NAME = "EachTestModelSource";
+	static val TEST_TARGET_MODEL_NAME = "EachTestModelTarget";
 	
-	private String[] nonContainmentNonRootIds = #["NonRootHelper0", "NonRootHelper1", "NonRootHelper2"];
+	String[] nonContainmentNonRootIds = #["NonRootHelper0", "NonRootHelper1", "NonRootHelper2"];
 
 	private def Root getRootElement() {
 		return TEST_SOURCE_MODEL_NAME.projectModelPath.firstRootElement as Root;
@@ -66,7 +66,7 @@ class BidirectionalExecutionTests extends AbstractAllElementTypesReactionsTests 
 	}
 	
 	@Test
-	public def void testBasicBidirectionalApplication() {
+	def void testBasicBidirectionalApplication() {
 		val targetRoot = TEST_TARGET_MODEL_NAME.projectModelPath.firstRootElement as Root;
 		startRecordingChanges(targetRoot);
 		val newNonRoot = AllElementTypesFactory.eINSTANCE.createNonRoot;
@@ -92,7 +92,7 @@ class BidirectionalExecutionTests extends AbstractAllElementTypesReactionsTests 
 	 *  has a changed URI (due to removal from container).
 	 */
 	@Test
-	public def void testApplyRemoveInOtherModel() {
+	def void testApplyRemoveInOtherModel() {
 		val targetRoot = TEST_TARGET_MODEL_NAME.projectModelPath.firstRootElement as Root;
 		startRecordingChanges(targetRoot);
 		targetRoot.nonRootObjectContainerHelper.nonRootObjectsContainment.remove(0);
@@ -116,7 +116,7 @@ class BidirectionalExecutionTests extends AbstractAllElementTypesReactionsTests 
 	 *  has a changed URI (due to removal from container).
 	 */
 	@Test
-	public def void testApplyRemoveRootInOtherModel() {
+	def void testApplyRemoveRootInOtherModel() {
 		val targetRoot = TEST_TARGET_MODEL_NAME.projectModelPath.firstRootElement as Root;
 		startRecordingChanges(targetRoot);
 		val propagatedChanges = deleteAndSynchronizeModel(TEST_TARGET_MODEL_NAME.projectModelPath);

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/ReactionsRollbackTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/ReactionsRollbackTests.xtend
@@ -10,8 +10,8 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl
 
 class ReactionsRollbackTests extends AbstractAllElementTypesReactionsTests {
-	private static val TEST_SOURCE_MODEL_NAME = "EachTestModelSource";
-	private static val TEST_TARGET_MODEL_NAME = "EachTestModelTarget";
+	static val TEST_SOURCE_MODEL_NAME = "EachTestModelSource";
+	static val TEST_TARGET_MODEL_NAME = "EachTestModelTarget";
 	
 	private def String getProjectModelPath(String modelName) {
 		"model/" + modelName + "." + MODEL_FILE_EXTENSION;
@@ -26,7 +26,7 @@ class ReactionsRollbackTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testReverse() {
+	def void testReverse() {
 		val root = AllElementTypesFactory.eINSTANCE.createRoot();
 		root.setId(TEST_SOURCE_MODEL_NAME);
 		createAndSynchronizeModel(TEST_SOURCE_MODEL_NAME.projectModelPath, root);

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/ImportTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/ImportTests.xtend
@@ -8,7 +8,7 @@ import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
 
 class ImportTests extends AbstractReactionImportsTests {
 
-	private static val TEST_SOURCE_MODEL_NAME = "ImportTestsModelSource";
+	static val TEST_SOURCE_MODEL_NAME = "ImportTestsModelSource";
 
 	private def Root getRootElement() {
 		return TEST_SOURCE_MODEL_NAME.projectModelPath.firstRootElement as Root;
@@ -105,21 +105,21 @@ class ImportTests extends AbstractReactionImportsTests {
 	// execute imported and transitive imported reactions:
 
 	@Test
-	public def void testRootReaction() {
+	def void testRootReaction() {
 		resetExecutionMonitor();
 		triggerReaction();
 		assertIsSet(ExecutionType.RootReaction);
 	}
 
 	@Test
-	public def void testImportedReaction() {
+	def void testImportedReaction() {
 		resetExecutionMonitor();
 		triggerReaction();
 		assertIsSet(ExecutionType.DirectSNReaction);
 	}
 
 	@Test
-	public def void testTransitiveImportedReaction() {
+	def void testTransitiveImportedReaction() {
 		resetExecutionMonitor();
 		triggerReaction();
 		assertIsSet(ExecutionType.TransitiveSNReaction);
@@ -128,7 +128,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// multiple imports: combination of imported reactions
 
 	@Test
-	public def void testMultipleImportedReactions() {
+	def void testMultipleImportedReactions() {
 		resetExecutionMonitor();
 		triggerReaction();
 		val monitor = new ImportTestsExecutionMonitor();
@@ -139,7 +139,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// call imported routines from within reaction:
 
 	@Test
-	public def void testReactionCallsRootRoutine() {
+	def void testReactionCallsRootRoutine() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_REACTION, TAG_ROOT_ROUTINE);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -149,7 +149,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testReactionCallsImportedRoutine_SN() {
+	def void testReactionCallsImportedRoutine_SN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_REACTION, TAG_DIRECT_ROUTINE_SN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -159,7 +159,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testReactionCallsImportedRoutine_QN() {
+	def void testReactionCallsImportedRoutine_QN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_REACTION, TAG_DIRECT_ROUTINE_QN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -171,7 +171,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// call transitive imported routines from within reaction:
 
 	@Test
-	public def void testReactionCallsTransitiveImportedRoutine_SN_SN() {
+	def void testReactionCallsTransitiveImportedRoutine_SN_SN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_REACTION, TAG_TRANSITIVE_ROUTINE_SN_SN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -181,7 +181,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testReactionCallsTransitiveImportedRoutine_SN_QN() {
+	def void testReactionCallsTransitiveImportedRoutine_SN_QN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_REACTION, TAG_TRANSITIVE_ROUTINE_SN_QN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -191,7 +191,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testReactionCallsTransitiveImportedRoutine_QN_SN() {
+	def void testReactionCallsTransitiveImportedRoutine_QN_SN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_REACTION, TAG_TRANSITIVE_ROUTINE_QN_SN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -201,7 +201,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testReactionCallsTransitiveImportedRoutine_QN_QN() {
+	def void testReactionCallsTransitiveImportedRoutine_QN_QN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_REACTION, TAG_TRANSITIVE_ROUTINE_QN_QN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -213,7 +213,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// call imported routines from within routine:
 
 	@Test
-	public def void testRoutineCallsRootRoutine() {
+	def void testRoutineCallsRootRoutine() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_ROUTINE, TAG_ROOT_ROUTINE);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -223,7 +223,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testRoutineCallsImportedRoutine_SN() {
+	def void testRoutineCallsImportedRoutine_SN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_ROUTINE, TAG_DIRECT_ROUTINE_SN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -233,7 +233,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testRoutineCallsImportedRoutine_QN() {
+	def void testRoutineCallsImportedRoutine_QN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_ROUTINE, TAG_DIRECT_ROUTINE_QN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -245,7 +245,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// call transitive imported routines from within routine:
 
 	@Test
-	public def void testRoutineCallsTransitiveImportedRoutine_SN_SN() {
+	def void testRoutineCallsTransitiveImportedRoutine_SN_SN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_ROUTINE, TAG_TRANSITIVE_ROUTINE_SN_SN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -255,7 +255,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testRoutineCallsTransitiveImportedRoutine_SN_QN() {
+	def void testRoutineCallsTransitiveImportedRoutine_SN_QN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_ROUTINE, TAG_TRANSITIVE_ROUTINE_SN_QN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -265,7 +265,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testRoutineCallsTransitiveImportedRoutine_QN_SN() {
+	def void testRoutineCallsTransitiveImportedRoutine_QN_SN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_ROUTINE, TAG_TRANSITIVE_ROUTINE_QN_SN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -275,7 +275,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testRoutineCallsTransitiveImportedRoutine_QN_QN() {
+	def void testRoutineCallsTransitiveImportedRoutine_QN_QN() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_ROUTINE, TAG_TRANSITIVE_ROUTINE_QN_QN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -287,7 +287,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// multiple imports: combination of imported routines
 
 	@Test
-	public def void testMultipleImportedRoutines() {
+	def void testMultipleImportedRoutines() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_CALL_ROUTINE_FROM_REACTION,
 			TAG_ROOT_ROUTINE, TAG_DIRECT_ROUTINE_SN, TAG_DIRECT2_ROUTINE_SN, TAG_TRANSITIVE_ROUTINE_SN_SN);
@@ -303,7 +303,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// import only routines:
 
 	@Test
-	public def void testRoutinesOnlyReactions() {
+	def void testRoutinesOnlyReactions() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_TEST_ROUTINES_ONLY_REACTIONS);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -320,7 +320,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testRoutinesOnlyRoutines() {
+	def void testRoutinesOnlyRoutines() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_TEST_ROUTINES_ONLY_ROUTINES);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -339,7 +339,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// check (transitive) imported segments still working:
 
 	@Test
-	public def void testImportedSegmentsWorking() {
+	def void testImportedSegmentsWorking() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_TEST_IMPORTED_SEGMENTS_WORKING);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -358,7 +358,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// reaction overrides:
 
 	@Test
-	public def void testOverrideReaction() {
+	def void testOverrideReaction() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_TEST_REACTION_OVERRIDE);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -371,7 +371,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testOverrideTransitiveReaction() {
+	def void testOverrideTransitiveReaction() {
 		resetExecutionMonitor();
 		triggerReaction(TAG_TEST_TRANSITIVE_REACTION_OVERRIDE);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -394,7 +394,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// override of imported routine:
 
 	@Test
-	public def void testCallOverriddenRoutineFromRoot() {
+	def void testCallOverriddenRoutineFromRoot() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_OVERRIDDEN_ROUTINE, TAG_FROM_ROOT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -406,7 +406,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testCallOverriddenRoutineFromOverriddenSegment() {
+	def void testCallOverriddenRoutineFromOverriddenSegment() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_OVERRIDDEN_ROUTINE, TAG_FROM_OVERRIDDEN_SEGMENT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -420,7 +420,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// override of transitive imported routine:
 
 	@Test
-	public def void testCallOverriddenTransitiveRoutineFromRoot() {
+	def void testCallOverriddenTransitiveRoutineFromRoot() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_OVERRIDDEN_TRANSITIVE_ROUTINE, TAG_FROM_ROOT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -432,7 +432,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testCallOverriddenTransitiveRoutineFromOverriddenSegment() {
+	def void testCallOverriddenTransitiveRoutineFromOverriddenSegment() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_OVERRIDDEN_TRANSITIVE_ROUTINE, TAG_FROM_OVERRIDDEN_SEGMENT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -444,7 +444,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testCallOverriddenTransitiveRoutineFromSegmentInBetween() {
+	def void testCallOverriddenTransitiveRoutineFromSegmentInBetween() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_OVERRIDDEN_TRANSITIVE_ROUTINE, TAG_FROM_SEGMENT_IN_BETWEEN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -458,7 +458,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// override of transitive imported routine, with independent override hierarchy:
 
 	@Test
-	public def void testCallOverriddenTransitiveRoutineWithSeparateOverrideHierarchyFromRoot() {
+	def void testCallOverriddenTransitiveRoutineWithSeparateOverrideHierarchyFromRoot() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_OVERRIDDEN_TRANSITIVE_ROUTINE_WITH_SEPARATE_OVERRIDE_HIERARCHY, TAG_FROM_ROOT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -470,7 +470,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testCallOverriddenTransitiveRoutineWithSeparateOverrideHierarchyFromOverriddenSegment() {
+	def void testCallOverriddenTransitiveRoutineWithSeparateOverrideHierarchyFromOverriddenSegment() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_OVERRIDDEN_TRANSITIVE_ROUTINE_WITH_SEPARATE_OVERRIDE_HIERARCHY, TAG_FROM_OVERRIDDEN_SEGMENT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -482,7 +482,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testCallOverriddenTransitiveRoutineWithSeparateOverrideHierarchyFromSegmentInBetween() {
+	def void testCallOverriddenTransitiveRoutineWithSeparateOverrideHierarchyFromSegmentInBetween() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_OVERRIDDEN_TRANSITIVE_ROUTINE_WITH_SEPARATE_OVERRIDE_HIERARCHY, TAG_FROM_SEGMENT_IN_BETWEEN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -496,7 +496,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// override of transitive imported routine, that has also already been overridden by imported segment:
 
 	@Test
-	public def void testCallAlreadyOverriddenTransitiveRoutineFromRoot() {
+	def void testCallAlreadyOverriddenTransitiveRoutineFromRoot() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_ALREADY_OVERRIDDEN_TRANSITIVE_ROUTINE, TAG_FROM_ROOT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -509,7 +509,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testCallAlreadyOverriddenTransitiveRoutineFromOverriddenSegment() {
+	def void testCallAlreadyOverriddenTransitiveRoutineFromOverriddenSegment() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_ALREADY_OVERRIDDEN_TRANSITIVE_ROUTINE, TAG_FROM_OVERRIDDEN_SEGMENT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -522,7 +522,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testCallAlreadyOverriddenTransitiveRoutineFromSegmentInBetween() {
+	def void testCallAlreadyOverriddenTransitiveRoutineFromSegmentInBetween() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_ALREADY_OVERRIDDEN_TRANSITIVE_ROUTINE, TAG_FROM_SEGMENT_IN_BETWEEN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -537,7 +537,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// imported segment overriding transitive imported routine:
 
 	@Test
-	public def void testCallTransitiveRoutineOverriddenByImportedSegmentFromRoot() {
+	def void testCallTransitiveRoutineOverriddenByImportedSegmentFromRoot() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_TRANSITIVE_ROUTINE_OVERRIDDEN_BY_IMPORTED_SEGMENT, TAG_FROM_ROOT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -549,7 +549,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testCallTransitiveRoutineOverriddenByImportedSegmentFromOverriddenSegment() {
+	def void testCallTransitiveRoutineOverriddenByImportedSegmentFromOverriddenSegment() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_TRANSITIVE_ROUTINE_OVERRIDDEN_BY_IMPORTED_SEGMENT, TAG_FROM_OVERRIDDEN_SEGMENT);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -561,7 +561,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	}
 
 	@Test
-	public def void testCallTransitiveRoutineOverriddenByImportedSegmentFromSegmentInBetween() {
+	def void testCallTransitiveRoutineOverriddenByImportedSegmentFromSegmentInBetween() {
 		resetExecutionMonitor();
 		triggerReaction(ImportTests.TAG_CALL_TRANSITIVE_ROUTINE_OVERRIDDEN_BY_IMPORTED_SEGMENT, TAG_FROM_SEGMENT_IN_BETWEEN);
 		val monitor = new ImportTestsExecutionMonitor();
@@ -575,7 +575,7 @@ class ImportTests extends AbstractReactionImportsTests {
 	// multiple imports and overrides of the same routines at different import paths:
 
 	@Test
-	public def void testMultipleImportsOfSameRoutines() {
+	def void testMultipleImportsOfSameRoutines() {
 		// import path 1:
 		resetExecutionMonitor();
 		triggerReaction(TAG_TEST_MULTIPLE_IMPORTS_OF_SAME_ROUTINES_IMPORT_PATH_1);

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/ImportTestsExecutionMonitor.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/ImportTestsExecutionMonitor.xtend
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertTrue
 
 final class ImportTestsExecutionMonitor {
 
-	public enum ExecutionType {
+	enum ExecutionType {
 		RootReaction,
 		RootRoutine,
 		RootDirectSNOverriddenReaction,
@@ -66,22 +66,22 @@ final class ImportTestsExecutionMonitor {
 		CommonRoutinesRoutine3
 	}
 
-	private static val ImportTestsExecutionMonitor INSTANCE = new ImportTestsExecutionMonitor();
+	static val ImportTestsExecutionMonitor INSTANCE = new ImportTestsExecutionMonitor();
 
-	public static def getInstance() {
+	static def getInstance() {
 		return INSTANCE;
 	}
 
-	private val values = EnumSet.noneOf(ExecutionType);
+	val values = EnumSet.noneOf(ExecutionType);
 
 	new() {
 	}
 
-	public def void set(ExecutionType type) {
+	def void set(ExecutionType type) {
 		values.add(type);
 	}
 
-	public def void setAll(ExecutionType... types) {
+	def void setAll(ExecutionType... types) {
 		if (types !== null) {
 			for (type : types) {
 				this.set(type);
@@ -89,40 +89,40 @@ final class ImportTestsExecutionMonitor {
 		}
 	}
 
-	public def boolean isSet(ExecutionType type) {
+	def boolean isSet(ExecutionType type) {
 		return values.contains(type);
 	}
 
-	public def void reset() {
+	def void reset() {
 		values.clear();
 	}
 
-	public override boolean equals(Object object) {
+	override boolean equals(Object object) {
 		if (object instanceof ImportTestsExecutionMonitor) {
 			return this.values.equals(object.values);
 		}
 		return false;
 	}
 
-	public override String toString() {
+	override String toString() {
 		return values.toString();
 	}
 
-	public def assertIsSet(ExecutionType type) {
+	def assertIsSet(ExecutionType type) {
 		assertTrue(type + " was expected to occur, but did not", this.isSet(type));
 	}
 
-	public def assertIsNotSet(ExecutionType type) {
+	def assertIsNotSet(ExecutionType type) {
 		assertTrue(type + " was not expected to occur but did", !this.isSet(type));
 	}
 
-	public def assertIsSetOnly(ExecutionType... types) {
+	def assertIsSetOnly(ExecutionType... types) {
 		val typesList = (types as List<ExecutionType> ?: #[]);
 		assertTrue("Expected " + typesList + " to occur, but got " + values,
 			values.size == typesList.size && values.containsAll(typesList));
 	}
 
-	public def assertEqualWithStatic() {
+	def assertEqualWithStatic() {
 		for (executionType : ExecutionType.values) {
 			if (this.isSet(executionType)) {
 				assertTrue(executionType + " was expected to occur but did not", instance.isSet(executionType));

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.xtend
@@ -15,12 +15,12 @@ import static org.junit.Assert.assertTrue
 import allElementTypes.AllElementTypesPackage
 
 class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
-	private static val TEST_SOURCE_MODEL_NAME = "EachTestModelSource";
-	private static val TEST_TARGET_MODEL_NAME = "EachTestModelTarget";
-	private static val FURTHER_SOURCE_TEST_MODEL_NAME = "Further_Source_Test_Model";
-	private static val FURTHER_TARGET_TEST_MODEL_NAME = "Further_Target_Test_Model"
+	static val TEST_SOURCE_MODEL_NAME = "EachTestModelSource";
+	static val TEST_TARGET_MODEL_NAME = "EachTestModelTarget";
+	static val FURTHER_SOURCE_TEST_MODEL_NAME = "Further_Source_Test_Model";
+	static val FURTHER_TARGET_TEST_MODEL_NAME = "Further_Target_Test_Model"
 	
-	private String[] nonContainmentNonRootIds = #["NonRootHelper0", "NonRootHelper1", "NonRootHelper2"];
+	String[] nonContainmentNonRootIds = #["NonRootHelper0", "NonRootHelper1", "NonRootHelper2"];
 
 	private def Root getRootElement() {
 		return TEST_SOURCE_MODEL_NAME.projectModelPath.firstRootElement as Root;
@@ -215,7 +215,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 
 	// TODO HK (Change MM) Unset does not produce any change event at the moment
 	// @Test
-	public def void testUnsetSingleValuedEAttribute() {
+	def void testUnsetSingleValuedEAttribute() {
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		unsetSingleValuedEAttribute(rootElement);
 		val compareMonitor = new SimpleChangesTestsExecutionMonitor();
@@ -225,7 +225,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	// @Test
-	public def void testUnsetSingleValuedNonContainmentEReference() throws Throwable {
+	def void testUnsetSingleValuedNonContainmentEReference() throws Throwable {
 		setSingleValuedNonContainmentNonRootObject(rootElement, nonContainmentNonRootIds.get(1));
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		unsetSingleValuedNonContainmentNonRootObject(rootElement);
@@ -237,7 +237,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testUpdateSingleValuedEAttribute() {
+	def void testUpdateSingleValuedEAttribute() {
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		setSingleValuedEAttribute(rootElement, -1);
 		val compareMonitor = new SimpleChangesTestsExecutionMonitor();
@@ -248,7 +248,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testUpdateSingleValuedPrimitiveTypeEAttribute() {
+	def void testUpdateSingleValuedPrimitiveTypeEAttribute() {
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		setSingleValuedPrimitiveTypeEAttribute(rootElement, -1);
 		val compareMonitor = new SimpleChangesTestsExecutionMonitor();
@@ -259,7 +259,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testCreateSingleValuedContainmentEReference() throws Throwable {
+	def void testCreateSingleValuedContainmentEReference() throws Throwable {
 		unsetSingleValuedContainmentNonRootObject(rootElement);
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		setSingleValuedContainmentNonRootObject(rootElement, "singleValuedContainmentNonRootTest");
@@ -272,7 +272,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testDeleteSingleValuedContainmentEReference() throws Throwable {
+	def void testDeleteSingleValuedContainmentEReference() throws Throwable {
 		setSingleValuedContainmentNonRootObject(rootElement, "singleValuedContainmentNonRoot");
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		val oldElement = rootElement.singleValuedContainmentEReference;
@@ -288,7 +288,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testReplaceSingleValuedContainmentEReference() throws Throwable {
+	def void testReplaceSingleValuedContainmentEReference() throws Throwable {
 		setSingleValuedContainmentNonRootObject(rootElement, "singleValuedContainmentNonRoot");
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		setSingleValuedContainmentNonRootObject(rootElement, "singleValuedContainmentNonRootTest");
@@ -303,7 +303,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testSetSingleValuedNonContainmentEReference() throws Throwable {
+	def void testSetSingleValuedNonContainmentEReference() throws Throwable {
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		setSingleValuedNonContainmentNonRootObject(rootElement, nonContainmentNonRootIds.get(1));
 		val compareMonitor = new SimpleChangesTestsExecutionMonitor();
@@ -315,7 +315,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testReplaceSingleValuedNonContainmentEReference() throws Throwable {
+	def void testReplaceSingleValuedNonContainmentEReference() throws Throwable {
 		setSingleValuedNonContainmentNonRootObject(rootElement, nonContainmentNonRootIds.get(0));
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		setSingleValuedNonContainmentNonRootObject(rootElement, nonContainmentNonRootIds.get(1));
@@ -328,7 +328,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testAddMultiValuedEAttribute() throws Throwable {
+	def void testAddMultiValuedEAttribute() throws Throwable {
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		addMultiValuedEAttribute(rootElement, 1);
 		val compareMonitor = new SimpleChangesTestsExecutionMonitor();
@@ -339,7 +339,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testDeleteMultiValuedEAttribute() throws Throwable {
+	def void testDeleteMultiValuedEAttribute() throws Throwable {
 		addMultiValuedEAttribute(rootElement, 1);
 		addMultiValuedEAttribute(rootElement, 2);
 		SimpleChangesTestsExecutionMonitor.reinitialize();
@@ -353,7 +353,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testReplaceMultiValuedEAttribute() throws Throwable {
+	def void testReplaceMultiValuedEAttribute() throws Throwable {
 		addMultiValuedEAttribute(rootElement, 1);
 		addMultiValuedEAttribute(rootElement, 2);
 		SimpleChangesTestsExecutionMonitor.reinitialize();
@@ -369,7 +369,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testAddMultiValuedContainmentEReference() throws Throwable {
+	def void testAddMultiValuedContainmentEReference() throws Throwable {
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		addMultiValuedContainmentNonRootObject(rootElement, "multiValuedContainmentNonRootTest");
 		val compareMonitor = new SimpleChangesTestsExecutionMonitor();
@@ -381,7 +381,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testDeleteMultiValuedContainmentEReference() throws Throwable {
+	def void testDeleteMultiValuedContainmentEReference() throws Throwable {
 		addMultiValuedContainmentNonRootObject(rootElement, "multiValuedContainmentNonRootTest");
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		removeMultiValuedContainmentNonRootObject(rootElement, "multiValuedContainmentNonRootTest");
@@ -394,7 +394,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testReplaceMultiValuedContainmentEReference() throws Throwable {
+	def void testReplaceMultiValuedContainmentEReference() throws Throwable {
 		addMultiValuedContainmentNonRootObject(rootElement, "multiValuedContainmentNonRootTest");
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		replaceMultiValuedContainmentNonRootObject(rootElement, "multiValuedContainmentNonRootTest",
@@ -411,7 +411,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testInsertMultiValuedNonContainmentEReference() throws Throwable {
+	def void testInsertMultiValuedNonContainmentEReference() throws Throwable {
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		insertMultiValuedNonContainmentNonRootObject(rootElement, nonContainmentNonRootIds.get(0));
 		val compareMonitor = new SimpleChangesTestsExecutionMonitor();
@@ -422,7 +422,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testRemoveMultiValuedNonContainmentEReference() throws Throwable {
+	def void testRemoveMultiValuedNonContainmentEReference() throws Throwable {
 		insertMultiValuedNonContainmentNonRootObject(rootElement, nonContainmentNonRootIds.get(1));
 		SimpleChangesTestsExecutionMonitor.reinitialize();
 		removeMultiValuedNonContainmentNonRootObject(rootElement, nonContainmentNonRootIds.get(1));
@@ -435,7 +435,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testReplaceMultiValuedNonContainmentEReference() throws Throwable {
+	def void testReplaceMultiValuedNonContainmentEReference() throws Throwable {
 		insertMultiValuedNonContainmentNonRootObject(rootElement, nonContainmentNonRootIds.get(0));
 		insertMultiValuedNonContainmentNonRootObject(rootElement, nonContainmentNonRootIds.get(1));
 		SimpleChangesTestsExecutionMonitor.reinitialize();
@@ -456,7 +456,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 
 	// TODO HK (Change MM) Permute operations are not supported by now? No EChange produced
 	// @Test
-	public def void testPermuteMultiValuedNonContainmentEReference() throws Throwable {
+	def void testPermuteMultiValuedNonContainmentEReference() throws Throwable {
 		for (nonRootId : nonContainmentNonRootIds) {
 			insertMultiValuedNonContainmentNonRootObject(rootElement, nonRootId);
 		}
@@ -469,7 +469,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testDeleteEachTestModel() throws Throwable {
+	def void testDeleteEachTestModel() throws Throwable {
 		assertModelExists(TEST_SOURCE_MODEL_NAME.projectModelPath);
 		deleteAndSynchronizeModel(TEST_SOURCE_MODEL_NAME.projectModelPath);
 		assertModelNotExists(TEST_SOURCE_MODEL_NAME.projectModelPath);
@@ -477,7 +477,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testCreateFurtherModel() throws Throwable {
+	def void testCreateFurtherModel() throws Throwable {
 		val root = AllElementTypesFactory.eINSTANCE.createRoot();
 		root.setId(FURTHER_SOURCE_TEST_MODEL_NAME);
 		createAndSynchronizeModel(FURTHER_SOURCE_TEST_MODEL_NAME.projectModelPath, root);
@@ -486,7 +486,7 @@ class SimpleChangesTests extends AbstractAllElementTypesReactionsTests {
 	}
 
 	@Test
-	public def void testDeleteFurtherModel() throws Throwable {
+	def void testDeleteFurtherModel() throws Throwable {
 		val root = AllElementTypesFactory.eINSTANCE.createRoot();
 		root.setId(FURTHER_SOURCE_TEST_MODEL_NAME);
 		createAndSynchronizeModel(FURTHER_SOURCE_TEST_MODEL_NAME.projectModelPath, root);

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTestsExecutionMonitor.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTestsExecutionMonitor.xtend
@@ -4,26 +4,26 @@ import java.util.BitSet
 import static org.junit.Assert.assertTrue;
 
 final class SimpleChangesTestsExecutionMonitor {
-	private static var SimpleChangesTestsExecutionMonitor INSTANCE;
+	static var SimpleChangesTestsExecutionMonitor INSTANCE;
 	
-	public static def getInstance() {
+	static def getInstance() {
 		if (INSTANCE === null) {
 			INSTANCE = new SimpleChangesTestsExecutionMonitor();
 		}
 		return INSTANCE;
 	}
 	
-	public static def void reinitialize() {
+	static def void reinitialize() {
 		INSTANCE = new SimpleChangesTestsExecutionMonitor();
 	}
 	
-	private BitSet values;
+	BitSet values;
 	
 	new() {
 		this.values = new BitSet(ChangeType.Size.ordinal + 1);
 	}
 	
-	public enum ChangeType {
+	enum ChangeType {
 		CreateEObject,
 		DeleteEObject,
 		UpdateSingleValuedPrimitveTypeEAttribute,
@@ -45,15 +45,15 @@ final class SimpleChangesTestsExecutionMonitor {
 		Size
 	}
 	
-	public def void set(ChangeType type) {
+	def void set(ChangeType type) {
 		this.values.set(type.ordinal);
 	}
 	
-	public def boolean isSet(ChangeType type) {
+	def boolean isSet(ChangeType type) {
 		return this.values.get(type.ordinal);
 	}
 	
-	public override boolean equals(Object object) {
+	override boolean equals(Object object) {
 		if (object instanceof SimpleChangesTestsExecutionMonitor) {
 			val monitor = object;
 			return monitor.values.equals(this.values);
@@ -61,7 +61,7 @@ final class SimpleChangesTestsExecutionMonitor {
 		return false;
 	}
 	
-	public def assertEqualWithStatic() {
+	def assertEqualWithStatic() {
 		for (var i = 0; i < ChangeType.Size.ordinal; i++) {
 			if (values.get(i)) {
 				assertTrue(ChangeType.values.get(i) + " was expected to occur but did not", INSTANCE.values.get(i));

--- a/tests/extensions/emfdomain/tools.vitruv.extensions.emf.monitorededitor.tests/unit/tools/vitruv/domains/emf/monitorededitor/tools/EditorManagementListenerMgrTests.java
+++ b/tests/extensions/emfdomain/tools.vitruv.extensions.emf.monitorededitor.tests/unit/tools/vitruv/domains/emf/monitorededitor/tools/EditorManagementListenerMgrTests.java
@@ -22,9 +22,6 @@ import tools.vitruv.domains.emf.monitorededitor.test.mocking.EclipseMock;
 import tools.vitruv.domains.emf.monitorededitor.test.mocking.EclipseWorkbenchMock;
 import tools.vitruv.domains.emf.monitorededitor.test.utils.BasicTestCase;
 import tools.vitruv.domains.emf.monitorededitor.test.utils.EnsureExecutedOnObj;
-import tools.vitruv.domains.emf.monitorededitor.tools.EclipseAdapterProvider;
-import tools.vitruv.domains.emf.monitorededitor.tools.EditorManagementListenerMgr;
-import tools.vitruv.domains.emf.monitorededitor.tools.IEditorManagementListener;
 
 public class EditorManagementListenerMgrTests extends BasicTestCase {
     private EclipseMock eclipseMock;

--- a/tests/extensions/emfdomain/tools.vitruv.extensions.emf.monitorededitor.tests/unit/tools/vitruv/domains/emf/monitorededitor/tools/ResourceReloadListenerTests.java
+++ b/tests/extensions/emfdomain/tools.vitruv.extensions.emf.monitorededitor.tests/unit/tools/vitruv/domains/emf/monitorededitor/tools/ResourceReloadListenerTests.java
@@ -20,7 +20,6 @@ import tools.vitruv.domains.emf.monitorededitor.test.testmodels.Files;
 import tools.vitruv.domains.emf.monitorededitor.test.testmodels.Models;
 import tools.vitruv.domains.emf.monitorededitor.test.utils.EnsureExecuted;
 import tools.vitruv.domains.emf.monitorededitor.test.utils.EnsureNotExecuted;
-import tools.vitruv.domains.emf.monitorededitor.tools.ResourceReloadListener;
 
 public class ResourceReloadListenerTests {
     @Test

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/EChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/EChangeTest.xtend
@@ -28,7 +28,7 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
  * Prepares two temporary model instances of the allelementtypes metamodel which 
  * can be modified by the EChange tests. The model is stored in one temporary file.
  */
- public abstract class EChangeTest {
+ abstract class EChangeTest {
 
  	protected var Root rootObject = null
  	protected var Resource resource = null

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/command/RemoveAtCommandTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/command/RemoveAtCommandTest.xtend
@@ -24,7 +24,7 @@ class RemoveAtCommandTest extends CommandTest {
 	protected var EList<Integer> list = null
 	
 	@Before
-	def public void beforeTest() {
+	def void beforeTest() {
 		owner = AllElementTypesFactory.eINSTANCE.createRoot
 		feature = AllElementTypesPackage.Literals.ROOT__MULTI_VALUED_EATTRIBUTE
 		editingDomain = EChangeUtil.getEditingDomain(owner)
@@ -38,7 +38,7 @@ class RemoveAtCommandTest extends CommandTest {
 	 * Tests both creation methods and constructors of the class.
 	 */
 	@Test
-	def public void createCommandTest() {
+	def void createCommandTest() {
 		// Test both create methods
 		var command = new RemoveAtCommand(editingDomain, list, 2, 3)
 		command.assertIsRemoveAtCommand(list, 2, 3)
@@ -52,7 +52,7 @@ class RemoveAtCommandTest extends CommandTest {
 	 * whether the command can be executed or not.
 	 */
 	@Test
-	def public void prepareTest() {
+	def void prepareTest() {
 		// Valid commands
 		createRemoveAtCommand(list, 0, 0).assertIsPreparable
 		createRemoveAtCommand(list, 4, 4).assertIsPreparable
@@ -75,7 +75,7 @@ class RemoveAtCommandTest extends CommandTest {
 	 * Tests the execution of the command.
 	 */
 	@Test
-	def public void executeTest() {
+	def void executeTest() {
 		createRemoveAtCommand(list, 8, 8).assertRemovedCorrectValueFrom(list)
 		createRemoveAtCommand(list, 0, 0).assertRemovedCorrectValueFrom(list)
 		createRemoveAtCommand(list, 1, 0).assertRemovedCorrectValueFrom(list)

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndInsertNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndInsertNonRootTest.xtend
@@ -21,12 +21,12 @@ import tools.vitruv.framework.tests.echange.EChangeTest
  * Test class for the concrete {@link CreateAndInsertNonRoot} EChange,
  * which creates a new non root EObject and inserts it in containment reference.
  */
-public class CreateAndInsertNonRootTest extends ReferenceEChangeTest {
+class CreateAndInsertNonRootTest extends ReferenceEChangeTest {
 	protected var EReference affectedFeature = null
 	protected var EList<NonRoot> referenceContent = null
 	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest
 		affectedFeature = AllElementTypesPackage.Literals.ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE
 		referenceContent = affectedEObject.eGet(affectedFeature) as EList<NonRoot>
@@ -39,7 +39,7 @@ public class CreateAndInsertNonRootTest extends ReferenceEChangeTest {
 	 * into a containment reference.
 	 */
 	@Test
-	def public void resolveBeforeTest() {
+	def void resolveBeforeTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(affectedEObject, newValue, 0)
 		unresolvedChange.assertIsNotResolved
@@ -57,7 +57,7 @@ public class CreateAndInsertNonRootTest extends ReferenceEChangeTest {
 	 * after the change, so the new non root element is in a containment reference.
 	 */
 	@Test
-	def public void resolveAfterTest() {
+	def void resolveAfterTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(affectedEObject, newValue, 0)
 		unresolvedChange.assertIsNotResolved		
@@ -78,7 +78,7 @@ public class CreateAndInsertNonRootTest extends ReferenceEChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(affectedEObject, newValue, 0)
 		
@@ -93,7 +93,7 @@ public class CreateAndInsertNonRootTest extends ReferenceEChangeTest {
 	 * containment reference.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create and resolve and apply change
 		val resolvedChange = createUnresolvedChange(affectedEObject, newValue, 0).resolveBefore(uuidGeneratorAndResolver)
 		resolvedChange.assertApplyForward
@@ -116,7 +116,7 @@ public class CreateAndInsertNonRootTest extends ReferenceEChangeTest {
 	 * deleted.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create and resolve and apply change 1
 		val resolvedChange = createUnresolvedChange(affectedEObject, newValue, 0).resolveBefore(uuidGeneratorAndResolver)
 		resolvedChange.assertApplyForward

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndInsertRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndInsertRootTest.xtend
@@ -30,7 +30,7 @@ class CreateAndInsertRootTest extends EChangeTest {
 	 * which can be inserted.
 	 */
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		newRootObject = AllElementTypesFactory.eINSTANCE.createRoot()
 		newRootObject2 = AllElementTypesFactory.eINSTANCE.createRoot()
@@ -44,7 +44,7 @@ class CreateAndInsertRootTest extends EChangeTest {
 	 * and the root object is not in the resource.
 	 */
 	@Test
-	def public void resolveBeforeTest() {
+	def void resolveBeforeTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 		unresolvedChange.assertIsNotResolved
@@ -63,7 +63,7 @@ class CreateAndInsertRootTest extends EChangeTest {
 	 * and the root object is in the resource.
 	 */
 	@Test
-	def public void resolveAfterTest() {
+	def void resolveAfterTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 		unresolvedChange.assertIsNotResolved
@@ -84,7 +84,7 @@ class CreateAndInsertRootTest extends EChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 		
@@ -98,7 +98,7 @@ class CreateAndInsertRootTest extends EChangeTest {
 	 * by creating and inserting a new root object.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create and resolve change 1
 		val resolvedChange = createUnresolvedChange(newRootObject, 1).resolveBefore(uuidGeneratorAndResolver)
 			
@@ -124,7 +124,7 @@ class CreateAndInsertRootTest extends EChangeTest {
 	 * by reverting the change. It removes and deletes a root object. 
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create and resolve and apply change 1
 		val resolvedChange = createUnresolvedChange(newRootObject, 1).resolveBefore(uuidGeneratorAndResolver)
 		resolvedChange.assertApplyForward

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndReplaceAndDeleteNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndReplaceAndDeleteNonRootTest.xtend
@@ -28,7 +28,7 @@ class CreateAndReplaceAndDeleteNonRootTest extends ReferenceEChangeTest {
 	protected var EReference affectedFeature = null
 	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		oldValue = AllElementTypesFactory.eINSTANCE.createNonRoot()
 		affectedFeature = AllElementTypesPackage.Literals.ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE
@@ -41,7 +41,7 @@ class CreateAndReplaceAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * the old value is in the containment reference.
 	 */
 	@Test
-	def public void resolveBeforeTest() {
+	def void resolveBeforeTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newValue)
 		unresolvedChange.assertIsNotResolved()
@@ -60,7 +60,7 @@ class CreateAndReplaceAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * the new value is in the containment reference.
 	 */
 	@Test
-	def public void resolveAfterTest() {
+	def void resolveAfterTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newValue)
 		unresolvedChange.assertIsNotResolved
@@ -81,7 +81,7 @@ class CreateAndReplaceAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newValue)
 		
@@ -95,7 +95,7 @@ class CreateAndReplaceAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * by creating a new non root and replacing an existing one.
 	 */
 	@Test
-	def public void applyForwardTest() {		
+	def void applyForwardTest() {		
 		// Create and resolve 1
 		val resolvedChange = createUnresolvedChange(newValue).resolveBefore(uuidGeneratorAndResolver)
 			
@@ -120,7 +120,7 @@ class CreateAndReplaceAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * by replacing a single value containment reference with its old value.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create change 
 		val resolvedChange = createUnresolvedChange(newValue).resolveBefore(uuidGeneratorAndResolver)
 			

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndReplaceNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/CreateAndReplaceNonRootTest.xtend
@@ -27,7 +27,7 @@ class CreateAndReplaceNonRootTest extends EChangeTest {
 	protected var NonRoot newNonRootObject = null
 	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest
 		affectedEObject = rootObject
 		affectedFeature = AllElementTypesPackage.Literals.ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE
@@ -41,7 +41,7 @@ class CreateAndReplaceNonRootTest extends EChangeTest {
 	 * into a single valued containment reference.
 	 */
 	@Test
-	def public void resolveBeforeTest() {
+	def void resolveBeforeTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newNonRootObject)
 		unresolvedChange.assertIsNotResolved
@@ -60,7 +60,7 @@ class CreateAndReplaceNonRootTest extends EChangeTest {
 	 * in the single valued containment reference.
 	 */
 	@Test
-	def public void resolveAfterTest() {
+	def void resolveAfterTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newNonRootObject)
 		unresolvedChange.assertIsNotResolved
@@ -81,7 +81,7 @@ class CreateAndReplaceNonRootTest extends EChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newNonRootObject)
 		
@@ -96,7 +96,7 @@ class CreateAndReplaceNonRootTest extends EChangeTest {
 	 * reference.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create and resolve and apply
 		val resolvedChange = createUnresolvedChange(newNonRootObject).resolveBefore(uuidGeneratorAndResolver)
 		resolvedChange.assertApplyForward
@@ -111,7 +111,7 @@ class CreateAndReplaceNonRootTest extends EChangeTest {
 	 * reference.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create and resolve
 		val resolvedChange = createUnresolvedChange(newNonRootObject).resolveBefore(uuidGeneratorAndResolver)
 			

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ExplicitUnsetEAttributeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ExplicitUnsetEAttributeTest.xtend
@@ -30,7 +30,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	
 	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		affectedEObject = rootObject	
 	}
@@ -40,7 +40,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	 * valued attribute and the model is in state before the change.
 	 */
 	@Test
-	def public void resolveBeforeSingleValuedAttributeTest() {
+	def void resolveBeforeSingleValuedAttributeTest() {
 		// Set state before
 		isSingleValuedAttributeTest
 		
@@ -53,7 +53,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	 * valued attribute and the model is in state after the change.
 	 */
 	@Test
-	def public void resolveAfterSingleValuedAttributeTest() {
+	def void resolveAfterSingleValuedAttributeTest() {
 		// Set state before
 		isSingleValuedAttributeTest	
 		
@@ -66,7 +66,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	 * valued attribute and the model is in state before the change.
 	 */
 	@Test
-	def public void resolveBeforeUnsetMultiValuedAttributeTest() {
+	def void resolveBeforeUnsetMultiValuedAttributeTest() {
 		// Set state before
 		isMultiValuedAttributeTest
 		
@@ -79,7 +79,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	 * valued attribute and the model is in state after the change.
 	 */
 	@Test
-	def public void resolveAfterUnsetMultiValuedAttributeTest() {
+	def void resolveAfterUnsetMultiValuedAttributeTest() {
 		// Set state before
 		isMultiValuedAttributeTest	
 		
@@ -92,7 +92,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Set state before
 		isSingleValuedAttributeTest
 		
@@ -109,7 +109,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	 * Unsets a single valued unsettable attribute.
 	 */
 	@Test
-	def public void applyForwardUnsetSingleValuedAttributeTest() {
+	def void applyForwardUnsetSingleValuedAttributeTest() {
 		// Set state before
 		isSingleValuedAttributeTest
 
@@ -122,7 +122,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	 * Unsets a multi valued unsettable attribute.
 	 */
 	@Test
-	def public void applyForwardUnsetMulitValuedAttributeTest() {
+	def void applyForwardUnsetMulitValuedAttributeTest() {
 		// Set state before
 		isMultiValuedAttributeTest
 
@@ -135,7 +135,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	 * Unsets a single valued unsettable attribute.
 	 */
 	@Test
-	def public void applyBackwardUnsetSingleValuedAttributeTest() {
+	def void applyBackwardUnsetSingleValuedAttributeTest() {
 		// Set state before
 		isSingleValuedAttributeTest
 		
@@ -148,7 +148,7 @@ class ExplicitUnsetEAttributeTest extends EChangeTest {
 	 * Unsets a multi valued unsettable attribute.
 	 */
 	@Test
-	def public void applyBackwardUnsetMulitValuedAttributeTest() {
+	def void applyBackwardUnsetMulitValuedAttributeTest() {
 		// Set state before
 		isMultiValuedAttributeTest
 		

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ExplicitUnsetEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ExplicitUnsetEReferenceTest.xtend
@@ -36,7 +36,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	protected var NonRoot oldValue3 = null	
 		
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		affectedEObject = rootObject
 		oldValue = AllElementTypesFactory.eINSTANCE.createNonRoot
@@ -49,7 +49,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * valued non containment reference and the model is in state before the change.
 	 */	
 	@Test
-	def public void resolveBeforeSingleValuedNonContainmentReferenceTest() {
+	def void resolveBeforeSingleValuedNonContainmentReferenceTest() {
 		// Set state before
 		isSingleValuedNonContainmentTest
 		
@@ -62,7 +62,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * valued containment reference and the model is in state before the change.
 	 */		
 	@Test
-	def public void resolveBeforeSingleValuedContainmentReferenceTest() {
+	def void resolveBeforeSingleValuedContainmentReferenceTest() {
 		// Set state before
 		isSingleValuedContainmentTest
 		
@@ -75,7 +75,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * valued non containment reference and the model is in state before the change.
 	 */		
 	@Test
-	def public void resolveBeforeMultiValuedNonContainmentReferenceTest() {
+	def void resolveBeforeMultiValuedNonContainmentReferenceTest() {
 		// Set state before
 		isMultiValuedNonContainmentTest
 		
@@ -88,7 +88,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * valued containment reference and the model is in state before the change.
 	 */		
 	@Test
-	def public void resolveBeforeMultiValuedContainmentReferenceTest() {
+	def void resolveBeforeMultiValuedContainmentReferenceTest() {
 		// Set state before
 		isMultiValuedContainmentTest
 		
@@ -101,7 +101,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * valued non containment reference and the model is in state after the change.
 	 */	
 	@Test
-	def public void resolveAfterSingleValuedNonContainmentReferenceTest() {
+	def void resolveAfterSingleValuedNonContainmentReferenceTest() {
 		// Set state before
 		isSingleValuedNonContainmentTest
 		
@@ -114,7 +114,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * valued containment reference and the model is in state after the change.
 	 */	
 	@Test
-	def public void resolveAfterSingleValuedContainmentReferenceTest() {
+	def void resolveAfterSingleValuedContainmentReferenceTest() {
 		// Set state before
 		isSingleValuedContainmentTest
 		
@@ -127,7 +127,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * valued non containment reference and the model is in state after the change.
 	 */	
 	@Test
-	def public void resolveAfterMultiValuedNonContainmentReferenceTest() {
+	def void resolveAfterMultiValuedNonContainmentReferenceTest() {
 		// Set state before
 		isMultiValuedNonContainmentTest
 		
@@ -140,7 +140,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * valued containment reference and the model is in state after the change.
 	 */	
 	@Test
-	def public void resolveAfterMultiValuedContainmentReferenceTest() {
+	def void resolveAfterMultiValuedContainmentReferenceTest() {
 		// Set state before
 		isMultiValuedContainmentTest
 		
@@ -152,7 +152,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * Tests whether the {@link ExplicitUnsetEReference} EChange resolves to the correct type.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Set state before
 		isSingleValuedNonContainmentTest
 		
@@ -169,7 +169,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * Unsets a single valued non containment reference.
 	 */	
 	@Test
-	def public void applyForwardSingleValuedNonContainmentReferenceTest() {
+	def void applyForwardSingleValuedNonContainmentReferenceTest() {
 		// Set state before
 		isSingleValuedNonContainmentTest
 				
@@ -182,7 +182,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * Unsets a single valued non containment reference.
 	 */	
 	@Test
-	def public void applyForwardSingleValuedContainmentReferenceTest() {
+	def void applyForwardSingleValuedContainmentReferenceTest() {
 		// Set state before
 		isSingleValuedContainmentTest
 		
@@ -195,7 +195,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * Unsets a multi valued non containment reference.
 	 */	
 	@Test
-	def public void applyForwardMultiValuedNonContainmentReferenceTest() {
+	def void applyForwardMultiValuedNonContainmentReferenceTest() {
 		// Set state before
 		isMultiValuedContainmentTest
 
@@ -208,7 +208,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * Unsets a multi valued containment reference.
 	 */	
 	@Test
-	def public void applyForwardMultiValuedNContainmentReferenceTest() {
+	def void applyForwardMultiValuedNContainmentReferenceTest() {
 		// Set state before
 		isMultiValuedContainmentTest	
 		
@@ -221,7 +221,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * Unsets a single valued non containment reference.
 	 */	
 	@Test
-	def public void applyBackwardSingleValuedNonContainmentReferenceTest() {
+	def void applyBackwardSingleValuedNonContainmentReferenceTest() {
 		// Set state before
 		isSingleValuedNonContainmentTest
 				
@@ -234,7 +234,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * Unsets a single valued non containment reference.
 	 */	
 	@Test
-	def public void applyBackwardSingleValuedContainmentReferenceTest() {
+	def void applyBackwardSingleValuedContainmentReferenceTest() {
 		// Set state before
 		isSingleValuedContainmentTest
 		
@@ -247,7 +247,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * Unsets a multi valued non containment reference.
 	 */	
 	@Test
-	def public void applyBackwardMultiValuedNonContainmentReferenceTest() {
+	def void applyBackwardMultiValuedNonContainmentReferenceTest() {
 		// Set state before
 		isMultiValuedNonContainmentTest
 
@@ -260,7 +260,7 @@ class ExplicitUnsetEReferenceTest extends EChangeTest {
 	 * Unsets a multi valued containment reference.
 	 */	
 	@Test
-	def public void applyBackwardMultiValuedNContainmentReferenceTest() {
+	def void applyBackwardMultiValuedNContainmentReferenceTest() {
 		// Set state before
 		isMultiValuedContainmentTest	
 		

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/RemoveAndDeleteNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/RemoveAndDeleteNonRootTest.xtend
@@ -22,12 +22,12 @@ import tools.vitruv.framework.change.echange.eobject.DeleteEObject
  * which removes a non root element reference from a containment reference 
  * list and deletes it.
  */
-public class RemoveAndDeleteNonRootTest extends ReferenceEChangeTest {
+class RemoveAndDeleteNonRootTest extends ReferenceEChangeTest {
 	protected var EReference affectedFeature = null
 	protected var EList<NonRoot> referenceContent = null
 
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		affectedFeature = AllElementTypesPackage.Literals.ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE
 		referenceContent = affectedEObject.eGet(affectedFeature) as EList<NonRoot>
@@ -39,7 +39,7 @@ public class RemoveAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * before the change, so the non root element is in a containment reference.
 	 */
 	@Test
-	def public void resolveBeforeTest() {
+	def void resolveBeforeTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(affectedEObject, newValue, 0)
 		unresolvedChange.assertIsNotResolved
@@ -57,7 +57,7 @@ public class RemoveAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * after the change, so the non root element was deleted.
 	 */
 	@Test
-	def public void resolveAfterTest() {		
+	def void resolveAfterTest() {		
 		// Create change
 		val unresolvedChange = createUnresolvedChange(affectedEObject, newValue, 0)
 		unresolvedChange.assertIsNotResolved
@@ -78,7 +78,7 @@ public class RemoveAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(affectedEObject, newValue, 0)
 		
@@ -92,7 +92,7 @@ public class RemoveAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * Removes and deletes a non root element from a containment reference.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create and resolve change 1
 		val resolvedChange = createUnresolvedChange(affectedEObject, newValue, 0).resolveBefore(uuidGeneratorAndResolver)
 		
@@ -118,7 +118,7 @@ public class RemoveAndDeleteNonRootTest extends ReferenceEChangeTest {
 	 * Creates and reinserts the removed object.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create and resolve and apply change 1
 		val resolvedChange = createUnresolvedChange(affectedEObject, newValue, 0).resolveBefore(uuidGeneratorAndResolver)
 		resolvedChange.assertApplyForward

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/RemoveAndDeleteRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/RemoveAndDeleteRootTest.xtend
@@ -25,7 +25,7 @@ class RemoveAndDeleteRootTest extends EChangeTest {
 	protected var EList<EObject> resourceContent = null
 	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		newRootObject = AllElementTypesFactory.eINSTANCE.createRoot()
 		newRootObject2 = AllElementTypesFactory.eINSTANCE.createRoot()
@@ -40,7 +40,7 @@ class RemoveAndDeleteRootTest extends EChangeTest {
 	 * object is in the resource.
 	 */
 	@Test
-	def public void resolveBeforeTest() {		
+	def void resolveBeforeTest() {		
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 		unresolvedChange.assertIsNotResolved
@@ -59,7 +59,7 @@ class RemoveAndDeleteRootTest extends EChangeTest {
 	 * are empty, and the root element was deleted.
 	 */
 	@Test
-	def public void resolveAftertTest() {
+	def void resolveAftertTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 		unresolvedChange.assertIsNotResolved		
@@ -79,7 +79,7 @@ class RemoveAndDeleteRootTest extends EChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 0)
 		
@@ -93,7 +93,7 @@ class RemoveAndDeleteRootTest extends EChangeTest {
 	 * and deleting a root object.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create and resolve change 1
 		val resolvedChange = createUnresolvedChange(newRootObject, 1).resolveBefore(uuidGeneratorAndResolver)
 			
@@ -119,7 +119,7 @@ class RemoveAndDeleteRootTest extends EChangeTest {
 	 * It creates and inserts a root object.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create and resolve and apply change 1
 		val resolvedChange = createUnresolvedChange(newRootObject, 0).resolveBefore(uuidGeneratorAndResolver)
 		resolvedChange.assertApplyForward

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ReplaceAndDeleteNonRootTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/compound/ReplaceAndDeleteNonRootTest.xtend
@@ -27,7 +27,7 @@ class ReplaceAndDeleteNonRootTest extends EChangeTest {
 	protected var NonRoot oldNonRootObject = null
 	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest
 		affectedEObject = rootObject
 		affectedFeature = AllElementTypesPackage.Literals.ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE
@@ -41,7 +41,7 @@ class ReplaceAndDeleteNonRootTest extends EChangeTest {
 	 * containment reference.
 	 */
 	@Test
-	def public void resolveBeforeTest() {
+	def void resolveBeforeTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(oldNonRootObject)
 		unresolvedChange.assertIsNotResolved
@@ -63,7 +63,7 @@ class ReplaceAndDeleteNonRootTest extends EChangeTest {
 	 * containment reference is null.
 	 */
 	@Test
-	def public void resolveAfterTest() {
+	def void resolveAfterTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(oldNonRootObject)
 		unresolvedChange.assertIsNotResolved	
@@ -84,7 +84,7 @@ class ReplaceAndDeleteNonRootTest extends EChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(oldNonRootObject)
 		
@@ -98,7 +98,7 @@ class ReplaceAndDeleteNonRootTest extends EChangeTest {
 	 * Removes a non root object from a single valued containment reference and deletes it.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create and resolve and apply
 		val resolvedChange = createUnresolvedChange(oldNonRootObject).resolveBefore(uuidGeneratorAndResolver)
 		resolvedChange.assertApplyForward
@@ -113,7 +113,7 @@ class ReplaceAndDeleteNonRootTest extends EChangeTest {
 	 * reference.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create and resolve
 		val resolvedChange = createUnresolvedChange(oldNonRootObject).resolveBefore(uuidGeneratorAndResolver)
 			

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/CreateEObjectTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/CreateEObjectTest.xtend
@@ -14,7 +14,7 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
  */
 class CreateEObjectTest extends EObjectTest {
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest
 		prepareStateBefore
 	}
@@ -24,7 +24,7 @@ class CreateEObjectTest extends EObjectTest {
 	 * the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(createdObject)
 			
@@ -38,7 +38,7 @@ class CreateEObjectTest extends EObjectTest {
 	 * new EObject and putting it in the staging area.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create change and resolve
 		val resolvedChange = createUnresolvedChange(createdObject).resolveBefore(uuidGeneratorAndResolver)
 			as CreateEObject<Root>
@@ -68,7 +68,7 @@ class CreateEObjectTest extends EObjectTest {
 	 * by removing a newly created object from the staging area.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Set state after
 		prepareStateAfter(createdObject)
 

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/DeleteEObjectTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/DeleteEObjectTest.xtend
@@ -14,7 +14,7 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
  */
 class DeleteEObjectTest extends EObjectTest {	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		prepareStateBefore(createdObject)
 	}
@@ -24,7 +24,7 @@ class DeleteEObjectTest extends EObjectTest {
 	 * the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(createdObject)
 			
@@ -38,7 +38,7 @@ class DeleteEObjectTest extends EObjectTest {
 	 * created EObject from the staging area.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create change and resolve
 		val resolvedChange = createUnresolvedChange(createdObject).resolveBefore(uuidGeneratorAndResolver)
 			as DeleteEObject<Root>
@@ -68,7 +68,7 @@ class DeleteEObjectTest extends EObjectTest {
 	 * Adds a deleted object to the staging area again.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Set state after
 		prepareStateAfter
 		

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/EObjectExistenceEChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/EObjectExistenceEChangeTest.xtend
@@ -19,7 +19,7 @@ class EObjectExistenceEChangeTest extends EObjectTest {
 	 * a new object which was not created yet. So the staging area will be filled.
 	 */
 	@Test
-	def public void resovlveBeforeTest() {	
+	def void resovlveBeforeTest() {	
 		// State before
 		assertIsStateBefore
 		
@@ -40,7 +40,7 @@ class EObjectExistenceEChangeTest extends EObjectTest {
 	 * new object which was already created and was put in the staging area.
 	 */
 	@Test
-	def public void resolveAfterTest() {
+	def void resolveAfterTest() {
 		// State before
 		assertIsStateBefore
 		
@@ -65,7 +65,7 @@ class EObjectExistenceEChangeTest extends EObjectTest {
 	 * affected EObject.
 	 */
 	@Test(expected=IllegalArgumentException)
-	def public void resolveInvalidAffectedEObjectTest() {
+	def void resolveInvalidAffectedEObjectTest() {
 		createdObject = null
 		
 		// Create change

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/EObjectTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/eobject/EObjectTest.xtend
@@ -8,7 +8,7 @@ import tools.vitruv.framework.tests.echange.EChangeTest
 /**
  * Abstract class which is used by the EObject EChange test classes.
  */
-public abstract class EObjectTest extends EChangeTest {
+abstract class EObjectTest extends EChangeTest {
 	protected var Root createdObject = null;
 	protected var Root createdObject2 = null;
 		

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/FeatureEChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/FeatureEChangeTest.xtend
@@ -26,7 +26,7 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
  * Test class for {@link FeatureEChange} which is used by every {@link EChange} which modifies {@link EStructuralFeature}s 
  * (single- or multi-valued attributes or references) of a {@link EObject}.
  */
- public class FeatureEChangeTest extends EChangeTest {
+ class FeatureEChangeTest extends EChangeTest {
  	protected var Root affectedEObject = null
  	protected var EAttribute affectedFeature = null
  	
@@ -37,7 +37,7 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
  	protected var UuidResolver uuidResolver2;
  	
  	@Before
- 	override public void beforeTest() {
+ 	override void beforeTest() {
  		super.beforeTest()
  		affectedEObject = rootObject
  		affectedFeature = AllElementTypesPackage.Literals.IDENTIFIED__ID
@@ -51,7 +51,7 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
  	}
  	
  	@After
- 	override public void afterTest() {
+ 	override void afterTest() {
  		super.afterTest()
  	}
 	 
@@ -61,7 +61,7 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
  	 * after unresolving the object. 
  	 */
  	@Test
- 	def public void resolveBeforeTest() {
+ 	def void resolveBeforeTest() {
 		// Create change 		
  		val unresolvedChange = createUnresolvedChange()
  		unresolvedChange.assertIsNotResolved(affectedEObject, affectedFeature)
@@ -76,7 +76,7 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 	 * Tests a failed resolve.
 	 */
 	@Test
-	def public void resolveEFeatureChangeFails() {
+	def void resolveEFeatureChangeFails() {
 		// Change first resource by insert second root element
 		affectedEObject = prepareSecondRoot
 		
@@ -97,7 +97,7 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 	 * Tests whether resolving an already resolved EFeatureChange throws an exception.
 	 */
 	@Test(expected=IllegalArgumentException)
-	def public void resolveResolvedEFeatureChange() {
+	def void resolveResolvedEFeatureChange() {
 		// Create change and resolve	
  		val resolvedChange = createUnresolvedChange().resolveBefore(uuidGeneratorAndResolver)
  			as FeatureEChange<Root, EAttribute>
@@ -112,7 +112,7 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
  	 * Test whether resolving the EFeatureChange fails by giving a null EObject
  	 */
  	@Test(expected=IllegalStateException)
- 	def public void resolveEFeatureAffectedObjectNull() {
+ 	def void resolveEFeatureAffectedObjectNull() {
  		affectedEObject = null
  		
 		// Create change	
@@ -130,7 +130,7 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
  	 * Tests whether resolving the EFeatureChange fails by giving a null EFeature
  	 */
  	 @Test
- 	 def public void resolveEFeatureAffectedFeatureNull() {
+ 	 def void resolveEFeatureAffectedFeatureNull() {
  	 	affectedFeature = null
  	 	
 		// Create change	
@@ -147,7 +147,7 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
  	  * Tests whether resolving the EFeatureChange fails by giving a null uuidGeneratorAndResolver
  	  */
  	  @Test
- 	  def public void resolveEFeatureuuidGeneratorAndResolverNull() {
+ 	  def void resolveEFeatureuuidGeneratorAndResolverNull() {
 		// Create change	
  		val unresolvedChange = createUnresolvedChange()	
  		unresolvedChange.assertIsNotResolved(affectedEObject, affectedFeature)	

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/attribute/InsertEAttributeValueTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/attribute/InsertEAttributeValueTest.xtend
@@ -15,9 +15,9 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
  * Test class for the concrete {@link InsertEAttributeValue} EChange,
  * which inserts a value in a multi valued attribute.
  */
-public class InsertEAttributeValueTest extends InsertRemoveEAttributeTest {
+class InsertEAttributeValueTest extends InsertRemoveEAttributeTest {
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest
 		assertIsStateBefore
 	}
@@ -25,7 +25,7 @@ public class InsertEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * Tests whether resolving the {@link InsertEAttributeValue} EChange returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(NEW_VALUE, 0)
 				
@@ -39,7 +39,7 @@ public class InsertEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * inserting new values in a multivalued attribute.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create change and resolve
 		val resolvedChange = createUnresolvedChange(NEW_VALUE, 0).resolveBefore(uuidGeneratorAndResolver)
 			as InsertEAttributeValue<Root, Integer>
@@ -65,7 +65,7 @@ public class InsertEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * Applies two {@link InsertEAttributeValue} EChanges backward.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create change and resolve and apply forward
 		val resolvedChange = createUnresolvedChange(NEW_VALUE, 0).resolveBefore(uuidGeneratorAndResolver)
 			as InsertEAttributeValue<Root, Integer>
@@ -96,7 +96,7 @@ public class InsertEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * Tests the {@link InsertEAttributeValue} EChange with invalid index.
 	 */
 	@Test(expected=RuntimeException)
-	def public void invalidIndexTest() {
+	def void invalidIndexTest() {
 	 	var index = 5 // Valid index in empty list is only 0
 	 	Assert.assertTrue(attributeContent.empty) 
 	 	
@@ -114,7 +114,7 @@ public class InsertEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * Tests an {@link InsertEAttributeValue} with an affected object which has no such attribute.
 	 */
 	@Test
-	def public void invalidAttributeTest() {
+	def void invalidAttributeTest() {
 	 	// NonRoot has no multivalued int attribute
 	 	val affectedNonRootEObject = AllElementTypesFactory.eINSTANCE.createNonRoot()
 	 	resource.contents.add(affectedNonRootEObject)
@@ -135,7 +135,7 @@ public class InsertEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * Tests an {@link InsertEAttributeValue} EChange with the wrong value type.
 	 */
 	@Test
-	def public void invalidValueTest() {
+	def void invalidValueTest() {
 	 	val newInvalidValue = "New String Value" // values are String, attribute value type is Integer
 	 	
 	 	// Resolving the change will be tested in EFeatureChange

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/attribute/InsertRemoveEAttributeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/attribute/InsertRemoveEAttributeTest.xtend
@@ -10,7 +10,7 @@ import org.eclipse.emf.common.util.EList
 /**
  * Abstract class which is used by insert and remove attribute test classes.
  */
-public abstract class InsertRemoveEAttributeTest extends EChangeTest {
+abstract class InsertRemoveEAttributeTest extends EChangeTest {
 	protected var Root affectedEObject = null
 	protected var EAttribute affectedFeature = null
 	protected var EList<Integer> attributeContent = null
@@ -20,7 +20,7 @@ public abstract class InsertRemoveEAttributeTest extends EChangeTest {
 	protected static val Integer NEW_VALUE_3 = 333
 	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		affectedEObject = rootObject
 		affectedFeature = AllElementTypesPackage.Literals.ROOT__MULTI_VALUED_EATTRIBUTE

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/attribute/RemoveEAttributeValueTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/attribute/RemoveEAttributeValueTest.xtend
@@ -15,9 +15,9 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
  * Test class for the concrete {@link RemoveEAttributeValue} EChange,
  * which removes a value in a multivalued attribute.
  */
-public class RemoveEAttributeValueTest extends InsertRemoveEAttributeTest {	
+class RemoveEAttributeValueTest extends InsertRemoveEAttributeTest {	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest
 		prepareStateBefore
 	}
@@ -27,7 +27,7 @@ public class RemoveEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * returns the same class. 
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(NEW_VALUE, 0)
 		
@@ -41,7 +41,7 @@ public class RemoveEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * by removing two values from an multivalued attribute.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create change and resolve
 		val resolvedChange = createUnresolvedChange(NEW_VALUE, 0).resolveBefore(uuidGeneratorAndResolver)
 			as RemoveEAttributeValue<Root, String>
@@ -68,7 +68,7 @@ public class RemoveEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * by inserting two removed values from an multivalued attribute.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create change and resolve and apply
 		val resolvedChange = createUnresolvedChange(NEW_VALUE, 0).resolveBefore(uuidGeneratorAndResolver)
 			as RemoveEAttributeValue<Root, String>
@@ -99,7 +99,7 @@ public class RemoveEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * Tests a {@link RemoveEAttributeValue} EChange with invalid index.
 	 */
 	@Test
-	def public void invalidIndexTest() {
+	def void invalidIndexTest() {
 		var index = 5 // > 2
 		
 		// Create change and resolve
@@ -116,7 +116,7 @@ public class RemoveEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * Tests an affected object which has no such attribute.
 	 */
 	@Test
-	def public void invalidAttributeTest() {
+	def void invalidAttributeTest() {
 		val affectedNonRootEObject = AllElementTypesFactory.eINSTANCE.createNonRoot()
 	 	resource.contents.add(affectedNonRootEObject)
 		
@@ -138,7 +138,7 @@ public class RemoveEAttributeValueTest extends InsertRemoveEAttributeTest {
 	 * Tests a {@link RemoveEAttributeValue} EChange with the wrong value type.
 	 */
 	@Test
-	def public void invalidValueTest() {
+	def void invalidValueTest() {
 		val newInvalidValue = "New String Value" // values are Strings, attribute value type is Integer
 		
 		// Create change and resolve

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/attribute/ReplaceSingleValuedEAttributeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/attribute/ReplaceSingleValuedEAttributeTest.xtend
@@ -18,7 +18,7 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
  * Test class for the concrete {@link ReplaceSingleValuedEAttribute} EChange, 
  * which replaces the value of an attribute with a new one.
  */
-public class ReplaceSingleValuedEAttributeTest extends EChangeTest {
+class ReplaceSingleValuedEAttributeTest extends EChangeTest {
 	protected var Root affectedEObject = null
  	protected var EAttribute affectedFeature = null
  	protected var String oldValue = null
@@ -28,7 +28,7 @@ public class ReplaceSingleValuedEAttributeTest extends EChangeTest {
   	protected static val DEFAULT_SINGLE_VALUED_EATTRIBUTE_VALUE = 123
   	
  	@Before
- 	override public void beforeTest() {
+ 	override void beforeTest() {
  		super.beforeTest()
  		affectedEObject = rootObject
  		affectedFeature = AllElementTypesPackage.Literals.IDENTIFIED__ID
@@ -42,7 +42,7 @@ public class ReplaceSingleValuedEAttributeTest extends EChangeTest {
 	 * the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange()
 		
@@ -56,7 +56,7 @@ public class ReplaceSingleValuedEAttributeTest extends EChangeTest {
 	 * by replacing a single value in a root element with a new value.
 	 */
 	 @Test
-	 def public void applyForwardTest() {
+	 def void applyForwardTest() {
 		// Create change
 		val resolvedChange = createUnresolvedChange().resolveBefore(uuidGeneratorAndResolver)
 			as ReplaceSingleValuedEAttribute<Root, String>
@@ -73,7 +73,7 @@ public class ReplaceSingleValuedEAttributeTest extends EChangeTest {
 	  * by replacing a single value in a root element with the old value.
 	  */
 	 @Test
-	 def public void applyBackwardTest() {
+	 def void applyBackwardTest() {
 		// Create change
 		val resolvedChange = createUnresolvedChange().resolveBefore(uuidGeneratorAndResolver)
 			as ReplaceSingleValuedEAttribute<Root, String>
@@ -92,7 +92,7 @@ public class ReplaceSingleValuedEAttributeTest extends EChangeTest {
 	  * Tests an affected object which has no such attribute.
 	  */
 	 @Test
-	 def public void invalidAttributeTest() {
+	 def void invalidAttributeTest() {
 	 	// NonRoot element has no int attribute.
 	 	val affectedNonRootEObject = AllElementTypesFactory.eINSTANCE.createNonRoot()
 	 	resource.contents.add(affectedNonRootEObject)
@@ -116,7 +116,7 @@ public class ReplaceSingleValuedEAttributeTest extends EChangeTest {
 	  * Tests a {@link ReplaceSingleValuedEAttribue} EChange with the wrong value type.
 	  */
 	 @Test
-	 def public void invalidValueTest() {
+	 def void invalidValueTest() {
 	 	val oldIntValue = DEFAULT_SINGLE_VALUED_EATTRIBUTE_VALUE // values are Integer, attribute value type is String
 	 	val newIntValue = 500
 	 	

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/InsertEReferenceTest.xtend
@@ -17,12 +17,12 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
  * Test class for the concrete {@link InsertEReferenceValue} EChange,
  * which inserts a reference in a multivalued attribute.
  */
-public class InsertEReferenceTest extends ReferenceEChangeTest {
+class InsertEReferenceTest extends ReferenceEChangeTest {
 	protected var EReference affectedFeature = null
 	protected var EList<NonRoot> referenceContent = null
 	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		resourceContent = resource.contents
 	}
@@ -34,7 +34,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * is in the resource already.
 	 */
 	@Test
-	def public void resolveBeforeNonContainmentTest() {
+	def void resolveBeforeNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -55,7 +55,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * is in the staging area.
 	 */
 	@Test
-	def public void resolveBeforeContainmentTest() {
+	def void resolveBeforeContainmentTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -75,7 +75,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * reference is already a root element.
 	 */
 	@Test
-	def public void resolveAfterNonContainmentTest() {
+	def void resolveAfterNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -98,7 +98,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * reference is in the resource after the change.
 	 */
 	@Test
-	def public void resolveAfterContainmentTest() {
+	def void resolveAfterContainmentTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -119,7 +119,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -138,7 +138,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	  * new value is already in the resource.
 	  */
 	@Test
-	def public void applyForwardNonContainmentTest() {
+	def void applyForwardNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -167,7 +167,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * new value is from the staging area.
 	 */
 	@Test
-	def public void applyForwardContainmentTest() {
+	def void applyForwardContainmentTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -197,7 +197,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * removed values are already in the resource.
 	 */
 	@Test
-	def public void applyBackwardNonContainmentTest() {
+	def void applyBackwardNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -232,7 +232,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * removed values will be placed in the staging area after removing them.
 	 */
 	@Test
-	def public void applyBackwardContainmentTest() {
+	def void applyBackwardContainmentTest() {
 		// Set state before
 		isContainmentTest
 
@@ -264,7 +264,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * Tests the {@link InsertEReference} EChange with invalid index.
 	 */
 	@Test
-	def public void invalidIndexTest() {
+	def void invalidIndexTest() {
 		// Set state before
 		isNonContainmentTest
 		var index = 5 // Valid index in empty list is only 0
@@ -284,7 +284,7 @@ public class InsertEReferenceTest extends ReferenceEChangeTest {
 	 * Tests an affected object which has no such reference.
 	 */
 	@Test
-	def public void invalidAttributeTest() {
+	def void invalidAttributeTest() {
 		// Set state before
 		isNonContainmentTest
 		val invalidAffectedEObject = newValue2 // NonRoot element

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/ReferenceEChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/ReferenceEChangeTest.xtend
@@ -11,7 +11,7 @@ import tools.vitruv.framework.tests.echange.EChangeTest
 /**
  * Abstract class which is used by all test classes for references.
  */
-public abstract class ReferenceEChangeTest extends EChangeTest {
+abstract class ReferenceEChangeTest extends EChangeTest {
 	protected var Root affectedEObject = null
 	protected var NonRoot newValue = null
 	protected var NonRoot newValue2 = null
@@ -21,7 +21,7 @@ public abstract class ReferenceEChangeTest extends EChangeTest {
 	 * Sets the default object and new value for tests.
 	 */
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		affectedEObject = rootObject
 		newValue = AllElementTypesFactory.eINSTANCE.createNonRoot()

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/RemoveEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/RemoveEReferenceTest.xtend
@@ -18,12 +18,12 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
  * Test class for the concrete {@link RemoveEReference} EChange, 
  * which removes a reference from a multivalued attribute.
  */
-public class RemoveEReferenceTest extends ReferenceEChangeTest {
+class RemoveEReferenceTest extends ReferenceEChangeTest {
 	protected var EReference affectedFeature = null
 	protected var EList<NonRoot> referenceContent = null
 	
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		resourceContent = resource.contents
 	}
@@ -35,7 +35,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * so the object needs to be in the resource.
 	 */
 	@Test
-	def public void resolveBeforeNonContainmentTest() {
+	def void resolveBeforeNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 			
@@ -56,7 +56,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * so the object is not in the resource.
 	 */
 	@Test
-	def public void resolveBeforeContainmentTest() {
+	def void resolveBeforeContainmentTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -77,7 +77,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * so the object is a root object in the resource.
 	 */
 	@Test
-	def public void resolveAfterNonContainmentTest() {
+	def void resolveAfterNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -101,7 +101,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * so the object is in the staging area.
 	 */
 	@Test
-	def public void resolveAfterContainmentTestTest() {
+	def void resolveAfterContainmentTestTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -120,7 +120,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -139,7 +139,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * to be a root object in the resource.
 	 */
 	@Test
-	def public void applyForwardNonContainmentTest() {
+	def void applyForwardNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -169,7 +169,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * will be in the staging area after removing them.
 	 */
 	@Test
-	def public void applyForwardContainmentTest() {
+	def void applyForwardContainmentTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -197,7 +197,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * a non containment reference so the values has to be in the resource.
 	 */
 	@Test
-	def public void applyBackwardNonContainmentTest() {
+	def void applyBackwardNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 
@@ -230,7 +230,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * before they are reinserted.
 	 */
 	@Test
-	def public void applyBackwardContainmentTest() {
+	def void applyBackwardContainmentTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -262,7 +262,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * Tests a {@link RemoveEReference} EChange with invalid index.
 	 */
 	@Test
-	def public void invalidIndexTest() {
+	def void invalidIndexTest() {
 		// Set state before
 		isNonContainmentTest
 		var index = 5 // Valid index is 0 or 1
@@ -284,7 +284,7 @@ public class RemoveEReferenceTest extends ReferenceEChangeTest {
 	 * such reference.
 	 */
 	@Test
-	def public void invalidAttributeTest() {
+	def void invalidAttributeTest() {
 		// Set state before
 		isNonContainmentTest
 		val invalidAffectedEObject = newValue2 // NonRoot element

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/ReplaceSingleValuedEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/ReplaceSingleValuedEReferenceTest.xtend
@@ -18,12 +18,12 @@ import static extension tools.vitruv.framework.change.echange.resolve.EChangeRes
  * Test class for the concrete {@link ReplaceSingleValuedEReference} EChange,
  * which replaces the value of a reference with a new one.
  */
-public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {	
+class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {	
 	protected var NonRoot oldValue = null	
 	protected var EReference affectedFeature = null
 
 	@Before
-	override public void beforeTest() {
+	override void beforeTest() {
 		super.beforeTest()
 		oldValue = AllElementTypesFactory.eINSTANCE.createNonRoot()	
 	}
@@ -35,7 +35,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * the resource.
 	 */
 	@Test
-	def public void resolveBeforeSingleValuedNonContainmentTest() {
+	def void resolveBeforeSingleValuedNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -54,7 +54,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * The reference is a containment reference, so the new object is in the staging area
 	 */
 	@Test
-	def public void resolveBeforeSingleValuedContainmentTest2() {
+	def void resolveBeforeSingleValuedContainmentTest2() {
 		// Set state before
 		isContainmentTest
 		
@@ -73,7 +73,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * The reference is a non containment reference, so the old value is in the resource.
 	 */
 	@Test
-	def public void resolveAfterSingleValuedNonContainmentTest() {
+	def void resolveAfterSingleValuedNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -95,7 +95,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * The reference is a containment reference, so the old value is in the staging area.
 	 */
 	 @Test
-	 def public void resolveAfterSingleValuedContainmentTest() {
+	 def void resolveAfterSingleValuedContainmentTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -116,7 +116,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -133,7 +133,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * by replacing a single value non containment reference in the root element.
 	 */
 	@Test
-	def public void applyForwardSingleValuedNonContainmentTest() {
+	def void applyForwardSingleValuedNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 				
@@ -156,7 +156,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * by replacing a single value containment reference in the root element.
 	 */
 	@Test
-	def public void applyForwardSingleValuedContainmentTest() {
+	def void applyForwardSingleValuedContainmentTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -180,7 +180,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * The new value is null.
 	 */
 	@Test
-	def public void applyForwardSingleValuedContainmentNewValueNullTest() {
+	def void applyForwardSingleValuedContainmentNewValueNullTest() {
 		// Set state before
 		newValue = null
 		isContainmentTest
@@ -206,7 +206,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * The old value is null.
 	 */
 	@Test
-	def public void applyForwardSingleValuedContainmentOldValueNullTest() {
+	def void applyForwardSingleValuedContainmentOldValueNullTest() {
 		// Set state before
 		oldValue = null
 		isContainmentTest
@@ -231,7 +231,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * by replacing a single value non containment reference with its old value.
 	 */
 	@Test
-	def public void applyBackwardSingleValuedNonContainmentTest() {
+	def void applyBackwardSingleValuedNonContainmentTest() {
 		// Set state before
 		isNonContainmentTest
 		
@@ -255,7 +255,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * by replacing a single value containment reference with its old value.
 	 */
 	@Test
-	def public void applyBackwardSingleValuedContainmentTest() {
+	def void applyBackwardSingleValuedContainmentTest() {
 		// Set state before
 		isContainmentTest
 		
@@ -280,7 +280,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * The new value was null.
 	 */
 	@Test
-	def public void applyBackwardSingleValuedContainmentNewValueNullTest() {
+	def void applyBackwardSingleValuedContainmentNewValueNullTest() {
 		// Set state before
 		newValue = null
 		isContainmentTest
@@ -306,7 +306,7 @@ public class ReplaceSingleValuedEReferenceTest extends ReferenceEChangeTest {
 	 * The old value was null.
 	 */
 	@Test
-	def public void replaceSingleValuedEReferenceApplyBackwardOldValueNullTest() {
+	def void replaceSingleValuedEReferenceApplyBackwardOldValueNullTest() {
 		// Set state before
 		oldValue = null
 		isContainmentTest

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/root/InsertRootEObjectTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/root/InsertRootEObjectTest.xtend
@@ -20,7 +20,7 @@ class InsertRootEObjectTest extends RootEChangeTest {
 	 * when the model is in state before the change and the change will be applied forward.
 	 */
 	@Test
-	def public void resolveBefore() {
+	def void resolveBefore() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 		unresolvedChange.assertIsNotResolved(newRootObject)		
@@ -39,7 +39,7 @@ class InsertRootEObjectTest extends RootEChangeTest {
 	 * and the change will be applied backward.
 	 */
 	@Test
-	def public void resolveAfterTest() {	
+	def void resolveAfterTest() {	
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 		unresolvedChange.assertIsNotResolved(newRootObject)		
@@ -59,7 +59,7 @@ class InsertRootEObjectTest extends RootEChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {
+	def void resolveToCorrectType() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 			
@@ -73,7 +73,7 @@ class InsertRootEObjectTest extends RootEChangeTest {
 	 * by inserting a new root elements into a resource.
 	 */
 	@Test
-	def public void applyForwardTest() {	
+	def void applyForwardTest() {	
 		assertIsStateBefore
 		
 		// Create change and resolve 1
@@ -104,7 +104,7 @@ class InsertRootEObjectTest extends RootEChangeTest {
 	 * by removing two inserted root objects from a resource.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Set state before
 		assertIsStateBefore
 		
@@ -138,7 +138,7 @@ class InsertRootEObjectTest extends RootEChangeTest {
 	 * Tests applying the {@link InsertRootEObject} EChange with invalid index.
 	 */
 	@Test
-	def public void invalidIndexTest() {
+	def void invalidIndexTest() {
 		// Set state before
 		var index = 5
 		Assert.assertTrue(resourceContent.size < index)

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/root/RemoveRootEObjectTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/root/RemoveRootEObjectTest.xtend
@@ -20,7 +20,7 @@ class RemoveRootEObjectTest extends RootEChangeTest {
 	 * to remove them in the tests.
 	 */
 	@Before
-	override public void beforeTest()  {
+	override void beforeTest()  {
 		super.beforeTest()
 		prepareStateBefore
 	}	
@@ -31,7 +31,7 @@ class RemoveRootEObjectTest extends RootEChangeTest {
 	 * in state before the change is applied forward.
 	 */
 	@Test
-	def public void resolveBeforeTest() {			
+	def void resolveBeforeTest() {			
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 		unresolvedChange.assertIsNotResolved(newRootObject)	
@@ -50,7 +50,7 @@ class RemoveRootEObjectTest extends RootEChangeTest {
 	 * in state after the change was applied.
 	 */
 	 @Test
-	 def public void resolveAfterTest() {
+	 def void resolveAfterTest() {
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 1)
 		unresolvedChange.assertIsNotResolved(newRootObject)	
@@ -66,7 +66,7 @@ class RemoveRootEObjectTest extends RootEChangeTest {
 	 * returns the same class.
 	 */
 	@Test
-	def public void resolveToCorrectType() {		
+	def void resolveToCorrectType() {		
 		// Create change
 		val unresolvedChange = createUnresolvedChange(newRootObject, 0)
 		unresolvedChange.assertIsNotResolved(newRootObject)	
@@ -82,7 +82,7 @@ class RemoveRootEObjectTest extends RootEChangeTest {
 	 * by removing two root elements from a resource.
 	 */
 	@Test
-	def public void applyForwardTest() {
+	def void applyForwardTest() {
 		// Create and resolve change 1
 		val resolvedChange = createUnresolvedChange(newRootObject, 1).resolveBefore(uuidGeneratorAndResolver)
 			as RemoveRootEObject<Root>
@@ -111,7 +111,7 @@ class RemoveRootEObjectTest extends RootEChangeTest {
 	 * by inserts two removed root objects in a resource.
 	 */
 	@Test
-	def public void applyBackwardTest() {
+	def void applyBackwardTest() {
 		// Create and resolve and apply forward 1
 		val resolvedChange = createUnresolvedChange(newRootObject, 0).resolveBefore(uuidGeneratorAndResolver)
 			as RemoveRootEObject<Root>
@@ -142,7 +142,7 @@ class RemoveRootEObjectTest extends RootEChangeTest {
 	 * Tests a {@link RemoveRootEObject} EChange with invalid index.
 	 */
 	@Test
-	def public void invalidIndexTest() {
+	def void invalidIndexTest() {
 		var index = 5
 		
 		// Create and resolve change

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/root/RootEChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/root/RootEChangeTest.xtend
@@ -10,7 +10,7 @@ import tools.vitruv.framework.tests.echange.EChangeTest
 /**
  * Abstract class which is extended by the Root EChange test classes.
  */
-public abstract class RootEChangeTest extends EChangeTest {
+abstract class RootEChangeTest extends EChangeTest {
 	protected var Root newRootObject = null;
 	protected var Root newRootObject2 = null;
 	protected var EList<EObject> resourceContent = null;

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/util/EChangeAssertEquals.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/util/EChangeAssertEquals.xtend
@@ -10,7 +10,7 @@ import tools.vitruv.framework.change.echange.feature.attribute.RemoveEAttributeV
  * Helper class to compare different instances of the same change.
  */
 class EChangeAssertEquals {
-	def public dispatch static void assertEquals(EChange change, EChange change2) {
+	def dispatch static void assertEquals(EChange change, EChange change2) {
 		// Is needed so xtend creates the assertEquals(EChange, EChange) method.
 		Assert.assertTrue(false)
 	}
@@ -18,7 +18,7 @@ class EChangeAssertEquals {
 	/**
 	 * Compares two {@link ReplaceSingleValuedEAttribute} EChanges.
 	 */
-	def public dispatch static void assertEquals(ReplaceSingleValuedEAttribute<?, ?> change, EChange change2) {
+	def dispatch static void assertEquals(ReplaceSingleValuedEAttribute<?, ?> change, EChange change2) {
 		var replaceChange = change2.assertIsInstanceOf(ReplaceSingleValuedEAttribute)
 		Assert.assertSame(change.affectedEObject, replaceChange.affectedEObject)
 		Assert.assertSame(change.affectedFeature, replaceChange.affectedFeature)
@@ -29,7 +29,7 @@ class EChangeAssertEquals {
 	/**
 	 * Compares two {@link InsertEAttributeValue} EChanges.
 	 */	
-	def public dispatch static void assertEquals(InsertEAttributeValue<?, ?> change, EChange change2) {
+	def dispatch static void assertEquals(InsertEAttributeValue<?, ?> change, EChange change2) {
 		var insertChange = change2.assertIsInstanceOf(InsertEAttributeValue)
 		Assert.assertSame(change.affectedEObject, insertChange.affectedEObject)
 		Assert.assertSame(change.affectedFeature, insertChange.affectedFeature)
@@ -39,7 +39,7 @@ class EChangeAssertEquals {
 	/**
 	 * Compares two {@link RemoveEAttributeValue} EChanges.
 	 */	
-	def public dispatch static void assertEquals(RemoveEAttributeValue<?, ?> change, EChange change2) {
+	def dispatch static void assertEquals(RemoveEAttributeValue<?, ?> change, EChange change2) {
 		var removeChange = change2.assertIsInstanceOf(RemoveEAttributeValue)
 		Assert.assertSame(change.affectedEObject, removeChange.affectedEObject)
 		Assert.assertSame(change.affectedFeature, removeChange.affectedFeature)	

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/util/EChangeAssertHelper.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/util/EChangeAssertHelper.xtend
@@ -14,7 +14,7 @@ class EChangeAssertHelper {
  	/**
  	 * Tests whether a unresolved change and a resolved change are the same class.
  	 */
- 	def public static void assertDifferentChangeSameClass(EChange unresolvedChange, EChange resolvedChange)	 {
+ 	def static void assertDifferentChangeSameClass(EChange unresolvedChange, EChange resolvedChange)	 {
  		Assert.assertFalse(unresolvedChange.isResolved)
  		Assert.assertTrue(resolvedChange.isResolved)
  		Assert.assertNotSame(unresolvedChange, resolvedChange)
@@ -24,7 +24,7 @@ class EChangeAssertHelper {
  	/**
  	 * Tests whether a unresolved changes and a resolved changes are the same classes.
  	 */
- 	def public static void assertDifferentChangeSameClass(List<? extends EChange> unresolvedChange, List<? extends EChange> resolvedChange)	 {
+ 	def static void assertDifferentChangeSameClass(List<? extends EChange> unresolvedChange, List<? extends EChange> resolvedChange)	 {
  		Assert.assertEquals(unresolvedChange.size, resolvedChange.size)
  		for (var i = 0; i < unresolvedChange.size; i++) {
  			assertDifferentChangeSameClass(unresolvedChange.get(i), resolvedChange.get(i))
@@ -34,7 +34,7 @@ class EChangeAssertHelper {
  	/**
  	 * Tests whether two objects are the same object or copies of each other.
  	 */
- 	def public static void assertEqualsOrCopy(Object object1, Object object2) {
+ 	def static void assertEqualsOrCopy(Object object1, Object object2) {
  		if (object1 === null && object2 === null) {
  			return;
  		}
@@ -46,7 +46,7 @@ class EChangeAssertHelper {
 	/**
 	 * Tests whether a change is resolved and applies it forward.
 	 */
-	def public static void assertApplyForward(EChange change) {
+	def static void assertApplyForward(EChange change) {
 		Assert.assertNotNull(change)
 		Assert.assertTrue(change.isResolved)
 		Assert.assertTrue(change.applyForward)
@@ -55,14 +55,14 @@ class EChangeAssertHelper {
 	/**
 	 * Tests whether a change sequence is resolved and applies it forward.
 	 */
-	def public static void assertApplyForward(List<EChange> change) {
+	def static void assertApplyForward(List<EChange> change) {
 		change.forEach[assertApplyForward]
 	}
 	
 	/**
 	 * Tests whether a change is resolved and applies it backward.
 	 */
-	def public static void assertApplyBackward(EChange change) {
+	def static void assertApplyBackward(EChange change) {
 		Assert.assertNotNull(change)
 		Assert.assertTrue(change.isResolved)
 		Assert.assertTrue(change.applyBackward)
@@ -71,14 +71,14 @@ class EChangeAssertHelper {
 	/**
 	 * Tests whether a change sequence is resolved and applies it backward.
 	 */
-	def public static void assertApplyBackward(List<EChange> change) {
+	def static void assertApplyBackward(List<EChange> change) {
 		change.reverseView.forEach[assertApplyBackward]
 	}
 	
 	/**
 	 * Tests whether an non applicable change could be applied forward.
 	 */	
-	def public static void assertCannotBeAppliedForward(EChange change) {
+	def static void assertCannotBeAppliedForward(EChange change) {
 		var boolean exceptionThrown = false
 		try {
 			change.applyForward
@@ -93,7 +93,7 @@ class EChangeAssertHelper {
 	/**
 	 * Tests whether an non applicable change could be applied backward.
 	 */
-	def public static void assertCannotBeAppliedBackward(EChange change) {
+	def static void assertCannotBeAppliedBackward(EChange change) {
 		var boolean exceptionThrown = false
 		try {
 			change.applyForward

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/ChangeDescription2ChangeTransformationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/ChangeDescription2ChangeTransformationTest.xtend
@@ -27,11 +27,11 @@ import tools.vitruv.framework.change.echange.resolve.EChangeUnresolver
 abstract class ChangeDescription2ChangeTransformationTest {
 	var protected AtomicEmfChangeRecorder changeRecorder
 	var protected Root rootElement
-	var private List<EChange> changes
+	var List<EChange> changes
 	
 	var rs = new ResourceSetImpl
 	var UuidGeneratorAndResolver uuidGeneratorAndResolver;
-	val private List<File> filesToDelete = new ArrayList<File>();
+	val List<File> filesToDelete = new ArrayList<File>();
 
 	public static val SINGLE_VALUED_CONTAINMENT_E_REFERENCE_NAME = "singleValuedContainmentEReference"
 	public static val SINGLE_VALUED_NON_CONTAINMENT_E_REFERENCE_NAME = "singleValuedNonContainmentEReference"
@@ -98,13 +98,13 @@ abstract class ChangeDescription2ChangeTransformationTest {
 		return this.changes
 	}
 
-	public def List<EChange> endRecording() {
+	def List<EChange> endRecording() {
 		changeRecorder.endRecording()
 		val changeDescriptions = changeRecorder.changes
 		return changeDescriptions.map[EChanges].flatten.toList;
 	}
 
-	public def startRecording() {
+	def startRecording() {
 		if (changeRecorder.isRecording) {
 			changeRecorder.stopRecording;
 		}
@@ -113,11 +113,11 @@ abstract class ChangeDescription2ChangeTransformationTest {
 		this.changeRecorder.beginRecording()
 	}
 
-	public def getRootElement() {
+	def getRootElement() {
 		return this.rootElement
 	}
 
-	public static def assertChangeCount(Iterable<?> changes, int expectedCount) {
+	static def assertChangeCount(Iterable<?> changes, int expectedCount) {
 		Assert.assertEquals(
 			"There were " + changes.size + " changes, although " + expectedCount + " were expected",
 			expectedCount,
@@ -125,7 +125,7 @@ abstract class ChangeDescription2ChangeTransformationTest {
 		);
 	}
 
-	public static def EChange claimChange(List<EChange> changes, int index) {
+	static def EChange claimChange(List<EChange> changes, int index) {
 		return changes.claimElementAt(index)
 	}
 

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/attribute/ChangeDescription2ChangeEAttributeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/attribute/ChangeDescription2ChangeEAttributeTest.xtend
@@ -5,7 +5,7 @@ import static extension tools.vitruv.framework.tests.change.util.AtomicEChangeAs
 import static allElementTypes.AllElementTypesPackage.Literals.*;
 
 abstract class ChangeDescription2ChangeEAttributeTest extends ChangeDescription2ChangeTransformationTest {
-	def public void testInsertEAttributeValue(int expectedIndex, int expectedValue, int position) {
+	def void testInsertEAttributeValue(int expectedIndex, int expectedValue, int position) {
 		// test
 		var int index = expectedIndex
 		startRecording

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/integration/ChangeDescriptionComplexSequencesTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/integration/ChangeDescriptionComplexSequencesTest.xtend
@@ -14,7 +14,7 @@ class ChangeDescriptionComplexSequencesTest extends ChangeDescription2ChangeTran
 	 * Changes that overwrite each other between two change propagation triggers are not recognized by EMF.
 	 */
 	@Test
-	def public void testOverwritingSequence() {
+	def void testOverwritingSequence() {
 		// prepare
 		startRecording
 		
@@ -38,7 +38,7 @@ class ChangeDescriptionComplexSequencesTest extends ChangeDescription2ChangeTran
 	
 	
 	@Test
-	def public void testInsertTreeInContainment() {
+	def void testInsertTreeInContainment() {
 		// prepare
 		this.rootElement.nonRootObjectContainerHelper = null;
 		startRecording
@@ -59,7 +59,7 @@ class ChangeDescriptionComplexSequencesTest extends ChangeDescription2ChangeTran
 	}
 	
 	@Test
-	def public void testInsertComplexTreeInContainment() {
+	def void testInsertComplexTreeInContainment() {
 		// prepare
 		this.rootElement.recursiveRoot = null;
 		

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -13,12 +13,12 @@ import tools.vitruv.framework.change.echange.EChange
 class ChangeDescription2InsertEReferenceTest extends ChangeDescription2EReferenceTest {
 
 	@Test
-	def public void testInsertEReferenceNonContainment() {
+	def void testInsertEReferenceNonContainment() {
 		testInsertInEReference(0)
 	}
 
 	@Test
-	def public void testMultipleInsertEReferenceNonContainment() {
+	def void testMultipleInsertEReferenceNonContainment() {
 		testInsertInEReference(0)
 		testInsertInEReference(1)
 		testInsertInEReference(2)
@@ -26,12 +26,12 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2EReferenc
 	}
 
 	@Test
-	def public void testInsertEReferenceContainment() {
+	def void testInsertEReferenceContainment() {
 		testInsertInContainmentEReference(0)
 	}
 
 	@Test
-	def public void testMultipleInsertEReferenceContainment() {
+	def void testMultipleInsertEReferenceContainment() {
 		testInsertInContainmentEReference(0)
 		testInsertInContainmentEReference(1)
 		testInsertInContainmentEReference(2)

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2RemoveEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2RemoveEReferenceTest.xtend
@@ -49,35 +49,35 @@ class ChangeDescription2RemoveEReferenceTest extends ChangeDescription2EReferenc
 	}
 	
 	@Test
-	def public void testRemoveNonContainmentEReferenceFromList() {
+	def void testRemoveNonContainmentEReferenceFromList() {
 		val isContainment = false
 		val isExplicitUnset = false
 		testRemoveEReference(isContainment, isExplicitUnset)
 	}
 	
 	@Test
-	def public void testRemoveNonContainmentEReferenceFromListWithExplicitUnset() {
+	def void testRemoveNonContainmentEReferenceFromListWithExplicitUnset() {
 		val isContainment = false
 		val isExplicitUnset = true
 		testRemoveEReference(isContainment, isExplicitUnset)
 	}
 	
 	@Test
-	def public void testRemoveContainmentEReferenceFromList() {
+	def void testRemoveContainmentEReferenceFromList() {
 		val isContainment = true
 		val isExplicitUnset = false
 		testRemoveEReference(isContainment, isExplicitUnset)
 	}
 
 	@Test
-	def public void testRemoveContainmentEReferenceFromListWithExplicitUnset() {
+	def void testRemoveContainmentEReferenceFromListWithExplicitUnset() {
 		val isContainment = true
 		val isExplicitUnset = true
 		testRemoveEReference(isContainment, isExplicitUnset)
 	}
 
 	@Test
-	def public void testClearEReferences() {
+	def void testClearEReferences() {
 		val index0Element = createAndAddNonRootToRootMultiReference(0)
 		val index1Element = createAndAddNonRootToRootMultiReference(1)
 		// test

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/rootobject/ChangeDescription2RootChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/rootobject/ChangeDescription2RootChangeTest.xtend
@@ -12,13 +12,13 @@ import tools.vitruv.framework.change.echange.EChange
 class ChangeDescription2RootChangeTest extends ChangeDescription2ChangeTransformationTest{
 	var protected Root rootElement2;
 	
-	def override prepareRootElement(){
+	override prepareRootElement(){
 		super.prepareRootElement
 		rootElement2 = createRootInResource(2);
 	}
 	
 	@After
-	def override afterTest() {
+	override afterTest() {
 		super.afterTest();
 	}
 		

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/AtomicEChangeAssertHelper.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/AtomicEChangeAssertHelper.xtend
@@ -25,18 +25,18 @@ import org.junit.Assert
 import tools.vitruv.framework.change.echange.feature.UnsetFeature
 
 class AtomicEChangeAssertHelper {
-	public def static void assertEObjectExistenceChange(EObjectExistenceEChange<?> change, EObject affectedEObject) {
+	def static void assertEObjectExistenceChange(EObjectExistenceEChange<?> change, EObject affectedEObject) {
 		change.assertAffectedEObject(affectedEObject)
 	}
 	
-	public def static Iterable<? extends EChange> assertCreateEObject(Iterable<? extends EChange> changes, EObject affectedEObject) {
+	def static Iterable<? extends EChange> assertCreateEObject(Iterable<? extends EChange> changes, EObject affectedEObject) {
 		changes.assertSizeGreaterEquals(1);
 		val createObject = assertType(changes.get(0), CreateEObject);
 		createObject.assertEObjectExistenceChange(affectedEObject);
 		return changes.tail
 	}
 			
-	public def static Iterable<? extends EChange> assertDeleteEObject(Iterable<? extends EChange> changes, EObject affectedEObject) {
+	def static Iterable<? extends EChange> assertDeleteEObject(Iterable<? extends EChange> changes, EObject affectedEObject) {
 		changes.assertSizeGreaterEquals(1);
 		val deleteObject = assertType(changes.get(0), DeleteEObject);
 		deleteObject.assertEObjectExistenceChange(affectedEObject);
@@ -48,7 +48,7 @@ class AtomicEChangeAssertHelper {
 		change.assertResource(resource)
 	}
 	
-	def public static Iterable<? extends EChange> assertInsertRootEObject(Iterable<? extends EChange> changes, Object expectedNewValue, String uri, Resource resource) {
+	def static Iterable<? extends EChange> assertInsertRootEObject(Iterable<? extends EChange> changes, Object expectedNewValue, String uri, Resource resource) {
 		changes.assertSizeGreaterEquals(1);
 		val insertRopot = assertType(changes.get(0), InsertRootEObject);
 		insertRopot.assertNewValue(expectedNewValue)
@@ -56,7 +56,7 @@ class AtomicEChangeAssertHelper {
 		return changes.tail;
 	}
 
-	def public static Iterable<? extends EChange> assertRemoveRootEObject(Iterable<? extends EChange> changes, Object expectedOldValue, String uri, Resource resource) {
+	def static Iterable<? extends EChange> assertRemoveRootEObject(Iterable<? extends EChange> changes, Object expectedOldValue, String uri, Resource resource) {
 		changes.assertSizeGreaterEquals(1);
 		val removeRoot = assertType(changes.get(0), RemoveRootEObject);
 		removeRoot.assertOldValue(expectedOldValue)
@@ -65,7 +65,7 @@ class AtomicEChangeAssertHelper {
 	}
 	
 	
-	def public static Iterable<? extends EChange> assertReplaceSingleValuedEAttribute(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature,
+	def static Iterable<? extends EChange> assertReplaceSingleValuedEAttribute(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature,
 			Object expectedOldValue, Object expectedNewValue, boolean wasUnset, boolean isUnset) {
 		changes.assertSizeGreaterEquals(1);
 		val removeEAttributeValue = assertType(changes.get(0), ReplaceSingleValuedEAttribute);
@@ -78,7 +78,7 @@ class AtomicEChangeAssertHelper {
 		return changes.tail;
 	}
 	
-	def public static Iterable<? extends EChange> assertInsertEAttribute(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature,
+	def static Iterable<? extends EChange> assertInsertEAttribute(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature,
 			Object expectedNewValue, int expectedIndex, boolean wasUnset) {
 		changes.assertSizeGreaterEquals(1);
 		val insertEAttributValue = assertType(changes.get(0), InsertEAttributeValue);
@@ -90,7 +90,7 @@ class AtomicEChangeAssertHelper {
 		return changes.tail;
 	}
 	
-	def public static Iterable<? extends EChange> assertRemoveEAttribute(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature,
+	def static Iterable<? extends EChange> assertRemoveEAttribute(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature,
 			Object expectedOldValue, int expectedOldIndex) {
 		changes.assertSizeGreaterEquals(1);
 		val removeEAttributeValue = assertType(changes.get(0), RemoveEAttributeValue);
@@ -144,7 +144,7 @@ class AtomicEChangeAssertHelper {
 	}
 	
 	// FIXME GENERICS
-	def public static Iterable<? extends EChange> assertInsertEReference(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature, 
+	def static Iterable<? extends EChange> assertInsertEReference(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature, 
 			EObject expectedNewValue, int expectedIndex, boolean isContainment, boolean wasUnset) {
 		changes.assertSizeGreaterEquals(1);
 		val insertEReference = assertType(changes.get(0), InsertEReference);
@@ -157,7 +157,7 @@ class AtomicEChangeAssertHelper {
 		return changes.tail;
 	}
 	
-	def public static Iterable<? extends EChange> assertRemoveEReference(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature,
+	def static Iterable<? extends EChange> assertRemoveEReference(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature,
 			EObject expectedOldValue, int expectedOldIndex, boolean isContainment) {
 		changes.assertSizeGreaterEquals(1);
 		val subtractiveChange = assertType(changes.get(0), RemoveEReference);
@@ -169,7 +169,7 @@ class AtomicEChangeAssertHelper {
 		return changes.tail;
 	}
 	
-	def public static Iterable<? extends EChange> assertUnsetFeature(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature) {
+	def static Iterable<? extends EChange> assertUnsetFeature(Iterable<? extends EChange> changes, EObject affectedEObject, EStructuralFeature affectedFeature) {
 		changes.assertSizeGreaterEquals(1);
 		val unsetChange = assertType(changes.get(0), UnsetFeature);
 		unsetChange.assertAffectedEFeature(affectedFeature)
@@ -177,7 +177,7 @@ class AtomicEChangeAssertHelper {
 		return changes.tail;
 	}
 	
-	def public static assertEmpty(Iterable<? extends EChange> changes) {
+	def static assertEmpty(Iterable<? extends EChange> changes) {
 		Assert.assertEquals(0, changes.size);	
 	}
 			

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/ChangeAssertHelper.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/ChangeAssertHelper.xtend
@@ -21,19 +21,19 @@ class ChangeAssertHelper {
 	private new() {
 	}
 
-	public static def <T> T assertObjectInstanceOf(Object object, Class<T> type) {
+	static def <T> T assertObjectInstanceOf(Object object, Class<T> type) {
 		Assert.assertTrue("The object " + object.class.simpleName + " should be type of " + type.simpleName,
 			type.isInstance(object))
 		return type.cast(object)
 	}
 
-	public static def <T extends AdditiveEChange<?>, SubtractiveEChange> assertOldAndNewValue(T eChange,
+	static def <T extends AdditiveEChange<?>, SubtractiveEChange> assertOldAndNewValue(T eChange,
 		Object oldValue, Object newValue) {
 		eChange.assertOldValue(oldValue)
 		eChange.assertNewValue(newValue)
 	}
 
-	public static def assertOldValue(EChange eChange, Object oldValue) {
+	static def assertOldValue(EChange eChange, Object oldValue) {
 		if (oldValue instanceof EObject) {
 			assertEqualsOrCopy("old value must be the same or a copy than the given old value", oldValue,
 				(eChange as SubtractiveEChange<?>).oldValue as EObject)				
@@ -43,7 +43,7 @@ class ChangeAssertHelper {
 		}
 	}
 
-	public static def assertNewValue(AdditiveEChange<?> eChange, Object newValue) {
+	static def assertNewValue(AdditiveEChange<?> eChange, Object newValue) {
 		val newValueInChange = eChange.newValue
 		var condition = newValue === null && newValueInChange === null;
 		if (newValue instanceof EObject && newValueInChange instanceof EObject) {
@@ -58,7 +58,7 @@ class ChangeAssertHelper {
 				"'!", condition)
 	}
 
-	public static def void assertAffectedEObject(EChange eChange, EObject expectedAffectedEObject) {
+	static def void assertAffectedEObject(EChange eChange, EObject expectedAffectedEObject) {
 		if (eChange instanceof FeatureEChange<?, ?>) {
 			assertEqualsOrCopy("The actual affected EObject is a different one than the expected affected EObject or its copy",
 				expectedAffectedEObject, eChange.affectedEObject)
@@ -70,17 +70,17 @@ class ChangeAssertHelper {
 		}
 	}
 
-	public static def assertAffectedEFeature(EChange eChange, EStructuralFeature expectedEFeature) {
+	static def assertAffectedEFeature(EChange eChange, EStructuralFeature expectedEFeature) {
 		Assert.assertEquals(
 			"The actual affected EStructuralFeature is a different one than the expected EStructuralFeature",
 			expectedEFeature, (eChange as FeatureEChange<?, ?>).affectedFeature)
 	}
 
-	public static def getFeatureByName(EObject eObject, String name) {
+	static def getFeatureByName(EObject eObject, String name) {
 		eObject.eClass.getEStructuralFeature(name)
 	}
 
-	def public static void assertPermuteAttributeListTest(List<?> changes, EObject rootElement,
+	def static void assertPermuteAttributeListTest(List<?> changes, EObject rootElement,
 		List<Integer> expectedIndicesForElementsAtOldIndices, EStructuralFeature affectedFeature) {
 	}
 
@@ -103,7 +103,7 @@ class ChangeAssertHelper {
 		Assert.assertEquals("The value is not at the correct index", expectedIndex, change.index)
 	}
 
-	def public static assertEqualsOrCopy(String message, EObject object1, EObject object2) {
+	def static assertEqualsOrCopy(String message, EObject object1, EObject object2) {
 		Assert.assertTrue(message, EcoreUtil.equals(object1, object2))
 	}
 	

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/CompoundEChangeAssertHelper.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/util/CompoundEChangeAssertHelper.xtend
@@ -45,13 +45,13 @@ class CompoundEChangeAssertHelper {
 			.assertDeleteEObject(expectedOldValue);
 	}
 
-	def public static Iterable<? extends EChange> assertCreateAndInsertRootEObject(Iterable<? extends EChange> changes, EObject expectedNewValue, String uri, Resource resource) {
+	def static Iterable<? extends EChange> assertCreateAndInsertRootEObject(Iterable<? extends EChange> changes, EObject expectedNewValue, String uri, Resource resource) {
 		changes.assertSizeGreaterEquals(2);
 		return changes.assertCreateEObject(expectedNewValue)
 			.assertInsertRootEObject(expectedNewValue, uri, resource)
 	}
 
-	def public static Iterable<? extends EChange> assertRemoveAndDeleteRootEObject(Iterable<? extends EChange> changes, EObject expectedOldValue, String uri, Resource resource) {
+	def static Iterable<? extends EChange> assertRemoveAndDeleteRootEObject(Iterable<? extends EChange> changes, EObject expectedOldValue, String uri, Resource resource) {
 		changes.assertSizeGreaterEquals(2);
 		return changes.assertRemoveRootEObject(expectedOldValue, uri, resource)
 			.assertDeleteEObject(expectedOldValue);


### PR DESCRIPTION
This PR removes a lot of the over thousand warnings that Eclipse had for this project.

As a consequence, the warnings that still exist are not drowned in a flood of unnecessary warnings.

Most changes simply remove unnecessary imports or modifiers.