### PR TITLE
Fix Error When Commonality Contains No Mappings for a Domain

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionElementBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionElementBuilder.xtend
@@ -32,11 +32,11 @@ import static com.google.common.base.Preconditions.*
  * <ol>
  * <li>Building phase. The user is using the offered methods to create the
  * desired elements. They must leave all builders in a sufficiently initialized
- * state (such that {@link #readyToBeAttached} is {@code true}.
+ * state (such that {@link #readyToBeAttached} is {@code true}).
  * <li>Attachment preparation phase. Just before the builder is to be attached
  * to a resource, this phase is triggered. The user may not modify builders
  * anymore and the builders do outstanding initializations (which can now rely
- * on the fact that things will not be changed by the user anymore).
+ * on the fact that nothing will be changed by the user anymore).
  * <li>Jvm Types Linking phase. After the builders have been attached to a 
  * resource, generated JVM types will be available. The builders now use them
  * to create the missing elements. Building is finished afterwards.
@@ -74,6 +74,15 @@ abstract package class FluentReactionElementBuilder {
 
 	protected new(FluentBuilderContext context) {
 		this.context = context
+	}
+	
+	/**
+	 * Determines whether building this builder in its current state will 
+	 * generate code. If this method returns {@code false}, there is no 
+	 * use in building this builder, and doing so might throw an exception.
+	 */
+	def boolean willGenerateCode() {
+		childBuilders.exists[willGenerateCode]
 	}
 
 	def package void triggerBeforeAttached(ReactionsFile reactionsFile, Resource targetResource) {
@@ -122,7 +131,7 @@ abstract package class FluentReactionElementBuilder {
 		afterJvmTypeCreation.add([initializer.accept(element)])
 		element
 	}
-
+	
 	def protected delegateTypeProvider() {
 		context.typeProviderFactory.findOrCreateTypeProvider(attachedReactionsFile.eResource.resourceSet)
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilder.xtend
@@ -13,8 +13,8 @@ import tools.vitruv.dsls.reactions.reactionsLanguage.ReactionsLanguageFactory
 /**
  * Entry point for fluent reaction builders. The offered methods each create a 
  * builder for a reactions language element. The builders offer only methods
- * that make sense in the current context and are named to match closely the 
- * reactions language’s syntax of. Because of that, using them should be 
+ * that make sense in the current context and are named to match  the reactions
+ * language’s syntax closely. Because of that, using them should be
  * self-explanatory.
  * 
  * <p>Unlike the builders, this class does not hold any state and can thus be

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsSegmentChildBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsSegmentChildBuilder.xtend
@@ -18,6 +18,10 @@ abstract package class FluentReactionsSegmentChildBuilder extends FluentReaction
 		super(context)
 	}
 
+	override willGenerateCode() {
+		true
+	}
+
 	def protected void transferReactionsSegmentTo(FluentReactionsSegmentChildBuilder infector,
 		FluentReactionsSegmentChildBuilder infected) {
 		infector.beforeAttached[infect(infected)]
@@ -48,8 +52,7 @@ abstract package class FluentReactionsSegmentChildBuilder extends FluentReaction
 		val parameter = method.parameters.findFirst[name == parameterName]
 		if (parameter === null) {
 			// most likely an error by the client
-			throw new IllegalStateException('''Could not find the variable or parameter “«parameterName»” in the «
-				createdElementType» “«createdElementName»”.''')
+			throw new IllegalStateException('''Could not find the variable or parameter “«parameterName»” in the «createdElementType» “«createdElementName»”.''')
 		}
 		return parameter
 	}
@@ -60,8 +63,7 @@ abstract package class FluentReactionsSegmentChildBuilder extends FluentReaction
 		if (method instanceof JvmOperation) {
 			return method
 		}
-		throw new IllegalStateException('''Could not find the method corresponding to “«correpondingExpression
-			»” in the «createdElementType» “«createdElementName»”''')
+		throw new IllegalStateException('''Could not find the method corresponding to “«correpondingExpression»” in the «createdElementType» “«createdElementName»”''')
 	}
 
 	def protected static extractExpressions(XExpression expression) {


### PR DESCRIPTION
Currently, code generation fails if there is a participation for a domain, but no mappings for this domain. This is a valid Commonality (although not a meaningful one) and should not fail the code generation. Hence the fix.

In the future, it would be a nice-to-have to introduce a warning for unused participations.