### PR TITLE
Ensure that Builders for All Project Domains are Registered

### DIFF
--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/ProjectBuildUtils.java
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/ProjectBuildUtils.java
@@ -98,7 +98,7 @@ public final class ProjectBuildUtils {
 	 */
 	public static boolean hasBuilder(final IProject project, final String builderId) {
 		checkArgument(project != null, "Project must not be null");
-		checkState(project.isOpen(), "Project must be open to be refreshed and built");
+		checkState(project.isOpen(), "Project must be open");
 		try {
 			for (ICommand buildSpec : project.getDescription().getBuildSpec()) {
 				if (builderId.equals(buildSpec.getBuilderName())) {

--- a/bundles/framework/tools.vitruv.framework.vsum.ui/src/tools/vitruv/framework/vsum/ui/util/VitruvInstanceCreator.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum.ui/src/tools/vitruv/framework/vsum/ui/util/VitruvInstanceCreator.xtend
@@ -38,14 +38,13 @@ class VitruvInstanceCreator {
 					VitruvProjectBuilderApplicator.getApplicatorsForVitruvDomain(domain).forEach[
 						setPropagateAfterBuild(true).addBuilder(project, virtualModel.folder, domain.fileExtensions.toSet)
 					]
-					return true
 				} catch (IllegalStateException e) {
 					LOGGER.error('''Could not initialize V-SUM project for project: «project.name»''')
 					return false
 				}
 			}
-
 		}
+		return true
 	}
 
 	private def InternalVirtualModel createVirtualModel(String vsumName) {


### PR DESCRIPTION
Fixes a bug that caused only a single builder to be registered for a project, despite the number of specifies domains in that project.