### PR TITLE
Dispose Virtual Model before Closing a Test View

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
@@ -56,8 +56,8 @@ abstract class VitruvApplicationTest implements CorrespondenceModelContainer, Te
 
 	@AfterEach
 	def final package void closeAfterTest() {
+		virtualModel.dispose()
 		testView?.close()
-		virtualModel.dispose
 	}
 
 	override CorrespondenceModel getCorrespondenceModel() { virtualModel.correspondenceModel }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
@@ -56,7 +56,7 @@ abstract class VitruvApplicationTest implements CorrespondenceModelContainer, Te
 
 	@AfterEach
 	def final package void closeAfterTest() {
-		virtualModel.dispose()
+		virtualModel?.dispose()
 		testView?.close()
 	}
 


### PR DESCRIPTION
Otherwise closing the view may try to delete files which are still loaded in the resource set of the virtual model, potentially leading to access problems.