### PR TITLE
Fix Initialization Order of CommonalitiesExecutionTest and TestReactionsCompiler

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.commonalities.testutils/META-INF/MANIFEST.MF
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities.testutils/META-INF/MANIFEST.MF
@@ -25,7 +25,8 @@ Require-Bundle: org.apache.log4j,
  tools.vitruv.dsls.commonalities.ui,
  tools.vitruv.dsls.mirbase.ui,
  tools.vitruv.dsls.reactions.ui,
- tools.vitruv.testutils
+ tools.vitruv.testutils,
+ edu.kit.ipd.sdq.activextendannotations
 Export-Package: tools.vitruv.dsls.commonalities.testutils,
  tools.vitruv.dsls.commonalities.testutils.operators
 Bundle-Vendor: vitruv.tools

--- a/bundles/dsls/tools.vitruv.dsls.commonalities.testutils/src/tools/vitruv/dsls/commonalities/testutils/CommonalitiesExecutionTest.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities.testutils/src/tools/vitruv/dsls/commonalities/testutils/CommonalitiesExecutionTest.xtend
@@ -9,30 +9,33 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.^extension.ExtendWith
 import tools.vitruv.testutils.TestProject
 import tools.vitruv.testutils.VitruvApplicationTest
+import edu.kit.ipd.sdq.activextendannotations.Lazy
+import static com.google.common.base.Preconditions.checkNotNull
 
 @ExtendWith(InjectionExtension)
 @InjectWith(CombinedUiInjectorProvider)
 @TestInstance(PER_CLASS)
 abstract class CommonalitiesExecutionTest extends VitruvApplicationTest {
-	var ExecutionTestCompiler compiler
-	var Path compilationProjectDir
+	var Path compilationDir
+	ExecutionTestCompiler.Factory factory
+	@Lazy
+	val ExecutionTestCompiler compiler = createCompiler(
+		checkNotNull(factory, "The compiler factory was not injected yet!").setParameters [
+			commonalitiesOwner = this
+			compilationProjectDir = checkNotNull(compilationDir, "The compilation directory was not acquired yet!")
+		]
+	)
 
 	protected abstract def ExecutionTestCompiler createCompiler(ExecutionTestCompiler.Factory factory)
 
 	@BeforeAll
 	def void acquireCompilationTargetDir(@TestProject(variant="commonalities compilation") Path compilationDir) {
-		compilationProjectDir = compilationDir
+		this.compilationDir = compilationDir
 	}
 
 	@Inject
 	def setCompilerFactory(ExecutionTestCompiler.Factory factory) {
-		if (compiler === null) {
-			factory.setParameters [
-				commonalitiesOwner = this
-				it.compilationProjectDir = this.compilationProjectDir
-			]
-			compiler = createCompiler(factory)
-		}
+		this.factory = factory
 	}
 
 	override protected getChangePropagationSpecifications() {

--- a/bundles/dsls/tools.vitruv.dsls.commonalities.testutils/src/tools/vitruv/dsls/commonalities/testutils/ExecutionTestCompiler.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities.testutils/src/tools/vitruv/dsls/commonalities/testutils/ExecutionTestCompiler.xtend
@@ -280,6 +280,7 @@ final class ExecutionTestCompiler {
 
 		def setParameters(Consumer<ExecutionTestCompiler.Parameters> configurer) {
 			configurer.accept(parameters)
+			this
 		}
 
 		def createCompiler(Consumer<ExecutionTestCompiler.Parameters> configurer) {

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/TestReactionsCompiler.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/TestReactionsCompiler.xtend
@@ -145,6 +145,7 @@ class TestReactionsCompiler {
 
 		def setParameters(Consumer<TestReactionsCompiler.TestReactionsCompilerParameters> configurer) {
 			configurer.accept(parameters)
+			this
 		}
 
 		def createCompiler(Consumer<TestReactionsCompiler.TestReactionsCompilerParameters> configurer) {


### PR DESCRIPTION
`CommonalitiesExecutionTest` stopped working, I am not quite sure why or when. Since this logic makes more sense anyway, I think we should just merge it.