### PR TITLE
Fix NullPointerException When Generating Code for Referenced Commonality Attributes

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/participation/ParticipationObjectsHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/participation/ParticipationObjectsHelper.xtend
@@ -35,18 +35,19 @@ class ParticipationObjectsHelper extends ReactionsGenerationHelper {
 
 	def XExpression getParticipationObject(ContextClass contextClass, XFeatureCall participationObjects,
 		TypeProvider typeProvider) {
-		return contextClass.name.getParticipationObject(participationObjects, typeProvider)
+		return getParticipationObject(contextClass.participationClass, contextClass.name, participationObjects, typeProvider)
 	}
 
 	def XExpression getParticipationObject(ParticipationClass participationClass, XFeatureCall participationObjects,
 		TypeProvider typeProvider) {
-		return participationClass.name.getParticipationObject(participationObjects, typeProvider)
+		return getParticipationObject(participationClass, participationClass.name, participationObjects, typeProvider)
 	}
 
-	private def XExpression getParticipationObject(String objectName, XFeatureCall participationObjects,
-		TypeProvider typeProvider) {
+	private def XExpression getParticipationObject(ParticipationClass participationClass, String objectName,
+		XFeatureCall participationObjects, TypeProvider typeProvider) {
 		participationObjects.memberFeatureCall => [
 			feature = typeProvider.findDeclaredType(ParticipationObjects).findMethod('getObject', String)
+			typeArguments += typeProvider.jvmTypeReferenceBuilder.typeRef(participationClass.changeClass.javaClassName)
 			memberCallArguments += stringLiteral(objectName)
 			explicitOperationCall = true
 		]

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/reference/ReferenceMappingOperatorHelper.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/reference/ReferenceMappingOperatorHelper.xtend
@@ -20,8 +20,7 @@ import static extension tools.vitruv.dsls.commonalities.generator.reactions.util
 import static extension tools.vitruv.dsls.commonalities.generator.reactions.util.ReactionsHelper.*
 import static extension tools.vitruv.dsls.commonalities.generator.reactions.util.XbaseHelper.*
 import static extension tools.vitruv.dsls.commonalities.language.extensions.CommonalitiesLanguageModelExtensions.*
-import org.eclipse.xtext.common.types.impl.JvmTypeImpl
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtext.common.types.TypesFactory
 
 class ReferenceMappingOperatorHelper extends ReactionsGenerationHelper {
 
@@ -138,7 +137,7 @@ class ReferenceMappingOperatorHelper extends ReactionsGenerationHelper {
 				containerObject,
 				correspondenceModel,
 				XbaseFactory.eINSTANCE.createXTypeLiteral => [
-					type = new UnknownJvmType(intermediateType.javaClassName)
+					type = intermediateType.javaClassName.jvmTypeForQualifiedName
 				]
 			)
 		]
@@ -151,34 +150,26 @@ class ReferenceMappingOperatorHelper extends ReactionsGenerationHelper {
 		val method = attributeReferenceHelperType.findMethod('getPotentialContainerIntermediate')
 		return attributeReferenceHelperType.memberFeatureCall(method) => [
 			staticWithDeclaringType = true
-			typeArguments += jvmTypeReferenceBuilder.typeRef(intermediateType.javaClassName)
+			val typeRef = jvmTypeReferenceBuilder.typeRef(intermediateType.javaClassName)
+			typeArguments += typeRef
 			memberCallArguments += expressions(
 				mapping.constructOperator(operatorContext),
 				containedObject,
 				correspondenceModel,
 				XbaseFactory.eINSTANCE.createXTypeLiteral => [
-					type = new UnknownJvmType(intermediateType.javaClassName)
+					type = intermediateType.javaClassName.jvmTypeForQualifiedName
 				]
 			)
 		]
 	}
-	
-	// Hack to create a XTypeLiteral for an unknown type.
-	// TODO: is there an Xbase-native way to do this? 
-	@FinalFieldsConstructor
-	private static class UnknownJvmType extends JvmTypeImpl {
-		val String fqn
-		
-		override getSimpleName() {
-			fqn.substring(fqn.lastIndexOf('.') + 1)
-		}
-		
-		override getQualifiedName(char innerClassDelimiter) {
-			fqn
-		}
-		
-		override getIdentifier() {
-			simpleName
-		}
+
+	private def getJvmTypeForQualifiedName(String name) {
+		TypesFactory.eINSTANCE.createJvmGenericType => [
+			val simpleNameSeparatorIndex = name.lastIndexOf('.')
+			if (simpleNameSeparatorIndex != -1)
+				packageName = name.substring(0, simpleNameSeparatorIndex)
+			simpleName = name.substring(simpleNameSeparatorIndex + 1)
+		]
 	}
+
 }

--- a/tests/dsls/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/ReferenceMappingOperatorExecutionTest.xtend
+++ b/tests/dsls/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/ReferenceMappingOperatorExecutionTest.xtend
@@ -1,0 +1,54 @@
+package tools.vitruv.dsls.commonalities.tests.execution
+
+import tools.vitruv.testutils.VitruvApplicationTest
+import org.junit.jupiter.api.^extension.ExtendWith
+import org.eclipse.xtext.testing.extensions.InjectionExtension
+import org.eclipse.xtext.testing.InjectWith
+import tools.vitruv.dsls.commonalities.tests.CommonalitiesLanguageInjectorProvider
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.DisplayName
+import tools.vitruv.dsls.commonalities.tests.util.TestCommonalitiesGenerator
+import javax.inject.Inject
+import org.eclipse.xtend.lib.annotations.Accessors
+import tools.vitruv.framework.change.processing.ChangePropagationSpecification
+import org.junit.jupiter.api.BeforeAll
+import tools.vitruv.testutils.TestProject
+import java.nio.file.Path
+import org.junit.jupiter.api.Test
+
+@ExtendWith(InjectionExtension)
+@InjectWith(CommonalitiesLanguageInjectorProvider)
+@TestInstance(PER_CLASS)
+@DisplayName('executing a commonality with attribute mapping operators')
+class ReferenceMappingOperatorExecutionTest extends VitruvApplicationTest {
+	@Inject TestCommonalitiesGenerator generator
+	
+	@Accessors(PROTECTED_GETTER)
+	var Iterable<? extends ChangePropagationSpecification> changePropagationSpecifications
+	
+	@BeforeAll
+	def void generate(@TestProject(variant = "commonalities") Path testProject) {
+		changePropagationSpecifications = generator.generate(testProject,
+			'WithReferenceMappingOperators.commonality' -> '''
+				import tools.vitruv.dsls.commonalities.tests.operators.mock
+				
+				concept operators
+				
+				commonality WithReferenceMappingOperators {
+					with AllElementTypes:(Root in Resource)
+					with AllElementTypes2:(Root2 in Resource)
+				
+					has self referencing operators:WithReferenceMappingOperators {
+						= AllElementTypes:Root.mock(ref Root.singleValuedEAttribute)
+					}
+				}
+			'''
+		)
+	}
+
+	@Test
+	@DisplayName('generates')
+	def void generates() {
+		// TODO validate something if the ref keyword stays, else remove this test
+	}
+}

--- a/tests/dsls/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/operators/MockReferenceMappingOperator.xtend
+++ b/tests/dsls/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/operators/MockReferenceMappingOperator.xtend
@@ -3,12 +3,15 @@ package tools.vitruv.dsls.commonalities.tests.operators
 import tools.vitruv.extensions.dslruntime.commonalities.operators.mapping.reference.IReferenceMappingOperator
 import org.eclipse.emf.ecore.EObject
 import tools.vitruv.extensions.dslruntime.commonalities.operators.mapping.reference.ReferenceMappingOperator
+import tools.vitruv.extensions.dslsruntime.reactions.ReactionExecutionState
 
 @ReferenceMappingOperator(
 	name = "mock",
-	isMultiValued = true
+	isMultiValued = true,
+	isAttributeReference = true
 )
 class MockReferenceMappingOperator implements IReferenceMappingOperator {
+	new(ReactionExecutionState executionState) {}
 	
 	override getContainedObjects(EObject container) {
 		throw new UnsupportedOperationException("This is a mock")

--- a/tests/dsls/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/util/CommonalityParseHelper.xtend
+++ b/tests/dsls/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/util/CommonalityParseHelper.xtend
@@ -12,7 +12,6 @@ import org.eclipse.xtext.testing.validation.ValidationTestHelper
 import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.xtext.resource.XtextResourceSet
 import javax.inject.Provider
-import org.eclipse.xtext.testing.util.ResourceHelper
 
 @Singleton
 class CommonalityParseHelper {


### PR DESCRIPTION
Fixes the exception in https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/pull/100 from me.

I left the unit test I used to reproduce the issue in. The corresponding Commonalities Language features needs to be removed or seriously improved anyway.