### PR TITLE
Give ModelPrinters the Owning Object of a Value as Context

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelDeepEqualityMatcher.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/matchers/ModelDeepEqualityMatcher.xtend
@@ -413,18 +413,43 @@ package class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatche
 			this
 		}
 
-		override PrintResult printFeature(
-			extension PrintTarget target,
+		override PrintResult printFeatureValue(
+			PrintTarget target,
 			PrintIdProvider idProvider,
 			EObject object,
-			EStructuralFeature feature
+			EStructuralFeature feature,
+			Object value
 		) {
+			printIfIgnored(target, object, feature)
+		}
+		
+		override PrintResult printFeatureValueSet(
+			PrintTarget target,
+			PrintIdProvider idProvider,
+			EObject object,
+			EStructuralFeature feature,
+			Collection<?> values
+		) {
+			printIfIgnored(target, object, feature)
+		}
+		
+		override PrintResult printFeatureValueList(
+			PrintTarget target,
+			PrintIdProvider idProvider,
+			EObject object,
+			EStructuralFeature feature,
+			Collection<?> values
+		) {
+			printIfIgnored(target, object, feature)
+		}
+		
+		def private printIfIgnored(extension PrintTarget target, EObject object, EStructuralFeature feature) {
 			if (featureFilters.exists[!includeFeature(object, feature)]) {
-				print(feature.name) + print('=…')
+				print('…')
 			} else {
 				NOT_RESPONSIBLE
 			}
-		}
+		} 
 	}
 
 	private static class ComparisonAwarePrintIdProvider implements PrintIdProvider {
@@ -511,7 +536,7 @@ package class ModelDeepEqualityMatcher<O extends EObject> extends TypeSafeMatche
 				} else {
 					PRINTED_NO_OUTPUT
 				}) + print('.') + print(feature.name) + print(' ') + print(difference.kind.verb) + print(': ')
-			+ target.printFeatureValue(idProvider, feature, value)
+			+ target.printFeatureValue(idProvider, difference.match.left ?: difference.match.right, feature, value)
 		}
 
 		def private String getVerb(DifferenceKind kind) {

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/CombinedModelPrinter.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/CombinedModelPrinter.xtend
@@ -44,28 +44,31 @@ class CombinedModelPrinter implements ModelPrinter {
 		override printFeatureValueList(
 			PrintTarget target,
 			PrintIdProvider idProvider,
+			EObject object,
 			EStructuralFeature feature,
 			Collection<?> valueList
 		) {
-			useFirstResponsible[printFeatureValueList(target, idProvider, feature, valueList)]
+			useFirstResponsible[printFeatureValueList(target, idProvider, object, feature, valueList)]
 		}
 
 		override printFeatureValueSet(
 			PrintTarget target,
 			PrintIdProvider idProvider,
+			EObject object,
 			EStructuralFeature feature,
 			Collection<?> valueSet
 		) {
-			useFirstResponsible[printFeatureValueSet(target, idProvider, feature, valueSet)]
+			useFirstResponsible[printFeatureValueSet(target, idProvider, object, feature, valueSet)]
 		}
 
 		override PrintResult printFeatureValue(
 			PrintTarget target,
 			PrintIdProvider idProvider,
+			EObject object,
 			EStructuralFeature feature,
 			Object value
 		) {
-			useFirstResponsible[printFeatureValue(target, idProvider, feature, value)]
+			useFirstResponsible[printFeatureValue(target, idProvider, object, feature, value)]
 		}
 
 		override withSubPrinter(ModelPrinter subPrinter) {

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultModelPrinter.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/DefaultModelPrinter.xtend
@@ -85,12 +85,12 @@ class DefaultModelPrinter implements ModelPrinter {
 		return print(feature.name) + print('=') + //
 		if (feature.isMany) {
 			if (feature.isOrdered) {
-				subPrinter.printFeatureValueList(target, idProvider, feature, object.eGet(feature) as Collection<?>)
+				subPrinter.printFeatureValueList(target, idProvider, object, feature, object.eGet(feature) as Collection<?>)
 			} else {
-				subPrinter.printFeatureValueSet(target, idProvider, feature, object.eGet(feature) as Collection<?>)
+				subPrinter.printFeatureValueSet(target, idProvider, object, feature, object.eGet(feature) as Collection<?>)
 			}
 		} else {
-			subPrinter.printFeatureValue(target, idProvider, feature, object.eGet(feature))
+			subPrinter.printFeatureValue(target, idProvider, object, feature, object.eGet(feature))
 		}
 	}
 
@@ -104,28 +104,31 @@ class DefaultModelPrinter implements ModelPrinter {
 	override printFeatureValueList(
 		PrintTarget target,
 		PrintIdProvider idProvider,
+		EObject object,
 		EStructuralFeature feature,
 		Collection<?> valueList
 	) {
 		target.printList(valueList) [ subTarget, element |
-			subPrinter.printFeatureValue(subTarget, idProvider, feature, element)
+			subPrinter.printFeatureValue(subTarget, idProvider, object, feature, element)
 		]
 	}
 
 	override printFeatureValueSet(
 		PrintTarget target,
 		PrintIdProvider idProvider,
+		EObject object,
 		EStructuralFeature feature,
 		Collection<?> valueSet
 	) {
 		target.printSet(valueSet) [ subTarget, element |
-			subPrinter.printFeatureValue(subTarget, idProvider, feature, element)
+			subPrinter.printFeatureValue(subTarget, idProvider, object, feature, element)
 		]
 	}
 
 	override PrintResult printFeatureValue(
 		PrintTarget target,
 		PrintIdProvider idProvider,
+		EObject object,
 		EStructuralFeature feature,
 		Object value
 	) {

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/ModelPrinter.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/printing/ModelPrinter.xtend
@@ -58,6 +58,7 @@ interface ModelPrinter {
 	def printFeatureValueList(
 		PrintTarget target,
 		PrintIdProvider idProvider,
+		EObject object,
 		EStructuralFeature feature,
 		Collection<?> valueList
 	) {
@@ -70,6 +71,7 @@ interface ModelPrinter {
 	def printFeatureValueSet(
 		PrintTarget target,
 		PrintIdProvider idProvider,
+		EObject object,
 		EStructuralFeature feature,
 		Collection<?> valueSet
 	) {
@@ -82,6 +84,7 @@ interface ModelPrinter {
 	def PrintResult printFeatureValue(
 		PrintTarget target,
 		PrintIdProvider idProvider,
+		EObject object,
 		EStructuralFeature feature,
 		Object value
 	) {

--- a/tests/dsls/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/util/CommonalitiesLanguageElementsPrinter.xtend
+++ b/tests/dsls/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/util/CommonalitiesLanguageElementsPrinter.xtend
@@ -11,6 +11,7 @@ import tools.vitruv.dsls.commonalities.language.Commonality
 import static extension tools.vitruv.testutils.printing.PrintResultExtension.*
 import tools.vitruv.dsls.commonalities.language.elements.EFeatureAdapter
 import tools.vitruv.testutils.printing.PrintResult
+import org.eclipse.emf.ecore.EObject
 
 class CommonalitiesLanguageElementsPrinter implements ModelPrinter {
 	override printObject(PrintTarget target, PrintIdProvider idProvider, Object object) {
@@ -31,6 +32,7 @@ class CommonalitiesLanguageElementsPrinter implements ModelPrinter {
 	override printFeatureValue(
 		PrintTarget target,
 		PrintIdProvider idProvider,
+		EObject object,
 		EStructuralFeature feature,
 		Object value
 	) {


### PR DESCRIPTION
This allows better reporting in the CBS applications tests.