### PR TITLE
Concurrency improvements

### DIFF
--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/InternalVirtualModel.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/InternalVirtualModel.xtend
@@ -19,6 +19,7 @@ interface InternalVirtualModel extends VirtualModel {
 		]
 	}
 	def void addChangePropagationListener(ChangePropagationListener propagationListener)
+	def void removeChangePropagationListener(ChangePropagationListener propagationListener)
 	def void setUserInteractor(UserInteractor userInteractor)
 	def void addPropagatedChangeListener(PropagatedChangeListener propagatedChangeListener)
 	def void removePropagatedChangeListener(PropagatedChangeListener propagatedChangeListener)

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
@@ -95,6 +95,10 @@ class VirtualModelImpl implements InternalVirtualModel {
 	override addChangePropagationListener(ChangePropagationListener changePropagationListener) {
 		changePropagator.addChangePropagationListener(changePropagationListener)
 	}
+	
+	override removeChangePropagationListener(ChangePropagationListener changePropagationListener) {
+		changePropagator.removeChangePropagationListener(changePropagationListener)
+	}
 
 	override synchronized propagateChange(VitruviusChange change) {
 		LOGGER.info('''Start change propagation''')

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
@@ -76,19 +76,19 @@ class VirtualModelImpl implements InternalVirtualModel {
 		this.resourceRepository.getCorrespondenceModel()
 	}
 
-	override getModelInstance(VURI modelVuri) {
+	override synchronized getModelInstance(VURI modelVuri) {
 		return this.resourceRepository.getModel(modelVuri)
 	}
 
-	override save() {
+	override synchronized save() {
 		this.resourceRepository.saveAllModels()
 	}
 
-	override persistRootElement(VURI persistenceVuri, EObject rootElement) {
+	override synchronized persistRootElement(VURI persistenceVuri, EObject rootElement) {
 		this.resourceRepository.persistAsRoot(rootElement, persistenceVuri)
 	}
 
-	override executeCommand(Callable<Void> command) {
+	override synchronized executeCommand(Callable<Void> command) {
 		this.resourceRepository.executeAsCommand(command);
 	}
 
@@ -96,7 +96,7 @@ class VirtualModelImpl implements InternalVirtualModel {
 		changePropagator.addChangePropagationListener(changePropagationListener)
 	}
 
-	override propagateChange(VitruviusChange change) {
+	override synchronized propagateChange(VitruviusChange change) {
 		LOGGER.info('''Start change propagation''')
 		change.unresolveIfApplicable
 		// Save is done by the change propagator because it has to be performed before finishing sync
@@ -109,14 +109,14 @@ class VirtualModelImpl implements InternalVirtualModel {
 	/**
 	 * @see tools.vitruv.framework.vsum.VirtualModel#propagateChangedState(Resource)
 	 */
-	override propagateChangedState(Resource newState) {
+	override synchronized propagateChangedState(Resource newState) {
 		return propagateChangedState(newState, newState?.URI)
 	}
 
 	/**
 	 * @see tools.vitruv.framework.vsum.VirtualModel#propagateChangedState(Resource, URI)
 	 */
-	override propagateChangedState(Resource newState, URI oldLocation) {
+	override synchronized propagateChangedState(Resource newState, URI oldLocation) {
 		if (newState === null || oldLocation === null) {
 			throw new IllegalArgumentException("New state and old location cannot be null!")
 		}
@@ -132,7 +132,7 @@ class VirtualModelImpl implements InternalVirtualModel {
 		return #[] // empty list
 	}
 
-	override reverseChanges(List<PropagatedChange> changes) {
+	override synchronized reverseChanges(List<PropagatedChange> changes) {
 		resourceRepository.executeAsCommand([|
 			changes.reverseView.forEach[it.applyBackward(uuidGeneratorAndResolver)]
 			return null

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelManager.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelManager.xtend
@@ -2,6 +2,7 @@ package tools.vitruv.framework.vsum
 
 import java.util.Map
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 final class VirtualModelManager {
 	Map<File, InternalVirtualModel> folderToVirtualModelMap;
@@ -9,7 +10,7 @@ final class VirtualModelManager {
 	static val instance = new VirtualModelManager();
 	
 	private new() {
-		this.folderToVirtualModelMap = newHashMap();
+		this.folderToVirtualModelMap = new ConcurrentHashMap();
 	}
 	
 	static def getInstance() {
@@ -17,10 +18,8 @@ final class VirtualModelManager {
 	}
 	
 	def getVirtualModel(File folder) {
-		if (folderToVirtualModelMap.containsKey(folder)) {
-			return folderToVirtualModelMap.get(folder);
-		} else {
-//			// get the workspace root 
+		folderToVirtualModelMap.computeIfAbsent(folder) [
+			// get the workspace root
 //			val root = ResourcesPlugin.getWorkspace().getRoot(); 
 //			// get the project handle 
 //			val project = root.getProject(name); 
@@ -28,7 +27,7 @@ final class VirtualModelManager {
 //			project.open(new NullProgressMonitor());
 //			// TODO HK: Extract VSUM from project
 			throw new UnsupportedOperationException();
-		}
+		]
 	}
 	
 	def putVirtualModel(InternalVirtualModel model) {

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagator.java
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagator.java
@@ -6,13 +6,6 @@ import tools.vitruv.framework.change.description.PropagatedChange;
 import tools.vitruv.framework.change.description.VitruviusChange;
 
 public interface ChangePropagator {
-    /**
-     * Resort changes and igores undos/redos.
-     *
-     * @param change
-     *            list of changes
-     * @return TODO
-     */
     List<PropagatedChange> propagateChange(VitruviusChange change);
 
     void addChangePropagationListener(ChangePropagationListener propagationListener);

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/modelsynchronization/ChangePropagatorImpl.xtend
@@ -2,7 +2,6 @@ package tools.vitruv.framework.vsum.modelsynchronization
 
 import java.util.ArrayList
 import java.util.Collections
-import java.util.HashSet
 import java.util.List
 import java.util.Set
 import org.apache.log4j.Logger
@@ -24,12 +23,11 @@ import tools.vitruv.framework.change.description.CompositeChange
 import tools.vitruv.framework.change.description.CompositeTransactionalChange
 import tools.vitruv.framework.correspondence.CorrespondencePackage
 import tools.vitruv.framework.change.description.ConcreteChange
-import java.util.LinkedList
-import java.util.Collection
 import tools.vitruv.framework.userinteraction.InternalUserInteractor
 import tools.vitruv.framework.userinteraction.UserInteractionListener
 import tools.vitruv.framework.change.interaction.UserInteractionBase
 import tools.vitruv.framework.userinteraction.UserInteractionFactory
+import static com.google.common.base.Preconditions.checkState
 
 class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserver, UserInteractionListener {
 	static Logger logger = Logger.getLogger(ChangePropagatorImpl.getSimpleName())
@@ -37,11 +35,11 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 	final ModelRepository resourceRepository
 	final ChangePropagationSpecificationProvider changePropagationProvider
 	final CorrespondenceProviding correspondenceProviding
-	Set<ChangePropagationListener> changePropagationListeners
+	final Set<ChangePropagationListener> changePropagationListeners
 	final ModelRepositoryImpl modelRepository;
 	final List<EObject> objectsCreatedDuringPropagation;
 	final InternalUserInteractor userInteractor;
-	final Collection<UserInteractionBase> userInteractions = new LinkedList();
+	final List<UserInteractionBase> userInteractions
 
 	new(ModelRepository resourceRepository, ChangePropagationSpecificationProvider changePropagationProvider,
 		VitruvDomainRepository metamodelRepository, CorrespondenceProviding correspondenceProviding,
@@ -51,7 +49,8 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 		this.changePropagationProvider = changePropagationProvider
 		changePropagationProvider.forEach[it.registerObserver(this)]
 		this.correspondenceProviding = correspondenceProviding
-		this.changePropagationListeners = new HashSet<ChangePropagationListener>()
+		this.changePropagationListeners = newHashSet //Collections.synchronizedSet(newHashSet)
+		this.userInteractions = newArrayList // Collections.synchronizedList(newArrayList)
 		this.metamodelRepository = metamodelRepository;
 		this.objectsCreatedDuringPropagation = newArrayList();
 		this.userInteractor = userInteractor;
@@ -69,13 +68,12 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 	}
 
 	override synchronized List<PropagatedChange> propagateChange(VitruviusChange change) {
-		if (change === null || !change.containsConcreteChange()) {
+		checkState(change !== null, '''Given change must not be empty''')
+		if (!change.containsConcreteChange()) {
 			logger.info('''The change does not contain any changes to synchronize: «change»''')
 			return Collections.emptyList()
 		}
-		if (!change.validate()) {
-			throw new IllegalArgumentException('''Change contains changes from different models: «change»''')
-		}
+		checkState(change.validate(), '''Change contains changes from different models: «change»''')
 
 		startChangePropagation(change);
 
@@ -95,7 +93,7 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 			«FOR propagatedChange : changePropagationResult»
 				Propagated Change:
 				«propagatedChange»«ENDFOR»
-			''');
+		''');
 		finishChangePropagation(change)
 
 		return changePropagationResult
@@ -103,15 +101,11 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 
 	private def void startChangePropagation(VitruviusChange change) {
 		logger.debug('''Started synchronizing change: «change»''')
-		for (ChangePropagationListener syncListener : this.changePropagationListeners) {
-			syncListener.startedChangePropagation()
-		}
+		this.changePropagationListeners.forEach[startedChangePropagation]
 	}
 
 	private def void finishChangePropagation(VitruviusChange change) {
-		for (ChangePropagationListener syncListener : this.changePropagationListeners) {
-			syncListener.finishedChangePropagation()
-		}
+		this.changePropagationListeners.forEach[finishedChangePropagation]
 		logger.debug('''Finished synchronizing change: «change»''')
 	}
 
@@ -119,20 +113,18 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 		TransactionalChange change,
 		ChangedResourcesTracker changedResourcesTracker
 	) {
-		val changeApplicationFunction = [UuidResolver uuidResolver |
+		val changeApplicationFunction = [ UuidResolver uuidResolver |
 			change.resolveBeforeAndApplyForward(uuidResolver)
-            // If change has a URI, add the model to the repository
-            if (change.URI !== null) resourceRepository.getModel(change.getURI());
-            change.affectedEObjects.forEach[modelRepository.addRootElement(it)];
-            return;
-    	];
+			// If change has a URI, add the model to the repository
+			if(change.URI !== null) resourceRepository.getModel(change.getURI());
+			change.affectedEObjects.forEach[modelRepository.addRootElement(it)];
+			return;
+		];
 		this.resourceRepository.executeOnUuidResolver(changeApplicationFunction);
 		modelRepository.cleanupRootElements;
 
 		val changedObjects = change.affectedEObjects;
-		if (changedObjects.nullOrEmpty) {
-			throw new IllegalStateException("There are no objects affected by the given changes");
-		}
+		checkState(!changedObjects.nullOrEmpty, "There are no objects affected by the given changes")
 
 		return propagateSingleChange(change, changedResourcesTracker)
 	}
@@ -142,32 +134,37 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 		ChangedResourcesTracker changedResourcesTracker
 	) {
 		val consequentialChanges = newArrayList();
-		
+
 		// retrieve user inputs from past changes, construct a UserInteractor which tries to reuse them:
 		val pastUserInputsFromChange = change.getUserInteractions()
 		if (!pastUserInputsFromChange.nullOrEmpty) {
-			userInteractor.decorateUserInteractionResultProvider([provider | UserInteractionFactory.instance.createPredefinedInteractionResultProvider(provider, pastUserInputsFromChange)]);
+			userInteractor.decorateUserInteractionResultProvider([ provider |
+				UserInteractionFactory.instance.
+					createPredefinedInteractionResultProvider(provider, pastUserInputsFromChange)
+			]);
 		}
-		//modelRepository.startRecording;
+		// modelRepository.startRecording;
 		resourceRepository.startRecording;
 		for (propagationSpecification : changePropagationProvider.
 			getChangePropagationSpecifications(change.changeDomain)) {
 			propagateChangeForChangePropagationSpecification(change, propagationSpecification, changedResourcesTracker);
 		}
-		//consequentialChanges += modelRepository.endRecording();
+		// consequentialChanges += modelRepository.endRecording();
 		consequentialChanges += resourceRepository.endRecording();
 		consequentialChanges.forEach[logger.trace('''Change generated by change propagation:\n «it»''')];
 
 		userInteractor.removeDecoratingUserInteractionResultProvider();
-        change.userInteractions = userInteractions
+		change.userInteractions = newArrayList(userInteractions)
+		userInteractions.clear
+
 		val propagatedChange = new PropagatedChange(change,
-				VitruviusChangeFactory.instance.createCompositeChange(consequentialChanges))
+			VitruviusChangeFactory.instance.createCompositeChange(consequentialChanges))
 		val resultingChanges = new ArrayList()
 		resultingChanges += propagatedChange
 
-		val consequentialChangesToRePropagate = propagatedChange.consequentialChanges.transactionalChangeSequence
-			.map[rewrapWithoutCorrespondenceChanges].filterNull.filter[containsConcreteChange]
-			.filter [changeDomain.shouldTransitivelyPropagateChanges]
+		val consequentialChangesToRePropagate = propagatedChange.consequentialChanges.transactionalChangeSequence.map [
+			rewrapWithoutCorrespondenceChanges
+		].filterNull.filter[containsConcreteChange].filter[changeDomain.shouldTransitivelyPropagateChanges]
 
 		for (changeToPropagate : consequentialChangesToRePropagate) {
 			resultingChanges += propagateSingleChange(changeToPropagate, changedResourcesTracker)
@@ -175,27 +172,28 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 
 		return resultingChanges
 	}
-	
+
 	private def dispatch TransactionalChange rewrapWithoutCorrespondenceChanges(CompositeTransactionalChange change) {
 		val newChange = VitruviusChangeFactory.instance.createCompositeTransactionalChange()
 		change.changes.map[rewrapWithoutCorrespondenceChanges].filterNull.forEach[newChange.addChange(it)];
 		return newChange;
 	}
-	
+
 	private def dispatch TransactionalChange rewrapWithoutCorrespondenceChanges(ConcreteChange change) {
-		return if (!change.affectedEObjects.exists[isInCorrespondenceModel]) change else null;
+		return if(!change.affectedEObjects.exists[isInCorrespondenceModel]) change else null;
 	}
-	
+
 	private def dispatch TransactionalChange rewrapWithoutCorrespondenceChanges(TransactionalChange change) {
 		return change;
 	}
-	
+
 	private def boolean isInCorrespondenceModel(EObject object) {
 		val typeAndSuperTypes = Collections.singletonList(object.eClass) + object.eClass.EAllSuperTypes
 		return typeAndSuperTypes.exists[EPackage === CorrespondencePackage.eINSTANCE]
 	}
 
-	def private dispatch Iterable<TransactionalChange> getTransactionalChangeSequence(CompositeTransactionalChange composite) {
+	def private dispatch Iterable<TransactionalChange> getTransactionalChangeSequence(
+		CompositeTransactionalChange composite) {
 		if (composite.containsConcreteChange) {
 			return Collections.singleton(composite)
 		} else {
@@ -204,15 +202,16 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 	}
 
 	def private dispatch Iterable<TransactionalChange> getTransactionalChangeSequence(CompositeChange<?> composite) {
-		composite.changes.flatMap [transactionalChangeSequence]
+		composite.changes.flatMap[transactionalChangeSequence]
 	}
 
-	def private dispatch Iterable<TransactionalChange> getTransactionalChangeSequence(TransactionalChange transactionalChange) {
+	def private dispatch Iterable<TransactionalChange> getTransactionalChangeSequence(
+		TransactionalChange transactionalChange) {
 		if (transactionalChange.containsConcreteChange) {
 			return Collections.singleton(transactionalChange)
 		} else {
 			return Collections.emptyList
-		} 
+		}
 	}
 
 	def private getChangeDomain(VitruviusChange change) {
@@ -224,20 +223,18 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 		modelRepository.cleanupRootElementsWithoutResource
 		// Find created objects without resource
 		for (createdObjectWithoutResource : objectsCreatedDuringPropagation.filter[eResource === null]) {
-			if (correspondenceProviding.correspondenceModel.hasCorrespondences(
-				#[createdObjectWithoutResource])) {
-				throw new IllegalStateException("Every object must be contained within a resource: " + createdObjectWithoutResource);
-			} else {
-				logger.warn("Object was created but has no correspondence and is thus lost: " +
-					createdObjectWithoutResource);
-			}
+			val hasCorrespondence = correspondenceProviding.correspondenceModel.hasCorrespondences(
+				#[createdObjectWithoutResource])
+			checkState(
+				!hasCorrespondence, '''Every object must be contained within a resource: «createdObjectWithoutResource»''')
+			logger.warn("Object was created but has no correspondence and is thus lost: " +
+				createdObjectWithoutResource)
 		}
-		objectsCreatedDuringPropagation.clear();
+		objectsCreatedDuringPropagation.clear()
 	}
 
 	private def void propagateChangeForChangePropagationSpecification(TransactionalChange change,
-		ChangePropagationSpecification propagationSpecification,
-		ChangedResourcesTracker changedResourcesTracker) {
+		ChangePropagationSpecification propagationSpecification, ChangedResourcesTracker changedResourcesTracker) {
 		val correspondenceModel = correspondenceProviding.getCorrespondenceModel();
 
 		// TODO HK: Clone the changes for each synchronization! Should even be cloned for
@@ -253,13 +250,13 @@ class ChangePropagatorImpl implements ChangePropagator, ChangePropagationObserve
 		changedResourcesTracker.addSourceResourceOfChange(change);
 	}
 
-	override objectCreated(EObject createdObject) {
+	override synchronized objectCreated(EObject createdObject) {
 		this.objectsCreatedDuringPropagation += createdObject;
 		this.modelRepository.addRootElement(createdObject);
 	}
 
-    override onUserInteractionReceived(UserInteractionBase interaction) {
-        userInteractions.add(interaction)
-    }
+	override onUserInteractionReceived(UserInteractionBase interaction) {
+		userInteractions.add(interaction)
+	}
 
 }


### PR DESCRIPTION
- Synchronizes operations of the `VirtualModel` to ensure that avoid parallel change propagations, save operations and view derivations
- Synchronizes access to `VirtualModel`s via the `VirtualModelManager`
- Improve state checks within the `ChangePropagatorImpl`
- Allow removal of listeners for change propagation from `VirtualModel`