### PR TITLE
UnsetFeaturesHidingModelPrinter to Print Only Set Features

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelDeepEqualityMatcher.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelDeepEqualityMatcher.xtend
@@ -506,13 +506,13 @@ package class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatche
 
 		def private PrintResult printFeatureDifference(extension PrintTarget target, EStructuralFeature feature,
 			String context, Diff difference, Object value) {
-			print(context) //
-			+ (if (difference.match.left !== null) {
-				print(' (') + idProvider.printWithId(difference.match.left)[_, id|print(id)] + print(')')
-			} else {
-				PRINTED_NO_OUTPUT
-			}) + print('.') + print(feature.name) + print(' ') + print(difference.kind.verb) + print(': ') //
-			+ printValue(value) [subTarget, theValue | printFeatureValue(subTarget, idProvider, feature, theValue)]
+			print(context)
+				+ (if (difference.match.left !== null) {
+					print(' (') + idProvider.printWithId(difference.match.left)[_, id|print(id)] + print(')')
+				} else {
+					PRINTED_NO_OUTPUT
+				}) + print('.') + print(feature.name) + print(' ') + print(difference.kind.verb) + print(': ')
+			+ target.printFeatureValue(idProvider, feature, value)
 		}
 
 		def private String getVerb(DifferenceKind kind) {

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/UnsetFeaturesHidingModelPrinter.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/UnsetFeaturesHidingModelPrinter.xtend
@@ -1,0 +1,23 @@
+package tools.vitruv.testutils.printing
+
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.EStructuralFeature
+import static tools.vitruv.testutils.printing.PrintResult.*
+
+class UnsetFeaturesHidingModelPrinter implements ModelPrinter {
+	override PrintResult printFeature(
+		PrintTarget target,
+		PrintIdProvider idProvider,
+		EObject object,
+		EStructuralFeature feature
+	) {
+		if (!object.eIsSet(feature)) 
+			PRINTED_NO_OUTPUT
+	 	else 
+			NOT_RESPONSIBLE
+	}
+	
+	override withSubPrinter(ModelPrinter subPrinter) {
+		this
+	}
+}


### PR DESCRIPTION
When dealing with PCM or, worse, UML, printing all features leads to an unmanageable amount of information.

Also includes a small fix for printing comparisons.