### PR TITLE
Make Test View Resource Handling Consistent

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/BasicTestView.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/BasicTestView.xtend
@@ -78,7 +78,7 @@ class BasicTestView implements TestView {
 	override <T extends Notifier> List<PropagatedChange> propagate(T notifier, Consumer<T> consumer) {
 		val toSave = determineResource(notifier)
 		notifier.record(consumer)
-		(toSave ?: determineResource(notifier)).save(emptyMap())
+		(toSave ?: determineResource(notifier))?.saveOrDelete()
 		return emptyList()
 	}
 	
@@ -97,6 +97,14 @@ class BasicTestView implements TestView {
 		move(source, target)
 	}
 
+	def private saveOrDelete(Resource resource) {
+		if (resource.contents.isEmpty) {
+			resource.delete(emptyMap)
+		} else {
+			resource.save(emptyMap)
+		}
+	}
+	 
 	override getUri(Path viewRelativePath) {
 		checkArgument(viewRelativePath !== null, "The viewRelativePath must not be null!")
 		checkArgument(!viewRelativePath.isEmpty, "The viewRelativePath must not be empty!")

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/ChangePublishingTestView.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/ChangePublishingTestView.xtend
@@ -19,6 +19,7 @@ import tools.vitruv.framework.change.description.PropagatedChange
 import tools.vitruv.framework.change.description.VitruviusChangeFactory
 import tools.vitruv.framework.vsum.VirtualModel
 import org.eclipse.xtend.lib.annotations.Delegate
+import org.eclipse.emf.ecore.resource.Resource
 
 /**
  * A test view that will record and publish the changes created in it.
@@ -95,7 +96,7 @@ class ChangePublishingTestView implements NonTransactionalTestView {
 	override propagate() {
 		changeRecorder.endRecording()
 		val compositeChange = VitruviusChangeFactory.instance.createCompositeChange(changeRecorder.changes)
-		compositeChange.saveOrDeleteResource
+		compositeChange.changedResource?.saveOrDelete()
 		checkState(compositeChange.validate, "The recorded change set is not valid!")
 		val propagationResult = changeProcessors.flatMap[apply(compositeChange)].toList
 		if (renewResourceCacheAfterPropagation) {
@@ -109,14 +110,11 @@ class ChangePublishingTestView implements NonTransactionalTestView {
 		resourceSet.resources.clear()
 	}
 
-	private def void saveOrDeleteResource(VitruviusChange change) {
-		val changedResource = change.changedResource
-		if (changedResource !== null) {
-			if (changedResource.contents.empty) {
-				changedResource.delete(emptyMap())
-			} else {
-				changedResource.save(emptyMap())
-			}
+	private def void saveOrDelete(Resource resource){
+		if (resource.contents.isEmpty) {
+			resource.delete(emptyMap)
+		} else {
+			resource.save(emptyMap)
 		}
 	}
 


### PR DESCRIPTION
`BasicTestView` was not deleting empty resources, while `ChangePublishingTestView` was. This PR makes both test views act the same.

It would be nicer if `ChangePublishingTestView.propagate` could delegate to `BasicTestView.propagate`, but this is not really possible because of the order of events (`record` has to happen before we stop the recording, but deleting the resource must happen afterwards).