### PR TITLE
Legacy Vitruv application test

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/LegacyVitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/LegacyVitruvApplicationTest.xtend
@@ -12,7 +12,7 @@ import org.eclipse.emf.common.notify.Notifier
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 /** 
- * DO NOT USE THIS CALL!
+ * DO NOT USE THIS TEST CLASS! Use {@link VitruvApplicationTest} instead.
  * This is a temporary fallback class for our existing application tests until we have adapted them to the new
  * framework defined by the {@link VitruvApplicationTest}.
  * It serves as a temporary proxy to be removed after their adaptation and should not be used to implement any 

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/LegacyVitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/LegacyVitruvApplicationTest.xtend
@@ -1,0 +1,100 @@
+package tools.vitruv.testutils
+
+import tools.vitruv.testutils.VitruvApplicationTest
+import java.util.List
+import tools.vitruv.framework.change.description.PropagatedChange
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.ecore.EObject
+import java.nio.file.Path
+import tools.vitruv.framework.change.description.VitruviusChangeFactory
+import static com.google.common.base.Preconditions.checkArgument
+import org.eclipse.emf.common.notify.Notifier
+import tools.vitruv.framework.correspondence.CorrespondenceModel
+
+/** 
+ * DO NOT USE THIS CALL!
+ * This is a temporary fallback class for our existing application tests until we have adapted them to the new
+ * framework defined by the {@link VitruvApplicationTest}.
+ * It serves as a temporary proxy to be removed after their adaptation and should not be used to implement any 
+ * new application tests.
+ */
+@Deprecated
+abstract class LegacyVitruvApplicationTest extends VitruvApplicationTest {
+	/** 
+	 * Saves the model containing the given {@link EObject} and propagates changes that were recorded for it.
+	 * @return a list with the {@link PropagatedChange}s, containing the original and consequential changes.
+	 */
+	@Deprecated
+	def protected List<PropagatedChange> saveAndSynchronizeChanges(EObject object) {
+		return saveAndSynchronizeChanges(object.eResource)
+	}
+
+	/** 
+	 * Saves the provided {@link Resource} and propagates changes that were recorded for it.
+	 * @return a list with the {@link PropagatedChange}s, containing the original * and consequential changes.
+	 */
+	@Deprecated
+	def protected List<PropagatedChange> saveAndSynchronizeChanges(Resource resource) {
+		changeRecorder.endRecording()
+		var compositeChange = VitruviusChangeFactory.instance.createCompositeChange(changeRecorder.changes)
+		compositeChange.changedResource?.save(emptyMap)
+		var propagationResult = virtualModel.propagateChange(compositeChange)
+		changeRecorder.beginRecording()
+		return propagationResult
+	}
+
+	/** 
+	 * Creates a model with the given root element at the given path within the test project.
+	 * Propagates the changes for inserting the root element.
+	 * @param modelPathInProject path within project to persist the model at
+	 * @param rootElement        root element to persist
+	 */
+	@Deprecated
+	def protected void createAndSynchronizeModel(String modelPathInProject, EObject rootElement) {
+		var Resource resource = resourceAt(Path.of(modelPathInProject))
+		startRecordingChanges(resource)
+		resource.contents += rootElement
+		saveAndSynchronizeChanges(rootElement)
+	}
+
+	/** 
+	 * Deletes the model at the provided {@code modelPathInProject}. Propagates changes for removing the root elements.
+	 */
+	@Deprecated
+	def protected List<PropagatedChange> deleteAndSynchronizeModel(String modelPathInProject) {
+		val resource = resourceAt(Path.of(modelPathInProject))
+		resource.delete(emptyMap())
+		val result = saveAndSynchronizeChanges(resource)
+		stopRecordingChanges(resource)
+		return result;
+	}
+
+	override CorrespondenceModel getCorrespondenceModel() { 
+		virtualModel.correspondenceModel
+	}
+	
+	@Deprecated
+	def private void startRecordingChanges(Notifier notifier) {
+		checkArgument(notifier !== null, '''The object to record changes of is null!''')
+		this.changeRecorder.addToRecording(notifier)
+	}
+	
+	@Deprecated
+	def protected void startRecordingChanges(EObject object) {
+		checkArgument(object !== null, '''The object to record changes of is null!''')
+		object.eResource.startRecordingChanges
+	}
+
+	@Deprecated	
+	def private void stopRecordingChanges(Notifier notifier) {
+		checkArgument(notifier !== null, '''The object to stop recording changes of is null!''')
+		this.changeRecorder.removeFromRecording(notifier)
+	}
+	
+	@Deprecated
+	def protected void stopRecordingChanges(EObject object) {
+		checkArgument(object !== null, '''The object to stop recording changes of is null!''')
+		object.eResource.stopRecordingChanges
+	}
+	
+}

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
@@ -196,7 +196,7 @@ abstract class VitruvApplicationTest implements CorrespondenceModelContainer {
 
 	def protected TestUserInteraction getUserInteractor() { testUserInteractor }
 
-	def private URI getPlatformModelUri(Path modelPathWithinProject) {
+	def protected final URI getPlatformModelUri(Path modelPathWithinProject) {
 		checkArgument(modelPathWithinProject !== null, "The modelPathWithinProject must not be null!")
 		checkArgument(!modelPathWithinProject.isEmpty, "The modelPathWithinProject must not be empty!")
 		return if (usePlatformURIs) {

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
@@ -213,8 +213,18 @@ abstract class VitruvApplicationTest implements CorrespondenceModelContainer {
 	def private Resource getAndLoadModelResource(Path modelPathWithinProject) {
 		resourceSet.getResource(getPlatformModelUri(modelPathWithinProject), true)
 	}
-	
+
 	def private void renewResourceCache() {
 		resourceSet.resources.clear()
 	}
+
+	/**
+	 * Access to the change recorder for the legacy {@link LegacyVitruvApplicationTest}.
+	 * Has to be removed as soon as {@link LegacyVitruvApplicationTest} is removed.
+	 */
+	@Deprecated
+	def package getChangeRecorder() {
+		changeRecorder;
+	}
+
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
@@ -102,16 +102,27 @@ abstract class VitruvApplicationTest implements CorrespondenceModelContainer {
 	 * @param modelPathWithinProject A project-relative path to a model.
 	 */
 	def protected Resource resourceAt(Path modelPathWithinProject) {
+		resourceAt(getPlatformModelUri(modelPathWithinProject))
+	}
+
+	/**
+	 * Gets the resource at the provided {@link URI}. If the resource does not exist yet, it will be
+	 * created virtually, without being persisted. You can use {@link ModelMatchers.exist} to test
+	 * whether the resource actually exists on the file system.
+	 *
+	 * @param modelUri the {@link URI} of the model to load.
+	 */
+	def protected Resource resourceAt(URI modelUri) {
 		synchronized (resourceSet) {
 			var Resource resource = null;
 			try {
-				resource = getAndLoadModelResource(modelPathWithinProject)
+				resource = resourceSet.getResource(modelUri, true)
 			} catch (RuntimeException e) {
 				// EMF failed during demand creation, usually because loading from the file system failed.
 				// If it has created an empty resource, retrieve it, and otherwise create one.
-				resource = getModelResource(modelPathWithinProject)
+				resource = resourceSet.getResource(modelUri, false)
 				if (resource === null) {
-					resource = createModelResource(modelPathWithinProject)
+					resource = resourceSet.createResource(modelUri)
 				}
 			}
 			return resource
@@ -199,14 +210,6 @@ abstract class VitruvApplicationTest implements CorrespondenceModelContainer {
 		}
 	}
 
-	def private Resource createModelResource(Path modelPathWithinProject) {
-		resourceSet.createResource(getPlatformModelUri(modelPathWithinProject))
-	}
-
-	def private Resource getModelResource(Path modelPathWithinProject) {
-		resourceSet.getResource(getPlatformModelUri(modelPathWithinProject), false)
-	}
-	
 	def private Resource getAndLoadModelResource(Path modelPathWithinProject) {
 		resourceSet.getResource(getPlatformModelUri(modelPathWithinProject), true)
 	}

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelMatchers.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelMatchers.xtend
@@ -46,6 +46,14 @@ class ModelMatchers {
 		new ResourceContainmentMatcher(rootMatcher)
 	}
 
+	def static Matcher<? super URI> isResource() {
+		new ResourceExistingMatcher(true)
+	}
+	
+	def static Matcher<? super URI> isNoResource() {
+		new ResourceExistingMatcher(false)
+	}
+	
 	def static Matcher<? super Resource> exists() {
 		new ResourceExistenceMatcher(true)
 	}


### PR DESCRIPTION
This PR introduces the `LegacyVitruvApplicationTest` providing an API comparable to the one of the old `VitruviusApplicationTest` to allows an easy temporary adaptation of our applications.
The class is to be removed as soon as the changes are adapted to the new `VitruvApplicationTest`.