### PR TITLE
Fix Quickfix Tests

### DIFF
--- a/tests/dsls/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/quickfix/ProjectConversionQuickfixTest.xtend
+++ b/tests/dsls/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/quickfix/ProjectConversionQuickfixTest.xtend
@@ -18,6 +18,7 @@ import static extension tools.vitruv.dsls.common.ui.ProjectAccess.*
 import java.util.List
 import org.eclipse.pde.core.project.IBundleProjectDescription
 import tools.vitruv.dsls.commonalities.testutils.BugFixedAbstractQuickfixTest
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
 
 @DisplayName("quick fixes for project natures")
 @ExtendWith(#[InjectionExtension, TestProjectManager])
@@ -45,6 +46,7 @@ class ProjectConversionQuickfixTest extends BugFixedAbstractQuickfixTest {
 			ProjectValidation.ErrorCodes.NOT_A_PLUGIN_PROJECT,
 			new Quickfix('Convert the project to a plugin project', null, testCommonality)
 		)
+		IResourcesSetupUtil.waitForBuild()
 
 		Assertions.assertTrue(testProject.isPluginProject, "is plugin project")
 		Assertions.assertTrue(
@@ -72,6 +74,7 @@ class ProjectConversionQuickfixTest extends BugFixedAbstractQuickfixTest {
 			ProjectValidation.ErrorCodes.NOT_A_JAVA_PROJECT,
 			new Quickfix('Convert the project to a Java project', null, testCommonality)
 		)
+		IResourcesSetupUtil.waitForBuild()
 
 		Assertions.assertTrue(testProject.isJavaProject, "is Java project")
 	}
@@ -86,11 +89,13 @@ class ProjectConversionQuickfixTest extends BugFixedAbstractQuickfixTest {
 			ProjectValidation.ErrorCodes.NOT_A_JAVA_PROJECT,
 			new Quickfix('Convert the project to a Java project', null, testCommonality)
 		)
+		IResourcesSetupUtil.waitForBuild()
 		testQuickfixesOn(
 			testCommonality,
 			ProjectValidation.ErrorCodes.NOT_A_PLUGIN_PROJECT,
 			new Quickfix('Convert the project to a plugin project', null, testCommonality)
 		)
+		IResourcesSetupUtil.waitForBuild()
 
 		Assertions.assertTrue(testProject.isJavaProject, "is Java project")
 		Assertions.assertTrue(testProject.isPluginProject, "is plugin project")


### PR DESCRIPTION
Like in the other quickfix tests, it seems to be necessary to for wait for some event after performing a quickfix (at least on Windows systems) in the project conversion quickfix tests. Maybe this is only due to some strange timing, but waiting for a project build seems to resolve the problem.
See discussion in #368.