### PR TITLE
Upgrade to Junit 2.13

### DIFF
--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
@@ -75,10 +75,10 @@ Require-Bundle: org.junit,
   tools.vitruv.extensions.dslsruntime.reactions;visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.hamcrest.core,
-  org.junit;version="4.5.0",
-  org.junit.runner;version="4.5.0",
-  org.junit.runner.manipulation;version="4.5.0",
-  org.junit.runner.notification;version="4.5.0",
-  org.junit.runners;version="4.5.0",
-  org.junit.runners.model;version="4.5.0"
+  org.junit;version="4.13.0",
+  org.junit.runner;version="4.13.0",
+  org.junit.runner.manipulation;version="4.13.0",
+  org.junit.runner.notification;version="4.13.0",
+  org.junit.runners;version="4.13.0",
+  org.junit.runners.model;version="4.13.0"
 Bundle-ActivationPolicy: lazy

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsBuilderTest.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsBuilderTest.xtend
@@ -5,8 +5,6 @@ import tools.vitruv.testutils.domains.AllElementTypes2DomainProvider
 import allElementTypes.AllElementTypesPackage
 import allElementTypes2.AllElementTypes2Package
 import org.eclipse.emf.ecore.EcorePackage
-import org.junit.rules.ExpectedException
-import org.junit.Rule
 import org.junit.runner.RunWith
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
@@ -22,9 +20,6 @@ abstract class FluentReactionsBuilderTest {
 	protected static val NonRoot = AllElementTypesPackage.eINSTANCE.nonRoot
 	protected static val Root2 = AllElementTypes2Package.eINSTANCE.root2
 	protected static val EObject = EcorePackage.eINSTANCE.EObject
-
-	@Rule
-	public val ExpectedException thrown = ExpectedException.none()
 
 	@Inject protected GeneratedReactionsMatcherBuilder matcher
 	@Inject protected FluentReactionsLanguageBuilder create

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 import org.junit.Ignore
 import org.eclipse.xtext.xbase.XbaseFactory
 import org.eclipse.xtext.common.types.JvmDeclaredType
+import static org.junit.Assert.assertThrows
 
 class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 	@Test
@@ -323,21 +324,19 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 
 	@Test
 	def void noEmptyReactionsFile() {
-		thrown.expectMessage("No reactions segments")
-		thrown.expect(IllegalStateException)
-
-		val builder = create.reactionsFile('empty')
-		matcher.build(builder)
+		assertThrows("No reactions segments", IllegalStateException, [
+			val builder = create.reactionsFile('empty')
+			matcher.build(builder)
+		])
 	}
 
 	@Test
 	def void noEmptyReactionsSegment() {
-		thrown.expectMessage("Neither routines, nor reactions, nor imports")
-		thrown.expect(IllegalStateException)
-
-		val builder = create.reactionsFile('Test') +=
-			create.reactionsSegment('empty').inReactionToChangesIn(AllElementTypes).executeActionsIn(AllElementTypes)
-		matcher.build(builder)
+		assertThrows("Neither routines, nor reactions, nor imports", IllegalStateException, [
+			val builder = create.reactionsFile('Test') +=
+				create.reactionsSegment('empty').inReactionToChangesIn(AllElementTypes).executeActionsIn(AllElementTypes)
+			matcher.build(builder)
+		])
 	}
 
 	@Test


### PR DESCRIPTION
This PR upgrades usage of Juni in Reactions tests to 2.13 with appropriate expection handling.

Makes PR #296 obsolete.