### PR TITLE
Better Model Matching

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelDeepEqualityMatcher.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelDeepEqualityMatcher.xtend
@@ -391,7 +391,7 @@ package class ModelDeepEqualityMatcher extends TypeSafeMatcher<EObject> {
 
 		override <T extends EObject> ifAlreadyPrintedElse(T object, (T, String)=>PrintResult existingPrinter,
 			(T, String)=>PrintResult newPrinter) {
-			delegate.printWithId(replaceWithRight(object)) [ T toPrint, String id |
+			delegate.printWithId(replaceWithRight(object)) [ toPrint, id |
 				if (alreadyPrinted.contains(toPrint)) {
 					existingPrinter.apply(toPrint, id)
 				} else {

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelDeepEqualityMatcher.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelDeepEqualityMatcher.xtend
@@ -168,7 +168,7 @@ package class ModelDeepEqualityMatcher extends TypeSafeMatcher<EObject> {
 		}
 
 		def private void checkMatches(Comparison comparison, EObject left, EObject right) {
-			if (checked.contains(left) && checked.contains(right)) return;
+			if (left === null || right === null || (checked.contains(left) && checked.contains(right))) return;
 			checked += left
 			checked += right
 

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultModelPrinter.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultModelPrinter.xtend
@@ -55,9 +55,9 @@ class DefaultModelPrinter implements ModelPrinter {
 		PrintIdProvider idProvider,
 		EObject object
 	) {
-		target.printObjectWithContent(idProvider, object) [ contentTarget |
-			contentTarget.printIterableElements(object.eClass.EAllStructuralFeatures) [ subTarget, feature |
-				subPrinter.printFeature(subTarget, idProvider, object, feature)
+		target.printObjectWithContent(idProvider, object) [ contentTarget, toPrint |
+			contentTarget.printIterableElements(toPrint.eClass.EAllStructuralFeatures) [ subTarget, feature |
+				subPrinter.printFeature(subTarget, idProvider, toPrint, feature)
 			]
 		]
 	}
@@ -152,7 +152,7 @@ class DefaultModelPrinter implements ModelPrinter {
 		PrintIdProvider idProvider,
 		EObject object
 	) {
-		target.printObjectWithContent(idProvider, object) [ contentTarget |
+		target.printObjectWithContent(idProvider, object) [ contentTarget, _ |
 			contentTarget.print('…')
 		]
 	}
@@ -178,16 +178,16 @@ class DefaultModelPrinter implements ModelPrinter {
 	 * use {@link contentPrinter} to print the object’s content.
 	 */
 	def protected <T extends EObject> printObjectWithContent(PrintTarget target, PrintIdProvider idProvider, T object,
-		(PrintTarget)=>PrintResult contentPrinter) {
-		idProvider.ifAlreadyPrintedElse(object, [target.printAlreadyPrinted(it)]) [ objectId |
-			target.print(objectId) + target.print('(') + contentPrinter.apply(target) + target.print(')')
+		(PrintTarget, T)=>PrintResult contentPrinter) {
+		idProvider.ifAlreadyPrintedElse(object, [obj, id|target.printAlreadyPrinted(obj, id)]) [ toPrint, id |
+			target.print(id) + target.print('(') + contentPrinter.apply(target, toPrint) + target.print(')')
 		]
 	}
 
 	/**
 	 * Called when printing an {@link EObject} that has previously been printed.
 	 */
-	def protected printAlreadyPrinted(extension PrintTarget target, String id) {
+	def protected printAlreadyPrinted(extension PrintTarget target, EObject object, String id) {
 		print(id)
 	}
 

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultModelPrinter.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultModelPrinter.xtend
@@ -89,8 +89,6 @@ class DefaultModelPrinter implements ModelPrinter {
 			} else {
 				subPrinter.printFeatureValueSet(target, idProvider, feature, object.eGet(feature) as Collection<?>)
 			}
-		} else if (!object.eIsSet(feature)) {
-			print('\u2205' /* empty set */ )
 		} else {
 			subPrinter.printFeatureValue(target, idProvider, feature, object.eGet(feature))
 		}
@@ -181,7 +179,7 @@ class DefaultModelPrinter implements ModelPrinter {
 	 */
 	def protected <T extends EObject> printObjectWithContent(PrintTarget target, PrintIdProvider idProvider, T object,
 		(PrintTarget)=>PrintResult contentPrinter) {
-		idProvider.ifAlreadyHasIdElse(object, [target.printAlreadyPrinted(it)]) [ objectId |
+		idProvider.ifAlreadyPrintedElse(object, [target.printAlreadyPrinted(it)]) [ objectId |
 			target.print(objectId) + target.print('(') + contentPrinter.apply(target) + target.print(')')
 		]
 	}

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultPrintIdProvider.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultPrintIdProvider.xtend
@@ -8,15 +8,15 @@ class DefaultPrintIdProvider implements PrintIdProvider {
 	val printed = new HashMap<EObject, String>()
 	val classCount = new HashMap<EClass, Integer>()
 
-	override ifAlreadyPrintedElse(EObject object, (String)=>PrintResult existingPrinter,
-		(String)=>PrintResult newPrinter) {
+	override <T extends EObject> ifAlreadyPrintedElse(T object, (T, String)=>PrintResult existingPrinter,
+		(T, String)=>PrintResult newPrinter) {
 		var objectId = printed.get(object)
 		if (objectId !== null) {
-			existingPrinter.apply(objectId)
+			existingPrinter.apply(object, objectId)
 		} else {
 			objectId = assignId(object)
 			printed.put(object, objectId)
-			newPrinter.apply(objectId)
+			newPrinter.apply(object, objectId)
 		}
 	}
 

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultPrintIdProvider.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultPrintIdProvider.xtend
@@ -1,0 +1,29 @@
+package tools.vitruv.testutils.printing
+
+import java.util.HashMap
+import org.eclipse.emf.ecore.EClass
+import org.eclipse.emf.ecore.EObject
+
+class DefaultPrintIdProvider implements PrintIdProvider {
+	val printed = new HashMap<EObject, String>()
+	val classCount = new HashMap<EClass, Integer>()
+
+	override ifAlreadyPrintedElse(EObject object, (String)=>PrintResult existingPrinter,
+		(String)=>PrintResult newPrinter) {
+		var objectId = printed.get(object)
+		if (objectId !== null) {
+			existingPrinter.apply(objectId)
+		} else {
+			objectId = assignId(object)
+			printed.put(object, objectId)
+			newPrinter.apply(objectId)
+		}
+	}
+
+	def private assignId(EObject object) {
+		val index = classCount.compute(object.eClass) [ key, oldValue |
+			if (oldValue === null) 1 else oldValue + 1
+		]
+		object.eClass.name + if (index == 1) "" else "#" + index
+	}
+}

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/ModelPrinting.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/ModelPrinting.xtend
@@ -93,7 +93,7 @@ final class ModelPrinting {
 	}
 
 	/**
-	 * Makes model printing use the printer provided by {@code printerProvider}.
+	 * Makes model printing use the printer provided by {@code printerProvider}. Replaces the current printer.
 	 * 
 	 * @param printerProvider function that will receive the current model printer and returns the new printer to use.
 	 * @return A closeable that, when closed, will revert the printer change. 
@@ -102,6 +102,17 @@ final class ModelPrinting {
 		val oldPrinter = ModelPrinting.printer
 		ModelPrinting.printer = printerProvider.apply(oldPrinter)
 		return [ModelPrinting.printer = oldPrinter]
+	}
+	
+	/**
+	 * Makes model printing use the provided printers. Installs a printer that will try the provided printers one after
+	 * the other until a responsible printer is found, and fall back to the currently installed printer none of the
+	 * provided printers are responsible.
+	 * 
+	 * @return A closeable that, when closed, will revert the printer change. 
+	 */
+	def static AutoCloseable prepend(ModelPrinter... printers) {
+		use[currentPrinter|new CombinedModelPrinter(printers, currentPrinter)]
 	}
 
 	def private static Description applyAsPrintTarget(Description description, (PrintTarget)=>PrintResult block) {

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/ModelPrinting.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/ModelPrinting.xtend
@@ -69,27 +69,27 @@ final class ModelPrinting {
 	}
 
 	def static appendModelValue(Description description, Object object) {
-		appendModelValue(description, object, new PrintIdProvider)
+		appendModelValue(description, object, new DefaultPrintIdProvider)
 	}
 
 	def static appendModelValueList(Description description, List<?> objects, PrintMode mode) {
-		appendModelValueList(description, objects, mode, new PrintIdProvider)
+		appendModelValueList(description, objects, mode, new DefaultPrintIdProvider)
 	}
 
 	def static appendModelValueSet(Description description, Set<?> objects, PrintMode mode) {
-		appendModelValueSet(description, objects, mode, new PrintIdProvider)
+		appendModelValueSet(description, objects, mode, new DefaultPrintIdProvider)
 	}
 
 	def static appendShortenedModelValue(Description description, Object object) {
-		appendShortenedModelValue(description, object, new PrintIdProvider)
+		appendShortenedModelValue(description, object, new DefaultPrintIdProvider)
 	}
 
 	def static appendShortenedModelValueList(Description description, List<?> objects, PrintMode mode) {
-		appendShortenedModelValueList(description, objects, mode, new PrintIdProvider)
+		appendShortenedModelValueList(description, objects, mode, new DefaultPrintIdProvider)
 	}
 
 	def static appendShortenedModelValueSet(Description description, Set<?> objects, PrintMode mode) {
-		appendShortenedModelValueSet(description, objects, mode, new PrintIdProvider)
+		appendShortenedModelValueSet(description, objects, mode, new DefaultPrintIdProvider)
 	}
 
 	/**

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/PrintIdProvider.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/PrintIdProvider.xtend
@@ -7,9 +7,18 @@ interface PrintIdProvider {
 	 * Uses {@code existingPrinter} to print {@code object} if {@code object} was already printed, and 
 	 * {@code newPrinter} if {@code object} was not printed yet.
 	 * 
-	 * @param existingPrinter a function receiving an identifier for {@code object} and printing {@code object}.
-	 * @param newPrinter a function receiving an identifier for {@code object} and printing {@code object}.
+	 * @param existingPrinter a function receiving an object and its identifier and printing the object.
+	 * @param newPrinter a function receiving an object and its identifier and printing the object.
 	 */
-	def PrintResult ifAlreadyPrintedElse(EObject object, (String)=>PrintResult existingPrinter,
-		(String)=>PrintResult newPrinter)
+	def <T extends EObject> PrintResult ifAlreadyPrintedElse(T object, (T, String)=>PrintResult existingPrinter,
+		(T, String)=>PrintResult newPrinter)
+
+	/**
+	 * Like {@link #ifAlreadyPrintedElse}, but uses {@code printer} in both cases.
+	 * 	 
+	 * @param printer a function receiving an object and its identifier and printing the object.
+	 */
+	def <T extends EObject> PrintResult printWithId(T object, (T, String)=>PrintResult printer) {
+		ifAlreadyPrintedElse(object, printer, printer)
+	}
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/PrintIdProvider.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/PrintIdProvider.xtend
@@ -1,28 +1,15 @@
 package tools.vitruv.testutils.printing
 
-import java.util.HashMap
-import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject
 
-class PrintIdProvider {
-	val printed = new HashMap<EObject, String>()
-	val classCount = new HashMap<EClass, Integer>()
-
-	def ifAlreadyHasIdElse(EObject object, (String)=>PrintResult existingPrinter, (String)=>PrintResult newPrinter) {
-		var objectId = printed.get(object)
-		if (objectId !== null) {
-			existingPrinter.apply(objectId)
-		} else {
-			objectId = assignId(object)
-			printed.put(object, objectId)
-			newPrinter.apply(objectId)
-		}
-	}
-
-	def private assignId(EObject object) {
-		val index = classCount.compute(object.eClass) [ key, oldValue |
-			if (oldValue === null) 1 else oldValue + 1
-		]
-		object.eClass.name + if (index == 1) "" else "#" + index
-	}
+interface PrintIdProvider {
+	/**
+	 * Uses {@code existingPrinter} to print {@code object} if {@code object} was already printed, and 
+	 * {@code newPrinter} if {@code object} was not printed yet.
+	 * 
+	 * @param existingPrinter a function receiving an identifier for {@code object} and printing {@code object}.
+	 * @param newPrinter a function receiving an identifier for {@code object} and printing {@code object}.
+	 */
+	def PrintResult ifAlreadyPrintedElse(EObject object, (String)=>PrintResult existingPrinter,
+		(String)=>PrintResult newPrinter)
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/PrintTarget.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/PrintTarget.xtend
@@ -28,10 +28,12 @@ interface PrintTarget {
 		(PrintTarget, T)=>PrintResult elementPrinter) {
 		printIterable('', '', elements, mode, elementPrinter)
 	}
-	
+
 	def <T> PrintResult printValue(T value, (PrintTarget, T)=>PrintResult valuePrinter) {
 		switch (value) {
-			Number:
+			case null,
+			Number,
+			Boolean:
 				valuePrinter.apply(this, value)
 			String:
 				print('"') + valuePrinter.apply(this, value) + print('"')


### PR DESCRIPTION
This is another series of improvements for `ModelDeepEqualityMatcher`. I fear it will take some more iterations until the matcher works well. While EMF Compare produces nice results if it works well, it does not always work well, and getting it to work well is hard. In detail, this PR:

 * fixes minor bugs
 * matches even more unmatched elements together (it seems to be the better trade-off to match too much)
 * improves how model elements are referenced in the prints so that equal objects can be recognized more easily
 * removes any differences that are caused by objects that cannot be navigated to because of ignored references (this one must be handled carefully, as it could actually lead to false negatives if done wrong)