### PR TITLE
Add and Use an Active Annotation to Create Model Creators

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils.metamodels/src/tools/vitruv/testutils/metamodels/AllElementTypes2Creators.xtend
+++ b/bundles/testutils/tools.vitruv.testutils.metamodels/src/tools/vitruv/testutils/metamodels/AllElementTypes2Creators.xtend
@@ -1,19 +1,12 @@
 package tools.vitruv.testutils.metamodels
 
-import edu.kit.ipd.sdq.activextendannotations.Utility
 import allElementTypes2.AllElementTypes2Factory
+import tools.vitruv.testutils.activeannotations.ModelCreators
 
-@Utility
-class AllElementTypes2Creators {
-	static def newRoot2() {
-		AllElementTypes2Factory.eINSTANCE.createRoot2
-	}
+@ModelCreators(factory=AllElementTypes2Factory)
+final class AllElementTypes2Creators {
+	public static val aet2 = new AllElementTypes2Creators()
 
-	static def newNonRoot2() {
-		AllElementTypes2Factory.eINSTANCE.createNonRoot2
-	}
-
-	static def newNonRootObjectContainerHelper2() {
-		AllElementTypes2Factory.eINSTANCE.createNonRootObjectContainerHelper2
+	private new() {
 	}
 }

--- a/bundles/testutils/tools.vitruv.testutils.metamodels/src/tools/vitruv/testutils/metamodels/AllElementTypesCreators.xtend
+++ b/bundles/testutils/tools.vitruv.testutils.metamodels/src/tools/vitruv/testutils/metamodels/AllElementTypesCreators.xtend
@@ -1,19 +1,12 @@
 package tools.vitruv.testutils.metamodels
 
-import edu.kit.ipd.sdq.activextendannotations.Utility
+import tools.vitruv.testutils.activeannotations.ModelCreators
 import allElementTypes.AllElementTypesFactory
 
-@Utility
-class AllElementTypesCreators {
-	static def newRoot() {
-		AllElementTypesFactory.eINSTANCE.createRoot
-	}
+@ModelCreators(factory=AllElementTypesFactory)
+final class AllElementTypesCreators {
+	public static val aet = new AllElementTypesCreators
 
-	static def newNonRoot() {
-		AllElementTypesFactory.eINSTANCE.createNonRoot
-	}
-
-	static def newNonRootObjectContainerHelper() {
-		AllElementTypesFactory.eINSTANCE.createNonRootObjectContainerHelper
+	private new() {
 	}
 }

--- a/bundles/testutils/tools.vitruv.testutils.metamodels/src/tools/vitruv/testutils/metamodels/PcmMockupCreators.xtend
+++ b/bundles/testutils/tools.vitruv.testutils.metamodels/src/tools/vitruv/testutils/metamodels/PcmMockupCreators.xtend
@@ -1,23 +1,12 @@
 package tools.vitruv.testutils.metamodels
 
-import edu.kit.ipd.sdq.activextendannotations.Utility
 import pcm_mockup.Pcm_mockupFactory
+import tools.vitruv.testutils.activeannotations.ModelCreators
 
-@Utility
-class PcmMockupCreators {
-	static def newPcmRepository() {
-		Pcm_mockupFactory.eINSTANCE.createRepository
-	}
+@ModelCreators(factory=Pcm_mockupFactory, stripPrefix = "P")
+final class PcmMockupCreators {
+	public static val pcm = new PcmMockupCreators()
 
-	static def newPcmInterface() {
-		Pcm_mockupFactory.eINSTANCE.createPInterface
-	}
-
-	static def newPcmComponent() {
-		Pcm_mockupFactory.eINSTANCE.createComponent
-	}
-
-	static def newPcmMethod() {
-		Pcm_mockupFactory.eINSTANCE.createPMethod
+	private new() {
 	}
 }

--- a/bundles/testutils/tools.vitruv.testutils.metamodels/src/tools/vitruv/testutils/metamodels/UmlMockupCreators.xtend
+++ b/bundles/testutils/tools.vitruv.testutils.metamodels/src/tools/vitruv/testutils/metamodels/UmlMockupCreators.xtend
@@ -1,27 +1,12 @@
 package tools.vitruv.testutils.metamodels
 
 import uml_mockup.Uml_mockupFactory
-import edu.kit.ipd.sdq.activextendannotations.Utility
+import tools.vitruv.testutils.activeannotations.ModelCreators
 
-@Utility
-class UmlMockupCreators {
-	static def newUmlPackage() {
-		Uml_mockupFactory.eINSTANCE.createUPackage
-	}
-	
-	static def newUmlInterface() {
-		Uml_mockupFactory.eINSTANCE.createUInterface
-	}
+@ModelCreators(factory=Uml_mockupFactory, stripPrefix = "U")
+final class UmlMockupCreators {
+	public static val uml = new UmlMockupCreators
 
-	static def newUmlClass() {
-		Uml_mockupFactory.eINSTANCE.createUClass
-	}
-	
-	static def newUmlMethod() {
-		Uml_mockupFactory.eINSTANCE.createUMethod
-	}
-	
-	static def newUmlAttribute() {
-		Uml_mockupFactory.eINSTANCE.createUAttribute
+	private new() {
 	}
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/activeannotations/ModelCreators.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/activeannotations/ModelCreators.xtend
@@ -1,0 +1,83 @@
+package tools.vitruv.testutils.activeannotations
+
+import org.eclipse.xtend.lib.macro.Active
+import java.lang.annotation.Target
+import org.eclipse.xtend.lib.macro.AbstractClassProcessor
+import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration
+import org.eclipse.xtend.lib.macro.TransformationContext
+import java.lang.annotation.Retention
+import org.eclipse.emf.ecore.EFactory
+import java.util.HashMap
+import static com.google.common.base.Preconditions.checkArgument
+
+/**
+ * Creates methods that are shortcuts for the creator methods of the provided {@link #factory}.
+ */
+@Active(ModelCreatorsProcessor)
+@Target(TYPE)
+@Retention(SOURCE)
+annotation ModelCreators {
+	/**
+	 * The factory to copy the create methods of.
+	 */
+	Class<? extends EFactory> factory
+	/**
+	 * Whether to make the created shortcuts methods static.
+	 */
+	boolean staticCreators = false
+	/**
+	 * A prefix to strip from the factory’s create methods’ names. “{@code create}” will always be stripped before
+	 * removing the prefix configured here.
+	 */
+	String stripPrefix = ""
+	/**
+	 * A prefix to add to all shortcut methods.
+	 */
+	String prefix = ""
+	/**
+	 * Replacements for method names. Every odd element is a name to replace that will be replaced by the following even
+	 * element. These replacements are performed before adding the prefix according to {@link #prefix}, but after
+	 * removing the prefixes “{@code create}” and {@link #stripPrefix}.
+	 */
+	String[] replace = #[]
+}
+
+class ModelCreatorsProcessor extends AbstractClassProcessor {
+
+	override doTransform(MutableClassDeclaration annotatedClass, @Extension TransformationContext context) {
+		val annotation = annotatedClass.findAnnotation(findTypeGlobally(ModelCreators))
+		if (annotation === null) {
+			annotatedClass.
+				addError('''Cannot find «ModelCreators.simpleName» annotation on «annotatedClass.simpleName»''')
+			return
+		}
+
+		val factory = annotation.getClassValue("factory")
+		val createStatic = annotation.getBooleanValue("staticCreators")
+		val stripPrefix = annotation.getStringValue("stripPrefix")
+		val prefix = annotation.getStringValue("prefix")
+		val rawReplacements = annotation.getStringArrayValue("replace")
+		checkArgument(rawReplacements.size % 2 == 0, '''The replace array must have an even number of elements!''')
+		val replacements = new HashMap<String, String>()
+		for (var i = 0; i < rawReplacements.size; i += 2) {
+			replacements.put(rawReplacements.get(i), rawReplacements.get(i + 1))
+		}
+		
+		factory.declaredResolvedMethods.map[declaration].filter [
+			simpleName.startsWith("create") && parameters.isEmpty
+		].forEach [ createMethod |
+			val baseName = createMethod.simpleName.removePrefix("create").removePrefix(stripPrefix)
+			val targetName = (prefix + replacements.getOrDefault(baseName, baseName).toFirstUpper())
+			annotatedClass.addMethod(targetName) [
+				static = createStatic
+				returnType = createMethod.returnType
+				body = '''return «factory».eINSTANCE.«createMethod.simpleName»();'''
+				primarySourceElement = annotatedClass
+			]
+		]
+	}
+
+	def private static removePrefix(String target, String prefix) {
+		if (target.startsWith(prefix)) target.substring(prefix.length) else target
+	}
+}

--- a/tests/dsls/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/tests/attributeoperators/AttributeMappingOperatorTest.xtend
+++ b/tests/dsls/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/tests/attributeoperators/AttributeMappingOperatorTest.xtend
@@ -27,17 +27,17 @@ class AttributeMappingOperatorTest extends CommonalitiesExecutionTest {
 	@Test
 	def void singleToSingleValuedAttribute() {
 		resourceAt('testid'.allElementTypes).propagate [
-			contents += newRoot => [
+			contents += aet.Root => [
 				id = 'testid'
 				singleValuedPrimitiveTypeEAttribute = 123
 			]
 		]
 
-		assertThat(resourceAt('testid'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('testid'.allElementTypes), contains(aet.Root => [
 			id = 'testid'
 			singleValuedPrimitiveTypeEAttribute = 123
 		], ignoringUnsetFeatures))
-		assertThat(resourceAt('testid'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('testid'.allElementTypes2), contains(aet2.Root2 => [
 			id2 = 'testid'
 			singleValuedPrimitiveTypeEAttribute2 = 123000
 		], ignoringUnsetFeatures))
@@ -47,17 +47,17 @@ class AttributeMappingOperatorTest extends CommonalitiesExecutionTest {
 	@Test
 	def void singleToSingleValuedAttributeReverse() {
 		resourceAt('testid'.allElementTypes2).propagate [
-			contents += newRoot2 => [
+			contents += aet2.Root2 => [
 				id2 = 'testid'
 				singleValuedPrimitiveTypeEAttribute2 = 123500
 			]
 		]
 
-		assertThat(resourceAt('testid'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('testid'.allElementTypes2), contains(aet2.Root2 => [
 			id2 = 'testid'
 			singleValuedPrimitiveTypeEAttribute2 = 123500
 		], ignoringUnsetFeatures))
-		assertThat(resourceAt('testid'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('testid'.allElementTypes), contains(aet.Root => [
 			id = 'testid'
 			singleValuedPrimitiveTypeEAttribute = 123
 		], ignoringUnsetFeatures))
@@ -66,17 +66,17 @@ class AttributeMappingOperatorTest extends CommonalitiesExecutionTest {
 	@Test
 	def void singleToMultiValuedAttribute() {
 		resourceAt('testid'.allElementTypes).propagate [
-			contents += newRoot => [
+			contents += aet.Root => [
 				id = 'testid'
 				singleValuedEAttribute = 324
 			]
 		]
 
-		assertThat(resourceAt('testid'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('testid'.allElementTypes), contains(aet.Root => [
 			id = 'testid'
 			singleValuedEAttribute = 324
 		], ignoringUnsetFeatures))
-		assertThat(resourceAt('testid'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('testid'.allElementTypes2), contains(aet2.Root2 => [
 			id2 = 'testid'
 			multiValuedEAttribute2 += #[3, 2, 4]
 		], ignoringUnsetFeatures))
@@ -85,17 +85,17 @@ class AttributeMappingOperatorTest extends CommonalitiesExecutionTest {
 	@Test
 	def void multiToSingleValuedAttribute() {
 		resourceAt('testid'.allElementTypes2).propagate [
-			contents += newRoot2 => [
+			contents += aet2.Root2 => [
 				id2 = 'testid'
 				multiValuedEAttribute2 += #[3, 2, 4]
 			]
 		]
 
-		assertThat(resourceAt('testid'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('testid'.allElementTypes2), contains(aet2.Root2 => [
 			id2 = 'testid'
 			multiValuedEAttribute2 += #[3, 2, 4]
 		], ignoringUnsetFeatures))
-		assertThat(resourceAt('testid'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('testid'.allElementTypes), contains(aet.Root => [
 			id = 'testid'
 			singleValuedEAttribute = 324
 		], ignoringUnsetFeatures))

--- a/tests/dsls/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/tests/identified/IdentifiedExecutionTest.xtend
+++ b/tests/dsls/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/tests/identified/IdentifiedExecutionTest.xtend
@@ -10,15 +10,11 @@ import tools.vitruv.dsls.commonalities.testutils.ExecutionTestCompiler
 import org.junit.jupiter.api.Test
 import allElementTypes.Root
 import allElementTypes2.Root2
-import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.newRoot
-import static tools.vitruv.testutils.metamodels.AllElementTypes2Creators.newRoot2
-import static tools.vitruv.testutils.metamodels.AllElementTypes2Creators.newNonRoot2
-import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.newNonRoot
+import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.aet
+import static tools.vitruv.testutils.metamodels.AllElementTypes2Creators.aet2
 import static extension tools.vitruv.testutils.domains.DomainModelCreators.*
-import static tools.vitruv.testutils.metamodels.PcmMockupCreators.newPcmRepository
-import static tools.vitruv.testutils.metamodels.PcmMockupCreators.newPcmComponent
-import static tools.vitruv.testutils.metamodels.UmlMockupCreators.newUmlPackage
-import static tools.vitruv.testutils.metamodels.UmlMockupCreators.newUmlClass
+import static tools.vitruv.testutils.metamodels.PcmMockupCreators.pcm
+import static tools.vitruv.testutils.metamodels.UmlMockupCreators.uml
 
 class IdentifiedExecutionTest extends CommonalitiesExecutionTest {
 	override createCompiler(ExecutionTestCompiler.Factory factory) {
@@ -34,44 +30,44 @@ class IdentifiedExecutionTest extends CommonalitiesExecutionTest {
 	@Test
 	def void rootInsert() {
 		resourceAt('testid'.allElementTypes2).propagate [
-			contents += newRoot2 => [id2 = 'testid']
+			contents += aet2.Root2 => [id2 = 'testid']
 		]
 
-		assertThat(resourceAt('testid'.allElementTypes2), contains(newRoot2 => [id2 = 'testid']))
-		assertThat(resourceAt('testid'.allElementTypes), contains(newRoot => [id = 'testid']))
-		assertThat(resourceAt('testid'.pcm_mockup), contains(newPcmRepository => [id = 'testid']))
-		assertThat(resourceAt('testid'.uml_mockup), contains(newUmlPackage => [id = 'testid']))
+		assertThat(resourceAt('testid'.allElementTypes2), contains(aet2.Root2 => [id2 = 'testid']))
+		assertThat(resourceAt('testid'.allElementTypes), contains(aet.Root => [id = 'testid']))
+		assertThat(resourceAt('testid'.pcm_mockup), contains(pcm.Repository => [id = 'testid']))
+		assertThat(resourceAt('testid'.uml_mockup), contains(uml.Package => [id = 'testid']))
 	}
 
 	@Test
 	def void multiRootInsert() {
 		#['first', 'second', 'third'].forEach [ name |
 			resourceAt(name.allElementTypes2).propagate [
-				contents += newRoot2 => [id2 = name]
+				contents += aet2.Root2 => [id2 = name]
 			]
 		]
 
-		assertThat(resourceAt('first'.allElementTypes2), contains(newRoot2 => [id2 = 'first']))
-		assertThat(resourceAt('first'.allElementTypes), contains(newRoot => [id = 'first']))
-		assertThat(resourceAt('first'.pcm_mockup), contains(newPcmRepository => [id = 'first']))
-		assertThat(resourceAt('first'.uml_mockup), contains(newUmlPackage => [id = 'first']))
+		assertThat(resourceAt('first'.allElementTypes2), contains(aet2.Root2 => [id2 = 'first']))
+		assertThat(resourceAt('first'.allElementTypes), contains(aet.Root => [id = 'first']))
+		assertThat(resourceAt('first'.pcm_mockup), contains(pcm.Repository => [id = 'first']))
+		assertThat(resourceAt('first'.uml_mockup), contains(uml.Package => [id = 'first']))
 
-		assertThat(resourceAt('second'.allElementTypes2), contains(newRoot2 => [id2 = 'second']))
-		assertThat(resourceAt('second'.allElementTypes), contains(newRoot => [id = 'second']))
-		assertThat(resourceAt('second'.pcm_mockup), contains(newPcmRepository => [id = 'second']))
-		assertThat(resourceAt('second'.uml_mockup), contains(newUmlPackage => [id = 'second']))
+		assertThat(resourceAt('second'.allElementTypes2), contains(aet2.Root2 => [id2 = 'second']))
+		assertThat(resourceAt('second'.allElementTypes), contains(aet.Root => [id = 'second']))
+		assertThat(resourceAt('second'.pcm_mockup), contains(pcm.Repository => [id = 'second']))
+		assertThat(resourceAt('second'.uml_mockup), contains(uml.Package => [id = 'second']))
 
-		assertThat(resourceAt('third'.allElementTypes2), contains(newRoot2 => [id2 = 'third']))
-		assertThat(resourceAt('third'.allElementTypes), contains(newRoot => [id = 'third']))
-		assertThat(resourceAt('third'.pcm_mockup), contains(newPcmRepository => [id = 'third']))
-		assertThat(resourceAt('third'.uml_mockup), contains(newUmlPackage => [id = 'third']))
+		assertThat(resourceAt('third'.allElementTypes2), contains(aet2.Root2 => [id2 = 'third']))
+		assertThat(resourceAt('third'.allElementTypes), contains(aet.Root => [id = 'third']))
+		assertThat(resourceAt('third'.pcm_mockup), contains(pcm.Repository => [id = 'third']))
+		assertThat(resourceAt('third'.uml_mockup), contains(uml.Package => [id = 'third']))
 	}
 
 	@Test
 	def void rootDelete() {
 		#['first', 'second', 'third'].forEach [ name |
 			resourceAt(name.allElementTypes2).propagate [
-				contents += newRoot2 => [id2 = name]
+				contents += aet2.Root2 => [id2 = name]
 			]
 		]
 
@@ -84,37 +80,37 @@ class IdentifiedExecutionTest extends CommonalitiesExecutionTest {
 
 	@Test
 	def void setIdAttribute() {
-		resourceAt('startid'.allElementTypes2).propagate[contents += newRoot2 => [id2 = 'startid']]
+		resourceAt('startid'.allElementTypes2).propagate[contents += aet2.Root2 => [id2 = 'startid']]
 
 		Root2.from('startid'.allElementTypes2).propagate[id2 = '1st id']
-		assertThat(resourceAt('startid'.allElementTypes2), contains(newRoot2 => [id2 = '1st id']))
-		assertThat(resourceAt('startid'.allElementTypes), contains(newRoot => [id = '1st id']))
-		assertThat(resourceAt('startid'.pcm_mockup), contains(newPcmRepository => [id = '1st id']))
-		assertThat(resourceAt('startid'.uml_mockup), contains(newUmlPackage => [id = '1st id']))
+		assertThat(resourceAt('startid'.allElementTypes2), contains(aet2.Root2 => [id2 = '1st id']))
+		assertThat(resourceAt('startid'.allElementTypes), contains(aet.Root => [id = '1st id']))
+		assertThat(resourceAt('startid'.pcm_mockup), contains(pcm.Repository => [id = '1st id']))
+		assertThat(resourceAt('startid'.uml_mockup), contains(uml.Package => [id = '1st id']))
 
 		Root.from('startid'.allElementTypes).propagate[id = '2nd id']
-		assertThat(resourceAt('startid'.allElementTypes2), contains(newRoot2 => [id2 = '2nd id']))
-		assertThat(resourceAt('startid'.allElementTypes), contains(newRoot => [id = '2nd id']))
-		assertThat(resourceAt('startid'.pcm_mockup), contains(newPcmRepository => [id = '2nd id']))
-		assertThat(resourceAt('startid'.uml_mockup), contains(newUmlPackage => [id = '2nd id']))
+		assertThat(resourceAt('startid'.allElementTypes2), contains(aet2.Root2 => [id2 = '2nd id']))
+		assertThat(resourceAt('startid'.allElementTypes), contains(aet.Root => [id = '2nd id']))
+		assertThat(resourceAt('startid'.pcm_mockup), contains(pcm.Repository => [id = '2nd id']))
+		assertThat(resourceAt('startid'.uml_mockup), contains(uml.Package => [id = '2nd id']))
 
 		Repository.from('startid'.pcm_mockup).propagate[id = '3th id']
-		assertThat(resourceAt('startid'.allElementTypes2), contains(newRoot2 => [id2 = '3th id']))
-		assertThat(resourceAt('startid'.allElementTypes), contains(newRoot => [id = '3th id']))
-		assertThat(resourceAt('startid'.pcm_mockup), contains(newPcmRepository => [id = '3th id']))
-		assertThat(resourceAt('startid'.uml_mockup), contains(newUmlPackage => [id = '3th id']))
+		assertThat(resourceAt('startid'.allElementTypes2), contains(aet2.Root2 => [id2 = '3th id']))
+		assertThat(resourceAt('startid'.allElementTypes), contains(aet.Root => [id = '3th id']))
+		assertThat(resourceAt('startid'.pcm_mockup), contains(pcm.Repository => [id = '3th id']))
+		assertThat(resourceAt('startid'.uml_mockup), contains(uml.Package => [id = '3th id']))
 
 		UPackage.from('startid'.uml_mockup).propagate[id = '4th id']
-		assertThat(resourceAt('startid'.allElementTypes2), contains(newRoot2 => [id2 = '4th id']))
-		assertThat(resourceAt('startid'.allElementTypes), contains(newRoot => [id = '4th id']))
-		assertThat(resourceAt('startid'.pcm_mockup), contains(newPcmRepository => [id = '4th id']))
-		assertThat(resourceAt('startid'.uml_mockup), contains(newUmlPackage => [id = '4th id']))
+		assertThat(resourceAt('startid'.allElementTypes2), contains(aet2.Root2 => [id2 = '4th id']))
+		assertThat(resourceAt('startid'.allElementTypes), contains(aet.Root => [id = '4th id']))
+		assertThat(resourceAt('startid'.pcm_mockup), contains(pcm.Repository => [id = '4th id']))
+		assertThat(resourceAt('startid'.uml_mockup), contains(uml.Package => [id = '4th id']))
 	}
 
 	@Test
 	def void setSimpleAttribute() {
 		resourceAt('test'.allElementTypes2).propagate [
-			contents += newRoot2 => [
+			contents += aet2.Root2 => [
 				singleValuedEAttribute2 = 0
 				id2 = 'test'
 			]
@@ -122,41 +118,41 @@ class IdentifiedExecutionTest extends CommonalitiesExecutionTest {
 		]
 
 		Root2.from('test'.allElementTypes2).propagate[singleValuedEAttribute2 = 1]
-		assertThat(resourceAt('test'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('test'.allElementTypes2), contains(aet2.Root2 => [
 			singleValuedEAttribute2 = 1
 			id2 = 'test'
 		]))
-		assertThat(resourceAt('test'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('test'.allElementTypes), contains(aet.Root => [
 			singleValuedEAttribute = 1
 			id = 'test'
 		]))
 
 		Root.from('test'.allElementTypes).propagate[singleValuedEAttribute = 2]
-		assertThat(resourceAt('test'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('test'.allElementTypes2), contains(aet2.Root2 => [
 			singleValuedEAttribute2 = 2
 			id2 = 'test'
 		]))
-		assertThat(resourceAt('test'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('test'.allElementTypes), contains(aet.Root => [
 			singleValuedEAttribute = 2
 			id = 'test'
 		]))
 
 		Root2.from('test'.allElementTypes2).propagate[singleValuedEAttribute2 = 3]
-		assertThat(resourceAt('test'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('test'.allElementTypes2), contains(aet2.Root2 => [
 			singleValuedEAttribute2 = 3
 			id2 = 'test'
 		]))
-		assertThat(resourceAt('test'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('test'.allElementTypes), contains(aet.Root => [
 			singleValuedEAttribute = 3
 			id = 'test'
 		]))
 
 		Root.from('test'.allElementTypes).propagate[singleValuedEAttribute = 4]
-		assertThat(resourceAt('test'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('test'.allElementTypes2), contains(aet2.Root2 => [
 			singleValuedEAttribute2 = 4
 			id2 = 'test'
 		]))
-		assertThat(resourceAt('test'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('test'.allElementTypes), contains(aet.Root => [
 			singleValuedEAttribute = 4
 			id = 'test'
 		]))
@@ -165,57 +161,57 @@ class IdentifiedExecutionTest extends CommonalitiesExecutionTest {
 	@Test
 	def void setMultiValue() {
 		resourceAt('test'.allElementTypes2).propagate [
-			contents += newRoot2 => [
+			contents += aet2.Root2 => [
 				multiValuedEAttribute2 += #[1, 2, 3]
 				id2 = 'test'
 			]
 		]
-		assertThat(resourceAt('test'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('test'.allElementTypes2), contains(aet2.Root2 => [
 			multiValuedEAttribute2 += #[1, 2, 3]
 			id2 = 'test'
 		]))
-		assertThat(resourceAt('test'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('test'.allElementTypes), contains(aet.Root => [
 			multiValuedEAttribute += #[1, 2, 3]
 			id = 'test'
 		]))
 
 		Root2.from('test'.allElementTypes2).propagate[multiValuedEAttribute2 += 4]
-		assertThat(resourceAt('test'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('test'.allElementTypes2), contains(aet2.Root2 => [
 			multiValuedEAttribute2 += #[1, 2, 3, 4]
 			id2 = 'test'
 		]))
-		assertThat(resourceAt('test'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('test'.allElementTypes), contains(aet.Root => [
 			multiValuedEAttribute += #[1, 2, 3, 4]
 			id = 'test'
 		]))
 
 		Root.from('test'.allElementTypes).propagate[multiValuedEAttribute += 5]
-		assertThat(resourceAt('test'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('test'.allElementTypes2), contains(aet2.Root2 => [
 			multiValuedEAttribute2 += #[1, 2, 3, 4, 5]
 			id2 = 'test'
 		]))
-		assertThat(resourceAt('test'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('test'.allElementTypes), contains(aet.Root => [
 			multiValuedEAttribute += #[1, 2, 3, 4, 5]
 			id = 'test'
 		]))
 
 	/*		Vitruvius doesn’t correctly translate the changes?
-	 * 		saveAndSynchronizeChanges(newRoot2.from('test'.allElementTypes2) => [multiValuedEAttribute2 -= #[1, 3, 5]])
-	 * 		assertThat(resourceAt('test'.allElementTypes2), contains(newRoot2 => [
+	 * 		saveAndSynchronizeChanges(root2.from('test'.allElementTypes2) => [multiValuedEAttribute2 -= #[1, 3, 5]])
+	 * 		assertThat(resourceAt('test'.allElementTypes2), contains(aet2.Root2 => [
 	 * 			multiValuedEAttribute2 += #[2, 4]
 	 * 			id2 = 'test'
 	 * 		]))
-	 * 		assertThat(resourceAt('test'.allElementTypes), contains(root => [
+	 * 		assertThat(resourceAt('test'.allElementTypes), contains(aet.Root => [
 	 * 			multiValuedEAttribute += #[2, 4]
 	 * 			id = 'test'
 	 * 		]))
 
 	 * 		saveAndSynchronizeChanges(Root.from('test'.allElementTypes) => [multiValuedEAttribute -= #[2]])
-	 * 		assertThat(resourceAt('test'.allElementTypes2), contains(newRoot2 => [
+	 * 		assertThat(resourceAt('test'.allElementTypes2), contains(aet2.Root2 => [
 	 * 			multiValuedEAttribute2 += 4
 	 * 			id2 = 'test'
 	 * 		]))
-	 * 		assertThat(resourceAt('test'.allElementTypes), contains(root => [
+	 * 		assertThat(resourceAt('test'.allElementTypes), contains(aet.Root => [
 	 * 			multiValuedEAttribute += 4
 	 * 			id = 'test'
 	 ]))*/
@@ -224,103 +220,103 @@ class IdentifiedExecutionTest extends CommonalitiesExecutionTest {
 	@Test
 	def void rootWithReferenceInsert() {
 		resourceAt('testid'.allElementTypes2).propagate [
-			contents += newRoot2 => [
+			contents += aet2.Root2 => [
 				id2 = 'testid'
-				multiValuedContainmentEReference2 += newNonRoot2 => [id2 = 'testname']
+				multiValuedContainmentEReference2 += aet2.NonRoot2 => [id2 = 'testname']
 			]
 		]
 
-		assertThat(resourceAt('testid'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('testid'.allElementTypes2), contains(aet2.Root2 => [
 			id2 = 'testid'
-			multiValuedContainmentEReference2 += newNonRoot2 => [id2 = 'testname']
+			multiValuedContainmentEReference2 += aet2.NonRoot2 => [id2 = 'testname']
 		]))
-		assertThat(resourceAt('testid'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('testid'.allElementTypes), contains(aet.Root => [
 			id = 'testid'
-			multiValuedContainmentEReference += newNonRoot => [id = 'testname']
+			multiValuedContainmentEReference += aet.NonRoot => [id = 'testname']
 		]))
-		assertThat(resourceAt('testid'.pcm_mockup), contains(newPcmRepository => [
+		assertThat(resourceAt('testid'.pcm_mockup), contains(pcm.Repository => [
 			id = 'testid'
-			components += newPcmComponent => [name = 'testname']
+			components += pcm.Component => [name = 'testname']
 		], ignoringFeatures('id')))
-		assertThat(resourceAt('testid'.uml_mockup), contains(newUmlPackage => [
+		assertThat(resourceAt('testid'.uml_mockup), contains(uml.Package => [
 			id = 'testid'
-			classes += newUmlClass => [name = 'testname']
+			classes += uml.Class => [name = 'testname']
 		], ignoringFeatures('id')))
 	}
 
 	@Test
 	def void multiReferenceInsert() {
 		resourceAt('testid'.allElementTypes2).propagate [
-			contents += newRoot2 => [
+			contents += aet2.Root2 => [
 				id2 = 'testid'
 				multiValuedContainmentEReference2 += #[
-					newNonRoot2 => [id2 = 'first'],
-					newNonRoot2 => [id2 = 'second']
+					aet2.NonRoot2 => [id2 = 'first'],
+					aet2.NonRoot2 => [id2 = 'second']
 				]
 			]
 		]
-		assertThat(resourceAt('testid'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('testid'.allElementTypes2), contains(aet2.Root2 => [
 			id2 = 'testid'
 			multiValuedContainmentEReference2 += #[
-				newNonRoot2 => [id2 = 'first'],
-				newNonRoot2 => [id2 = 'second']
+				aet2.NonRoot2 => [id2 = 'first'],
+				aet2.NonRoot2 => [id2 = 'second']
 			]
 		]))
-		assertThat(resourceAt('testid'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('testid'.allElementTypes), contains(aet.Root => [
 			id = 'testid'
 			multiValuedContainmentEReference += #[
-				newNonRoot => [id = 'first'],
-				newNonRoot => [id = 'second']
+				aet.NonRoot => [id = 'first'],
+				aet.NonRoot => [id = 'second']
 			]
 		]))
-		assertThat(resourceAt('testid'.pcm_mockup), contains(newPcmRepository => [
+		assertThat(resourceAt('testid'.pcm_mockup), contains(pcm.Repository => [
 			id = 'testid'
 			components += #[
-				newPcmComponent => [name = 'first'],
-				newPcmComponent => [name = 'second']
+				pcm.Component => [name = 'first'],
+				pcm.Component => [name = 'second']
 			]
 		], ignoringFeatures('id')))
-		assertThat(resourceAt('testid'.uml_mockup), contains(newUmlPackage => [
+		assertThat(resourceAt('testid'.uml_mockup), contains(uml.Package => [
 			id = 'testid'
 			classes += #[
-				newUmlClass => [name = 'first'],
-				newUmlClass => [name = 'second']
+				uml.Class => [name = 'first'],
+				uml.Class => [name = 'second']
 			]
 		], ignoringFeatures('id')))
 
 		Repository.from('testid'.pcm_mockup).propagate [
-			components += newPcmComponent => [name = 'third']
+			components += pcm.Component => [name = 'third']
 		]
-		assertThat(resourceAt('testid'.allElementTypes2), contains(newRoot2 => [
+		assertThat(resourceAt('testid'.allElementTypes2), contains(aet2.Root2 => [
 			id2 = 'testid'
 			multiValuedContainmentEReference2 += #[
-				newNonRoot2 => [id2 = 'first'],
-				newNonRoot2 => [id2 = 'second'],
-				newNonRoot2 => [id2 = 'third']
+				aet2.NonRoot2 => [id2 = 'first'],
+				aet2.NonRoot2 => [id2 = 'second'],
+				aet2.NonRoot2 => [id2 = 'third']
 			]
 		]))
-		assertThat(resourceAt('testid'.allElementTypes), contains(newRoot => [
+		assertThat(resourceAt('testid'.allElementTypes), contains(aet.Root => [
 			id = 'testid'
 			multiValuedContainmentEReference += #[
-				newNonRoot => [id = 'first'],
-				newNonRoot => [id = 'second'],
-				newNonRoot => [id = 'third']
+				aet.NonRoot => [id = 'first'],
+				aet.NonRoot => [id = 'second'],
+				aet.NonRoot => [id = 'third']
 			]
 		]))
-		assertThat(resourceAt('testid'.pcm_mockup), contains(newPcmRepository => [
+		assertThat(resourceAt('testid'.pcm_mockup), contains(pcm.Repository => [
 			id = 'testid'
 			components += #[
-				newPcmComponent => [name = 'first'],
-				newPcmComponent => [name = 'second'],
-				newPcmComponent => [name = 'third']
+				pcm.Component => [name = 'first'],
+				pcm.Component => [name = 'second'],
+				pcm.Component => [name = 'third']
 			]
 		], ignoringFeatures('id')))
-		assertThat(resourceAt('testid'.uml_mockup), contains(newUmlPackage => [
+		assertThat(resourceAt('testid'.uml_mockup), contains(uml.Package => [
 			id = 'testid'
 			classes += #[
-				newUmlClass => [name = 'first'],
-				newUmlClass => [name = 'second'],
-				newUmlClass => [name = 'third']
+				uml.Class => [name = 'first'],
+				uml.Class => [name = 'second'],
+				uml.Class => [name = 'third']
 			]
 		], ignoringFeatures('id')))
 	}

--- a/tests/dsls/tools.vitruv.dsls.mappings.addressesXrecipients.tests/src/tools/vitruv/dsls/mappings/addressesXrecipients/tests/AddressesCreators.xtend
+++ b/tests/dsls/tools.vitruv.dsls.mappings.addressesXrecipients.tests/src/tools/vitruv/dsls/mappings/addressesXrecipients/tests/AddressesCreators.xtend
@@ -1,21 +1,13 @@
 package tools.vitruv.dsls.mappings.addressesXrecipients.tests
 
-import edu.kit.ipd.sdq.activextendannotations.Utility
 import edu.kit.ipd.sdq.metamodels.addresses.AddressesFactory
 import tools.vitruv.demo.domains.addresses.AddressesDomainProvider
 import tools.vitruv.testutils.domains.DomainUtil
+import tools.vitruv.testutils.activeannotations.ModelCreators
 
-@Utility
+@ModelCreators(factory=AddressesFactory, staticCreators=true, prefix="new")
 class AddressesCreators {
 	static def addresses(String modelName) {
 		DomainUtil.getModelFileName(modelName, new AddressesDomainProvider)
-	}
-
-	static def newAddresses() {
-		AddressesFactory.eINSTANCE.createAddresses
-	}
-
-	static def newAddress() {
-		AddressesFactory.eINSTANCE.createAddress
 	}
 }

--- a/tests/dsls/tools.vitruv.dsls.mappings.addressesXrecipients.tests/src/tools/vitruv/dsls/mappings/addressesXrecipients/tests/RecipientsCreators.xtend
+++ b/tests/dsls/tools.vitruv.dsls.mappings.addressesXrecipients.tests/src/tools/vitruv/dsls/mappings/addressesXrecipients/tests/RecipientsCreators.xtend
@@ -4,26 +4,12 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
 import edu.kit.ipd.sdq.metamodels.recipients.RecipientsFactory
 import tools.vitruv.demo.domains.recipients.RecipientsDomainProvider
 import tools.vitruv.testutils.domains.DomainUtil
+import tools.vitruv.testutils.activeannotations.ModelCreators
 
 @Utility
+@ModelCreators(factory=RecipientsFactory, staticCreators=true, prefix="new")
 class RecipientsCreators {
 	static def recipients(String modelName) {
 		DomainUtil.getModelFileName(modelName, new RecipientsDomainProvider)
-	}
-
-	static def newRecipients() {
-		RecipientsFactory.eINSTANCE.createRecipients
-	}
-
-	static def newRecipient() {
-		RecipientsFactory.eINSTANCE.createRecipient
-	}
-
-	static def newCity() {
-		RecipientsFactory.eINSTANCE.createCity
-	}
-
-	static def newLocation() {
-		RecipientsFactory.eINSTANCE.createLocation
 	}
 }

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
@@ -15,8 +15,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			create.reactionsSegment('simpleChangesRootTests').inReactionToChangesIn(AllElementTypes).
 				executeActionsIn(AllElementTypes) += create.reaction('CreateRootTest').afterElement(Root).created.call [
 				action [
-					vall('newRoot').create(Root)
-					addCorrespondenceBetween('newRoot').and.affectedEObject
+					vall('root').create(Root)
+					addCorrespondenceBetween('root').and.affectedEObject
 				]
 			]
 
@@ -34,8 +34,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val newRoot = create allElementTypes::Root
-					add correspondence between newRoot and affectedEObject
+					val root = create allElementTypes::Root
+					add correspondence between root and affectedEObject
 				}
 			}
 		'''
@@ -88,8 +88,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			executeActionsIn(AllElementTypes)
 		baseSegment += create.reaction('CreateRootTest').afterElement(Root).created.call [
 			action [
-				vall('newRoot').create(Root)
-				addCorrespondenceBetween('newRoot').and.affectedEObject
+				vall('root').create(Root)
+				addCorrespondenceBetween('root').and.affectedEObject
 			]
 		]
 
@@ -125,8 +125,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val newRoot = create allElementTypes::Root
-					add correspondence between newRoot and affectedEObject
+					val root = create allElementTypes::Root
+					add correspondence between root and affectedEObject
 				}
 			}
 			
@@ -171,8 +171,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			executeActionsIn(AllElementTypes)
 		baseSegment += create.reaction('CreateRootTest').afterElement(Root).created.call [
 			action [
-				vall('newRoot').create(Root)
-				addCorrespondenceBetween('newRoot').and.affectedEObject
+				vall('root').create(Root)
+				addCorrespondenceBetween('root').and.affectedEObject
 			]
 		]
 
@@ -181,8 +181,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		extendedSegment +=
 			create.reaction('CreateRootTest').overrideSegment(baseSegment).afterElement(Root).created.call [
 				action [
-					vall('newRootInOverride').create(Root)
-					addCorrespondenceBetween('newRootInOverride').and.affectedEObject
+					vall('rootInOverride').create(Root)
+					addCorrespondenceBetween('rootInOverride').and.affectedEObject
 				]
 			]
 
@@ -203,8 +203,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val newRoot = create allElementTypes::Root
-					add correspondence between newRoot and affectedEObject
+					val root = create allElementTypes::Root
+					add correspondence between root and affectedEObject
 				}
 			}
 			
@@ -223,8 +223,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val newRootInOverride = create allElementTypes::Root
-					add correspondence between newRootInOverride and affectedEObject
+					val rootInOverride = create allElementTypes::Root
+					add correspondence between rootInOverride and affectedEObject
 				}
 			}
 		'''
@@ -240,8 +240,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			executeActionsIn(AllElementTypes)
 		baseSegment += create.reaction('CreateRootTest').afterElement(Root).created.call [
 			action [
-				vall('newRoot').create(Root)
-				addCorrespondenceBetween('newRoot').and.affectedEObject
+				vall('root').create(Root)
+				addCorrespondenceBetween('root').and.affectedEObject
 			]
 		]
 
@@ -251,8 +251,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		.overrideAlongImportPath(baseSegment).input [
 			model(Root, 'affectedEObject')
 		].action [
-			vall('newRoot2').create(Root)
-			addCorrespondenceBetween('newRoot2').and.affectedEObject
+			vall('aet2.Root2').create(Root)
+			addCorrespondenceBetween('aet2.Root2').and.affectedEObject
 		]
 
 		val extendedSegment2 = create.reactionsSegment('extendedSegment2').inReactionToChangesIn(AllElementTypes).
@@ -261,8 +261,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		.overrideAlongImportPath(extendedSegment, baseSegment).input [
 			model(Root, 'affectedEObject')
 		].action [
-			vall('newRoot3').create(Root)
-			addCorrespondenceBetween('newRoot3').and.affectedEObject
+			vall('root3').create(Root)
+			addCorrespondenceBetween('root3').and.affectedEObject
 		]
 
 		builder += baseSegment
@@ -283,8 +283,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val newRoot = create allElementTypes::Root
-					add correspondence between newRoot and affectedEObject
+					val root = create allElementTypes::Root
+					add correspondence between root and affectedEObject
 				}
 			}
 			
@@ -298,8 +298,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine baseSegment::createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val newRoot2 = create allElementTypes::Root
-					add correspondence between newRoot2 and affectedEObject
+					val aet2.Root2 = create allElementTypes::Root
+					add correspondence between aet2.Root2 and affectedEObject
 				}
 			}
 			
@@ -313,8 +313,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine extendedSegment.baseSegment::createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val newRoot3 = create allElementTypes::Root
-					add correspondence between newRoot3 and affectedEObject
+					val root3 = create allElementTypes::Root
+					add correspondence between root3 and affectedEObject
 				}
 			}
 		'''
@@ -375,8 +375,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		val commonRoutine = create.routine('commonRootCreate').input [
 			model(EObject, 'affectedEObject')
 		].action [
-			vall('newRoot').create(Root)
-			addCorrespondenceBetween('newRoot').and.affectedEObject
+			vall('root').create(Root)
+			addCorrespondenceBetween('root').and.affectedEObject
 		]
 
 		val reactionsFile = create.reactionsFile('createRootTest')
@@ -408,8 +408,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine commonRootCreate(ecore::EObject affectedEObject) {
 				action {
-					val newRoot = create allElementTypes::Root
-					add correspondence between newRoot and affectedEObject
+					val root = create allElementTypes::Root
+					add correspondence between root and affectedEObject
 				}
 			}
 		'''
@@ -422,8 +422,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		val commonRoutine = create.routine('commonRootCreate').input [
 			model(EObject, 'affectedEObject')
 		].action [
-			vall('newRoot').create(Root)
-			addCorrespondenceBetween('newRoot').and.affectedEObject
+			vall('root').create(Root)
+			addCorrespondenceBetween('root').and.affectedEObject
 		]
 
 		val reactionsFile = create.reactionsFile('createRootTest')
@@ -458,8 +458,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine commonRootCreate(ecore::EObject affectedEObject) {
 				action {
-					val newRoot = create allElementTypes::Root
-					add correspondence between newRoot and affectedEObject
+					val root = create allElementTypes::Root
+					add correspondence between root and affectedEObject
 				}
 			}
 		'''
@@ -481,7 +481,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 				]
 			]
 		].action [
-			vall('newRoot').create(Root)
+			vall('root').create(Root)
 		]
 
 		val reactionsFile = create.reactionsFile('routineWithMatchTest') +=
@@ -504,7 +504,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 					}
 				}
 				action {
-					val newRoot = create allElementTypes::Root
+					val root = create allElementTypes::Root
 				}
 			}
 		'''
@@ -525,8 +525,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 				]
 			]
 		].action [
-			vall('newRoot').create(Root)
-			addCorrespondenceBetween("newRoot").and.affectedEObject
+			vall('root').create(Root)
+			addCorrespondenceBetween("root").and.affectedEObject
 		]
 
 		val reaction = create.reaction('CreateRoot').afterElement(Root).created.call(routineWithMatch)
@@ -558,8 +558,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 					}
 				}
 				action {
-					val newRoot = create allElementTypes::Root
-					add correspondence between newRoot and affectedEObject
+					val root = create allElementTypes::Root
+					add correspondence between root and affectedEObject
 				}
 			}
 		'''
@@ -572,8 +572,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		val commonRoutine = create.routine('commonRootCreate').input [
 			model(EObject, 'affectedEObject')
 		].action [
-			vall('newRoot').create(Root)
-			addCorrespondenceBetween('newRoot').and.affectedEObject
+			vall('root').create(Root)
+			addCorrespondenceBetween('root').and.affectedEObject
 		]
 
 		val reactionsFile = create.reactionsFile('createRootTest')
@@ -605,8 +605,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine commonRootCreate(ecore::EObject affectedEObject) {
 				action {
-					val newRoot = create allElementTypes::Root
-					add correspondence between newRoot and affectedEObject
+					val root = create allElementTypes::Root
+					add correspondence between root and affectedEObject
 				}
 			}
 			
@@ -630,8 +630,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		val commonRoutine = create.routine('commonRootCreate').input [
 			model(EObject, 'affectedEObject')
 		].action [
-			vall('newRoot').create(Root)
-			addCorrespondenceBetween('newRoot').and.affectedEObject
+			vall('root').create(Root)
+			addCorrespondenceBetween('root').and.affectedEObject
 		]
 
 		val reactionsFile = create.reactionsFile('createRootTest')
@@ -676,8 +676,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 					
 			routine commonRootCreate(ecore::EObject affectedEObject) {
 				action {
-					val newRoot = create allElementTypes::Root
-					add correspondence between newRoot and affectedEObject
+					val root = create allElementTypes::Root
+					add correspondence between root and affectedEObject
 				}
 			}
 		'''

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
@@ -15,8 +15,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			create.reactionsSegment('simpleChangesRootTests').inReactionToChangesIn(AllElementTypes).
 				executeActionsIn(AllElementTypes) += create.reaction('CreateRootTest').afterElement(Root).created.call [
 				action [
-					vall('root').create(Root)
-					addCorrespondenceBetween('root').and.affectedEObject
+					vall('newRoot').create(Root)
+					addCorrespondenceBetween('newRoot').and.affectedEObject
 				]
 			]
 
@@ -34,8 +34,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val root = create allElementTypes::Root
-					add correspondence between root and affectedEObject
+					val newRoot = create allElementTypes::Root
+					add correspondence between newRoot and affectedEObject
 				}
 			}
 		'''
@@ -88,8 +88,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			executeActionsIn(AllElementTypes)
 		baseSegment += create.reaction('CreateRootTest').afterElement(Root).created.call [
 			action [
-				vall('root').create(Root)
-				addCorrespondenceBetween('root').and.affectedEObject
+				vall('newRoot').create(Root)
+				addCorrespondenceBetween('newRoot').and.affectedEObject
 			]
 		]
 
@@ -125,8 +125,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val root = create allElementTypes::Root
-					add correspondence between root and affectedEObject
+					val newRoot = create allElementTypes::Root
+					add correspondence between newRoot and affectedEObject
 				}
 			}
 			
@@ -171,8 +171,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			executeActionsIn(AllElementTypes)
 		baseSegment += create.reaction('CreateRootTest').afterElement(Root).created.call [
 			action [
-				vall('root').create(Root)
-				addCorrespondenceBetween('root').and.affectedEObject
+				vall('newRoot').create(Root)
+				addCorrespondenceBetween('newRoot').and.affectedEObject
 			]
 		]
 
@@ -181,8 +181,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		extendedSegment +=
 			create.reaction('CreateRootTest').overrideSegment(baseSegment).afterElement(Root).created.call [
 				action [
-					vall('rootInOverride').create(Root)
-					addCorrespondenceBetween('rootInOverride').and.affectedEObject
+					vall('newRootInOverride').create(Root)
+					addCorrespondenceBetween('newRootInOverride').and.affectedEObject
 				]
 			]
 
@@ -203,8 +203,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val root = create allElementTypes::Root
-					add correspondence between root and affectedEObject
+					val newRoot = create allElementTypes::Root
+					add correspondence between newRoot and affectedEObject
 				}
 			}
 			
@@ -223,8 +223,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val rootInOverride = create allElementTypes::Root
-					add correspondence between rootInOverride and affectedEObject
+					val newRootInOverride = create allElementTypes::Root
+					add correspondence between newRootInOverride and affectedEObject
 				}
 			}
 		'''
@@ -240,8 +240,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			executeActionsIn(AllElementTypes)
 		baseSegment += create.reaction('CreateRootTest').afterElement(Root).created.call [
 			action [
-				vall('root').create(Root)
-				addCorrespondenceBetween('root').and.affectedEObject
+				vall('newRoot').create(Root)
+				addCorrespondenceBetween('newRoot').and.affectedEObject
 			]
 		]
 
@@ -251,8 +251,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		.overrideAlongImportPath(baseSegment).input [
 			model(Root, 'affectedEObject')
 		].action [
-			vall('aet2.Root2').create(Root)
-			addCorrespondenceBetween('aet2.Root2').and.affectedEObject
+			vall('newRoot2').create(Root)
+			addCorrespondenceBetween('newRoot2').and.affectedEObject
 		]
 
 		val extendedSegment2 = create.reactionsSegment('extendedSegment2').inReactionToChangesIn(AllElementTypes).
@@ -261,8 +261,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		.overrideAlongImportPath(extendedSegment, baseSegment).input [
 			model(Root, 'affectedEObject')
 		].action [
-			vall('root3').create(Root)
-			addCorrespondenceBetween('root3').and.affectedEObject
+			vall('newRoot3').create(Root)
+			addCorrespondenceBetween('newRoot3').and.affectedEObject
 		]
 
 		builder += baseSegment
@@ -283,8 +283,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val root = create allElementTypes::Root
-					add correspondence between root and affectedEObject
+					val newRoot = create allElementTypes::Root
+					add correspondence between newRoot and affectedEObject
 				}
 			}
 			
@@ -298,8 +298,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine baseSegment::createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val aet2.Root2 = create allElementTypes::Root
-					add correspondence between aet2.Root2 and affectedEObject
+					val newRoot2 = create allElementTypes::Root
+					add correspondence between newRoot2 and affectedEObject
 				}
 			}
 			
@@ -313,8 +313,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine extendedSegment.baseSegment::createRootTestRepair(allElementTypes::Root affectedEObject) {
 				action {
-					val root3 = create allElementTypes::Root
-					add correspondence between root3 and affectedEObject
+					val newRoot3 = create allElementTypes::Root
+					add correspondence between newRoot3 and affectedEObject
 				}
 			}
 		'''
@@ -375,8 +375,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		val commonRoutine = create.routine('commonRootCreate').input [
 			model(EObject, 'affectedEObject')
 		].action [
-			vall('root').create(Root)
-			addCorrespondenceBetween('root').and.affectedEObject
+			vall('newRoot').create(Root)
+			addCorrespondenceBetween('newRoot').and.affectedEObject
 		]
 
 		val reactionsFile = create.reactionsFile('createRootTest')
@@ -408,8 +408,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine commonRootCreate(ecore::EObject affectedEObject) {
 				action {
-					val root = create allElementTypes::Root
-					add correspondence between root and affectedEObject
+					val newRoot = create allElementTypes::Root
+					add correspondence between newRoot and affectedEObject
 				}
 			}
 		'''
@@ -422,8 +422,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		val commonRoutine = create.routine('commonRootCreate').input [
 			model(EObject, 'affectedEObject')
 		].action [
-			vall('root').create(Root)
-			addCorrespondenceBetween('root').and.affectedEObject
+			vall('newRoot').create(Root)
+			addCorrespondenceBetween('newRoot').and.affectedEObject
 		]
 
 		val reactionsFile = create.reactionsFile('createRootTest')
@@ -458,8 +458,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine commonRootCreate(ecore::EObject affectedEObject) {
 				action {
-					val root = create allElementTypes::Root
-					add correspondence between root and affectedEObject
+					val newRoot = create allElementTypes::Root
+					add correspondence between newRoot and affectedEObject
 				}
 			}
 		'''
@@ -481,7 +481,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 				]
 			]
 		].action [
-			vall('root').create(Root)
+			vall('newRoot').create(Root)
 		]
 
 		val reactionsFile = create.reactionsFile('routineWithMatchTest') +=
@@ -504,7 +504,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 					}
 				}
 				action {
-					val root = create allElementTypes::Root
+					val newRoot = create allElementTypes::Root
 				}
 			}
 		'''
@@ -525,8 +525,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 				]
 			]
 		].action [
-			vall('root').create(Root)
-			addCorrespondenceBetween("root").and.affectedEObject
+			vall('newRoot').create(Root)
+			addCorrespondenceBetween("newRoot").and.affectedEObject
 		]
 
 		val reaction = create.reaction('CreateRoot').afterElement(Root).created.call(routineWithMatch)
@@ -558,8 +558,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 					}
 				}
 				action {
-					val root = create allElementTypes::Root
-					add correspondence between root and affectedEObject
+					val newRoot = create allElementTypes::Root
+					add correspondence between newRoot and affectedEObject
 				}
 			}
 		'''
@@ -572,8 +572,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		val commonRoutine = create.routine('commonRootCreate').input [
 			model(EObject, 'affectedEObject')
 		].action [
-			vall('root').create(Root)
-			addCorrespondenceBetween('root').and.affectedEObject
+			vall('newRoot').create(Root)
+			addCorrespondenceBetween('newRoot').and.affectedEObject
 		]
 
 		val reactionsFile = create.reactionsFile('createRootTest')
@@ -605,8 +605,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			
 			routine commonRootCreate(ecore::EObject affectedEObject) {
 				action {
-					val root = create allElementTypes::Root
-					add correspondence between root and affectedEObject
+					val newRoot = create allElementTypes::Root
+					add correspondence between newRoot and affectedEObject
 				}
 			}
 			
@@ -630,8 +630,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		val commonRoutine = create.routine('commonRootCreate').input [
 			model(EObject, 'affectedEObject')
 		].action [
-			vall('root').create(Root)
-			addCorrespondenceBetween('root').and.affectedEObject
+			vall('newRoot').create(Root)
+			addCorrespondenceBetween('newRoot').and.affectedEObject
 		]
 
 		val reactionsFile = create.reactionsFile('createRootTest')
@@ -676,8 +676,8 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 					
 			routine commonRootCreate(ecore::EObject affectedEObject) {
 				action {
-					val root = create allElementTypes::Root
-					add correspondence between root and affectedEObject
+					val newRoot = create allElementTypes::Root
+					add correspondence between newRoot and affectedEObject
 				}
 			}
 		'''

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
@@ -39,7 +39,7 @@ class BidirectionalExecutionTests extends ReactionsExecutionTest {
 		resourceAt(SOURCE_MODEL).propagate [
 			contents += aet.Root => [
 				id = 'EachTestModelSource'
-				nonRootObjectContainerHelper = nonRootObjectContainerHelper => [
+				nonRootObjectContainerHelper = aet.NonRootObjectContainerHelper => [
 					id = 'NonRootObjectContainer'
 					nonRootObjectsContainment += nonContainmentNonRootIds.map [ nonRootId |
 						aet.NonRoot => [id = nonRootId]

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
@@ -10,7 +10,7 @@ import tools.vitruv.framework.change.echange.eobject.CreateEObject
 import tools.vitruv.framework.change.echange.feature.reference.ReplaceSingleValuedEReference
 
 import static org.hamcrest.CoreMatchers.*
-import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
+import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.aet
 import static tools.vitruv.testutils.matchers.ModelMatchers.*
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.testutils.matchers.ModelMatchers.containsModelOf
@@ -37,12 +37,12 @@ class BidirectionalExecutionTests extends ReactionsExecutionTest {
 	@BeforeEach
 	def setup() {
 		resourceAt(SOURCE_MODEL).propagate [
-			contents += newRoot => [
+			contents += aet.Root => [
 				id = 'EachTestModelSource'
-				nonRootObjectContainerHelper = newNonRootObjectContainerHelper => [
+				nonRootObjectContainerHelper = nonRootObjectContainerHelper => [
 					id = 'NonRootObjectContainer'
 					nonRootObjectsContainment += nonContainmentNonRootIds.map [ nonRootId |
-						newNonRoot => [id = nonRootId]
+						aet.NonRoot => [id = nonRootId]
 					]
 				]
 			]
@@ -60,7 +60,7 @@ class BidirectionalExecutionTests extends ReactionsExecutionTest {
 	@Test
 	def void testBasicBidirectionalApplication() {
 		val propagatedChanges = Root.from(TARGET_MODEL).propagate [
-			singleValuedContainmentEReference = newNonRoot => [
+			singleValuedContainmentEReference = aet.NonRoot => [
 				id = 'bidirectionalId'
 			]
 		]

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/ReactionsRollbackTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/ReactionsRollbackTests.xtend
@@ -2,7 +2,7 @@ package tools.vitruv.dsls.reactions.tests.complexTests
 
 import allElementTypes.Root
 
-import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
+import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.aet
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.testutils.matchers.ModelMatchers.containsModelOf
 import static org.hamcrest.CoreMatchers.nullValue
@@ -26,12 +26,12 @@ class ReactionsRollbackTests extends ReactionsExecutionTest {
 	@Test
 	def void testReverse() {
 		resourceAt(SOURCE_MODEL).propagate [
-			contents += newRoot => [id = 'Rollback']
+			contents += aet.Root => [id = 'Rollback']
 		]
 		assertThat(resourceAt(SOURCE_MODEL), containsModelOf(resourceAt(TARGET_MODEL)))
 
 		val result = Root.from(SOURCE_MODEL).propagate [
-			singleValuedContainmentEReference = newNonRoot => [
+			singleValuedContainmentEReference = aet.NonRoot => [
 				id = 'testId'
 			]
 		]

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/ImportTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/ImportTests.xtend
@@ -10,7 +10,7 @@ import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.dsls.reactions.tests.ExecutionMonitor.observedExecutions
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.newRoot
+import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.aet
 import static extension tools.vitruv.testutils.domains.DomainModelCreators.allElementTypes
 import tools.vitruv.dsls.reactions.tests.ReactionsExecutionTest
 import tools.vitruv.dsls.reactions.tests.TestReactionsCompiler
@@ -37,7 +37,7 @@ class ImportTests extends ReactionsExecutionTest {
 	@BeforeEach
 	def void createRoot() {
 		resourceAt(SOURCE_MODEL).propagate [
-			contents += newRoot => [id = 'ImportTestsModelSource']
+			contents += aet.Root => [id = 'ImportTestsModelSource']
 		]
 	}
 

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.xtend
@@ -8,9 +8,7 @@ import static tools.vitruv.dsls.reactions.tests.simpleChangesTests.SimpleChanges
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.dsls.reactions.tests.ExecutionMonitor.observedExecutions
-import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.newNonRoot
-import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.newNonRootObjectContainerHelper
-import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.newRoot
+import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.aet
 import static tools.vitruv.testutils.matchers.ModelMatchers.containsModelOf
 import static org.hamcrest.CoreMatchers.is
 import static tools.vitruv.testutils.matchers.ModelMatchers.exists
@@ -39,12 +37,12 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 	@BeforeEach
 	def createRoot() {
 		resourceAt(SOURCE_MODEL).propagate [
-			contents += newRoot => [
+			contents += aet.Root => [
 				id = 'EachTestModelSource'
-				nonRootObjectContainerHelper = newNonRootObjectContainerHelper => [
+				nonRootObjectContainerHelper = nonRootObjectContainerHelper => [
 					id = 'NonRootObjectContainer'
 					nonRootObjectsContainment += nonContainmentNonRootIds.map [ nonRootId |
-						newNonRoot => [id = nonRootId]
+						aet.NonRoot => [id = nonRootId]
 					]
 				]
 			]
@@ -114,7 +112,7 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 	@Test
 	def void testCreateSingleValuedContainmentEReference() {
 		Root.from(SOURCE_MODEL).propagate [
-			singleValuedContainmentEReference = newNonRoot => [id = "singleValuedContainmentNonRootTest"]
+			singleValuedContainmentEReference = aet.NonRoot => [id = "singleValuedContainmentNonRootTest"]
 		]
 
 		assertThat(executionMonitor, observedExecutions(CreateEObject, CreateNonRootEObjectSingle))
@@ -123,7 +121,7 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 
 	@Test
 	def void testDeleteSingleValuedContainmentEReference() {
-		val oldElement = newNonRoot => [id = "singleValuedContainmentNonRoot"]
+		val oldElement = aet.NonRoot => [id = "singleValuedContainmentNonRoot"]
 		Root.from(SOURCE_MODEL).propagate [
 			singleValuedContainmentEReference = oldElement
 		]
@@ -140,11 +138,11 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 	@Test
 	def void testReplaceSingleValuedContainmentEReference() {
 		Root.from(SOURCE_MODEL).propagate [
-			singleValuedContainmentEReference = newNonRoot => [id = "singleValuedContainmentNonRootBefore"]
+			singleValuedContainmentEReference = aet.NonRoot => [id = "singleValuedContainmentNonRootBefore"]
 		]
 		executionMonitor.reset()
 		Root.from(SOURCE_MODEL).propagate [
-			singleValuedContainmentEReference = newNonRoot => [id = "singleValuedContainmentNonRootAfter"]
+			singleValuedContainmentEReference = aet.NonRoot => [id = "singleValuedContainmentNonRootAfter"]
 		]
 
 		assertThat(executionMonitor,
@@ -224,7 +222,7 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 	@Test
 	def void testAddMultiValuedContainmentEReference() {
 		Root.from(SOURCE_MODEL).propagate [
-			multiValuedContainmentEReference += newNonRoot => [id = "multiValuedContainmentNonRootTest"]
+			multiValuedContainmentEReference += aet.NonRoot => [id = "multiValuedContainmentNonRootTest"]
 		]
 
 		assertThat(executionMonitor, observedExecutions(CreateNonRootEObjectInList, CreateEObject))
@@ -234,7 +232,7 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 	@Test
 	def void testDeleteMultiValuedContainmentEReference() {
 		Root.from(SOURCE_MODEL).propagate [
-			multiValuedContainmentEReference += newNonRoot => [id = "multiValuedContainmentNonRootTest"]
+			multiValuedContainmentEReference += aet.NonRoot => [id = "multiValuedContainmentNonRootTest"]
 		]
 		executionMonitor.reset()
 		Root.from(SOURCE_MODEL).propagate [
@@ -248,11 +246,11 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 	@Test
 	def void testReplaceMultiValuedContainmentEReference() {
 		Root.from(SOURCE_MODEL).propagate [
-			multiValuedContainmentEReference += newNonRoot => [id = "multiValuedContainmentNonRootBefore"]
+			multiValuedContainmentEReference += aet.NonRoot => [id = "multiValuedContainmentNonRootBefore"]
 		]
 		executionMonitor.reset()
 		Root.from(SOURCE_MODEL).propagate [
-			multiValuedContainmentEReference.set(0, newNonRoot => [id = "multiValuedContainmentNonRootAfter"])
+			multiValuedContainmentEReference.set(0, aet.NonRoot => [id = "multiValuedContainmentNonRootAfter"])
 		]
 
 		assertThat(executionMonitor,
@@ -336,7 +334,7 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 	@Test
 	def void testCreateFurtherModel() {
 		resourceAt(FURTHER_SOURCE_MODEL).propagate [
-			contents += newRoot => [
+			contents += aet.Root => [
 				id = "Further_Source_Test_Model"
 			]
 		]
@@ -347,7 +345,7 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 	@Test
 	def void testDeleteFurtherModel() {
 		resourceAt(FURTHER_SOURCE_MODEL).propagate [
-			contents += newRoot => [
+			contents += aet.Root => [
 				id = "Further_Source_Test_Model"
 			]
 		]

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/simpleChangesTests/SimpleChangesTests.xtend
@@ -39,7 +39,7 @@ class SimpleChangesTests extends ReactionsExecutionTest {
 		resourceAt(SOURCE_MODEL).propagate [
 			contents += aet.Root => [
 				id = 'EachTestModelSource'
-				nonRootObjectContainerHelper = nonRootObjectContainerHelper => [
+				nonRootObjectContainerHelper = aet.NonRootObjectContainerHelper => [
 					id = 'NonRootObjectContainer'
 					nonRootObjectsContainment += nonContainmentNonRootIds.map [ nonRootId |
 						aet.NonRoot => [id = nonRootId]

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/PcmStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/PcmStateChangeTest.xtend
@@ -2,14 +2,12 @@ package tools.vitruv.framework.tests.domains
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Disabled
-import static tools.vitruv.testutils.metamodels.PcmMockupCreators.newPcmComponent
-import static tools.vitruv.testutils.metamodels.PcmMockupCreators.newPcmInterface
-import static tools.vitruv.testutils.metamodels.PcmMockupCreators.newPcmMethod
+import static tools.vitruv.testutils.metamodels.PcmMockupCreators.pcm
 
 class PcmStateChangeTest extends StateChangePropagationTest {
 	@Test
 	def void testAddComponent() {
-		pcmRoot.components += newPcmComponent => [name = "NewlyAddedComponent"]
+		pcmRoot.components += pcm.Component => [name = "NewlyAddedComponent"]
 		compareChanges(pcmModel, pcmCheckpoint)
 	}
 
@@ -27,21 +25,21 @@ class PcmStateChangeTest extends StateChangePropagationTest {
 
 	@Test
 	def void testAddProvidedInterface() {
-		val newInterface = newPcmInterface => [name = "NewlyAddedInterface"]
-		pcmRoot.interfaces += newInterface
-		newInterface.methods += newPcmMethod => [name = "newMethod"]
+		val newInterface = pcm.Interface => [name = "NewlyAddedInterface"]
+		pcmRoot.interfaces += pcm.Interface
+		newInterface.methods += pcm.Method => [name = "newMethod"]
 		pcmRoot.components.get(0).providedInterface = newInterface
 		compareChanges(pcmModel, pcmCheckpoint)
 	}
 
 	@Test
 	def void testInterfaceWithMultipleMethods() {
-		val newInterface = newPcmInterface => [
+		val newInterface = pcm.Interface => [
 			name = "NewlyAddedInterface"
 		]
 		pcmRoot.interfaces += newInterface
 		newInterface.methods += (0 .. 5).map [ index |
-			newPcmMethod => [name = '''newMethod«index»''']
+			pcm.Method => [name = '''newMethod«index»''']
 		]
 		pcmRoot.components.get(0).providedInterface = newInterface
 		compareChanges(pcmModel, pcmCheckpoint)
@@ -50,8 +48,8 @@ class PcmStateChangeTest extends StateChangePropagationTest {
 	@Disabled("Example for a test case that will NOT pass since the state-based diff looses some information")
 	@Test
 	def void testAddDifferentProvidedInterface() {
-		val firstInterface = newPcmInterface => [name = "NewlyAddedInterface"]
-		val secondInterface = newPcmInterface => [name = "NewlyAddedInterface2"]
+		val firstInterface = pcm.Interface => [name = "NewlyAddedInterface"]
+		val secondInterface = pcm.Interface => [name = "NewlyAddedInterface2"]
 		pcmRoot.interfaces += #[firstInterface, secondInterface]
 		pcmRoot.components.get(0).providedInterface = firstInterface
 		pcmRoot.components.get(0).providedInterface = secondInterface
@@ -61,9 +59,9 @@ class PcmStateChangeTest extends StateChangePropagationTest {
 	@Test
 	def void testAddMultipleInterfaces() {
 		pcmRoot.interfaces += (1 .. 3).map [ index |
-			newPcmInterface => [name = '''NewlyAddedInterface«index»''']
+			pcm.Interface => [name = '''NewlyAddedInterface«index»''']
 		]
-		pcmRoot.interfaces.forEach[methods += newPcmMethod => [name = "newMethod"]]
+		pcmRoot.interfaces.forEach[methods += pcm.Method => [name = "newMethod"]]
 		compareChanges(pcmModel, pcmCheckpoint)
 	}
 }

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/StateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/StateChangePropagationTest.xtend
@@ -24,12 +24,8 @@ import tools.vitruv.testutils.TestProject
 import java.nio.file.Path
 
 import static org.junit.jupiter.api.Assertions.*
-import static tools.vitruv.testutils.metamodels.PcmMockupCreators.newPcmRepository
-import static tools.vitruv.testutils.metamodels.PcmMockupCreators.newPcmInterface
-import static tools.vitruv.testutils.metamodels.PcmMockupCreators.newPcmComponent
-import static tools.vitruv.testutils.metamodels.UmlMockupCreators.newUmlInterface
-import static tools.vitruv.testutils.metamodels.UmlMockupCreators.newUmlClass
-import static tools.vitruv.testutils.metamodels.UmlMockupCreators.newUmlPackage
+import static tools.vitruv.testutils.metamodels.PcmMockupCreators.pcm
+import static tools.vitruv.testutils.metamodels.UmlMockupCreators.uml
 import tools.vitruv.testutils.TestProjectManager
 
 @ExtendWith(TestProjectManager, TestLogging)
@@ -113,10 +109,10 @@ abstract class StateChangePropagationTest {
 
 	private def createPcmMockupModel() {
 		pcmModel = resourceSet.createResource(getModelVURI("My.pcm_mockup")) => [
-			contents += (pcmRoot = newPcmRepository => [
+			contents += (pcmRoot = pcm.Repository => [
 				name = "RootRepository"
-				interfaces += newPcmInterface
-				components += newPcmComponent
+				interfaces += pcm.Interface
+				components += pcm.Component
 			])
 		]
 		EcoreResourceBridge.saveResource(pcmModel)
@@ -124,10 +120,10 @@ abstract class StateChangePropagationTest {
 
 	private def createUmlMockupModel() {
 		umlModel = resourceSet.createResource(getModelVURI("My.uml_mockup")) => [
-			contents += (umlRoot = newUmlPackage => [
+			contents += (umlRoot = uml.Package => [
 				name = "RootPackage"
-				interfaces += newUmlInterface
-				classes += newUmlClass
+				interfaces += uml.Interface
+				classes += uml.Class
 			])
 		]
 		EcoreResourceBridge.saveResource(umlModel)

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/UmlStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/UmlStateChangeTest.xtend
@@ -1,10 +1,7 @@
 package tools.vitruv.framework.tests.domains
 
 import org.junit.jupiter.api.Test
-import static tools.vitruv.testutils.metamodels.UmlMockupCreators.newUmlAttribute
-import static tools.vitruv.testutils.metamodels.UmlMockupCreators.newUmlMethod
-import static tools.vitruv.testutils.metamodels.UmlMockupCreators.newUmlClass
-import static tools.vitruv.testutils.metamodels.UmlMockupCreators.newUmlInterface
+import static tools.vitruv.testutils.metamodels.UmlMockupCreators.uml
 
 class UmlStateChangeTest extends StateChangePropagationTest {
 	@Test
@@ -17,7 +14,7 @@ class UmlStateChangeTest extends StateChangePropagationTest {
 	@Test
 	def void testNewAttributes() {
 		umlRoot.classes.get(0) => [
-			attributes += newUmlAttribute => [attributeName = "NewlyAddedAttribute"]
+			attributes += uml.Attribute => [attributeName = "NewlyAddedAttribute"]
 		]
 		compareChanges(umlModel, umlCheckpoint)
 	}
@@ -25,21 +22,21 @@ class UmlStateChangeTest extends StateChangePropagationTest {
 	@Test
 	def void testNewMethod() {
 		umlRoot.interfaces.get(0) => [
-			methods += newUmlMethod => [name = "NewlyAddedMethod"]
+			methods += uml.Method => [name = "NewlyAddedMethod"]
 		]
 		compareChanges(umlModel, umlCheckpoint)
 	}
 
 	@Test
 	def void testNewClass() {
-		umlRoot.classes += newUmlClass => [name = "NewlyAddedClass"]
+		umlRoot.classes += uml.Class => [name = "NewlyAddedClass"]
 		compareChanges(umlModel, umlCheckpoint)
 	}
 
 	@Test
 	def void testReplaceClass() {
 		umlRoot.classes.remove(0)
-		umlRoot.classes += newUmlClass => [name = "NewlyAddedClass"]
+		umlRoot.classes += uml.Class => [name = "NewlyAddedClass"]
 		compareChanges(umlModel, umlCheckpoint)
 	}
 
@@ -51,7 +48,7 @@ class UmlStateChangeTest extends StateChangePropagationTest {
 
 	@Test
 	def void testNewInterface() {
-		umlRoot.interfaces += newUmlInterface => [name = "NewlyAddedInterface"]
+		umlRoot.interfaces += uml.Interface => [name = "NewlyAddedInterface"]
 		compareChanges(umlModel, umlCheckpoint)
 	}
 }


### PR DESCRIPTION
Allows to easily use the pattern for declarative model creators. 

For the four main test models, I used an even more declarative approach: One writes `pcm.Repository` instead of `newPcmRepository`.