### PR TITLE
Remove Duplicate Adapter Removal

### DIFF
--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
@@ -337,13 +337,11 @@ class ResourceRepositoryImpl implements ModelRepository, CorrespondenceProviding
 	override Resource getModelResource(VURI vuri) {
 		getModelInstanceOriginal(vuri).resource
 	}
-	
+
 	def dispose() {
 		resourceSet.transactionalEditingDomain?.dispose
-		resourceSet.resources.forEach[
-			allContents.forEach[eAdapters.clear]
-			unload
-		]
+		resourceSet.resources.forEach[unload]
 		resourceSet.resources.clear
 	}
+
 }


### PR DESCRIPTION
Disposing the `ResourceSetImpl` unnecessarily cleared the adapters of each object, although `unload` does that anyway.
Under specific conditions, this can lead to concurrent modifications of the resource list and thus a `ConcurrentModificationExeception` in the iterator.
This PR simply removes the duplicate adapter removal.