### PR TITLE
Improve return type of CorrespondenceModelContainer#getCorrespondenceModel

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
@@ -33,6 +33,7 @@ import tools.vitruv.testutils.matchers.CorrespondenceModelContainer
 import tools.vitruv.testutils.TestLogging
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.testutils.matchers.ChangeMatchers.isValid
+import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 @ExtendWith(TestProjectManager, TestLogging)
 abstract class VitruvApplicationTest implements CorrespondenceModelContainer {
@@ -186,7 +187,7 @@ abstract class VitruvApplicationTest implements CorrespondenceModelContainer {
 		return propagationResult
 	}
 
-	override getCorrespondenceModel() { virtualModel.correspondenceModel }
+	override CorrespondenceModel getCorrespondenceModel() { virtualModel.correspondenceModel }
 
 	def protected InternalVirtualModel getVirtualModel() { virtualModel }
 

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/CorrespondenceModelContainer.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/CorrespondenceModelContainer.xtend
@@ -1,7 +1,8 @@
 package tools.vitruv.testutils.matchers
 
 import tools.vitruv.framework.correspondence.CorrespondenceModelView
+import tools.vitruv.framework.correspondence.Correspondence
 
 interface CorrespondenceModelContainer {
-	def CorrespondenceModelView<?> getCorrespondenceModel()
+	def CorrespondenceModelView<? extends Correspondence> getCorrespondenceModel()
 }


### PR DESCRIPTION
The type of `CorrespondenceModelContainer#getCorrespondenceModel` was wrong, and `VitruvApplicationTest#getCorrespondenceModel` casted the `CorrespondenceModel` up. Caused problems in the CBS tests.