### PR TITLE
Add a Capture helper class to capture values from lambdas

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/Capture.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/Capture.xtend
@@ -2,30 +2,70 @@ package tools.vitruv.testutils
 
 import static com.google.common.base.Preconditions.checkState
 
+/**
+ * Helper to capture values that are created in Lambdas, so that they can be used outside the Lambda. This is 
+ * sometimes necessary because Java never allows writing to variables outside of a Lambda’s scope.
+ * <p>
+ * Example usage:
+ * <pre>
+ * <code>
+ * def initRepository(String repositoryName) {
+ *     val repository = new Capture&lt;Repository&gt;
+ *     resourceAt(repositoryModelFor(repositoryName)).propagate [
+ *	       contents += pcm.repository.Repository => [
+ *		       entityName = repositoryName
+ *	       ] >> repository
+ *     ]
+ *     return +repository
+ * }
+ * </code>
+ * </pre> 
+ */
 class Capture<T> {
 	var isSet = false
 	var T instance = null
 
-	def set(T t) {
-		instance = t
+    /**
+     * Sets the current value, overriding a previous value.
+     */
+	def set(T value) {
+		instance = value
 		isSet = true
 	}
 	
-	def T operator_add(T t) {
-		set(t)
-		return t
+	/**
+	 * Syntactic sugar for {@linkplain #set setting} the {@code value} of this capture.
+	 * @return {@code value}
+	 */
+	def T operator_add(T value) {
+		set(value)
+		return value
 	}
 	
+	/**
+	 * Syntactic sugar for {@linkplain #get getting} this capture’s current value.
+	 */
 	def T operator_plus() {
 		get()
 	}
 	
+	/**
+	 * Gets the current value.
+	 * 
+	 * @throws java.lang.IllegalStateException if no value has been set yet.
+	 */
 	def get() {
 		checkState(isSet, '''No value has been set yet!''')
 		return instance
 	}
 	
-	def static <T> operator_doubleGreaterThan(T element, Capture<T> capture) {
-		capture += element
+	
+	/**
+	 * Syntactic sugar for {@linkplain #set setting} the {@code value} of this capture.
+	 * @return {@code value}
+	 */
+	def static <T> T operator_doubleGreaterThan(T value, Capture<T> capture) {
+		capture += value
+		return value
 	}
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/Capture.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/Capture.xtend
@@ -1,0 +1,31 @@
+package tools.vitruv.testutils
+
+import static com.google.common.base.Preconditions.checkState
+
+class Capture<T> {
+	var isSet = false
+	var T instance = null
+
+	def set(T t) {
+		instance = t
+		isSet = true
+	}
+	
+	def T operator_add(T t) {
+		set(t)
+		return t
+	}
+	
+	def T operator_plus() {
+		get()
+	}
+	
+	def get() {
+		checkState(isSet, '''No value has been set yet!''')
+		return instance
+	}
+	
+	def static <T> operator_doubleGreaterThan(T element, Capture<T> capture) {
+		capture += element
+	}
+}


### PR DESCRIPTION
Workaround for the fact that you must not set variables from lambdas. 

```Xtend
val repository = new Capture<Repository>
resourceAt(repositoryModelFor(repositoryName)).propagate [
	contents += pcm.repository.Repository => [
		entityName = repositoryName
	] >> repository
]
return +repository
```