### PR TITLE
Close OutputStream in DomainAwareResourceSetTests

### DIFF
--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/repository/DomainAwareResourceSetTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/repository/DomainAwareResourceSetTest.xtend
@@ -38,7 +38,7 @@ class DomainAwareResourceSetTest {
 		resourceFactoryRegistry = new TestResource.Factory.Registry
 		awareOfDomains(TestDomain.repository)
 	]
-	
+
 	@BeforeAll
 	def static void writeResourceToLoad(@TestProject Path testProject) {
 		aetResourceUri = URI.createFileURI(testProject.resolve("example".allElementTypes).toString)
@@ -54,32 +54,32 @@ class DomainAwareResourceSetTest {
 			]
 		]
 	}
-	
+
 	@BeforeEach
 	def void resetTestObjects() {
 		TestResource.lastLoadOptions = null
-		TestResource.lastSaveOptions = null	
+		TestResource.lastSaveOptions = null
 		TestDomain.instance.defaultLoadOptions = emptyMap
 		TestDomain.instance.defaultSaveOptions = emptyMap
 	}
-	
+
 	@Test
 	@DisplayName("does not affect load options for other domains")
 	def void noInfluenceOnLoadingOtherDomains() {
 		domainAwareResourceSet.getResource(aet2ResourceUri, true)
 		assertThat(TestResource.lastLoadOptions, is(<Object, Object>emptyMap))
-		
+
 		domainAwareResourceSet.getEObject(aet2ResourceUri.appendFragment('/'), true)
 		assertThat(TestResource.lastLoadOptions, is(<Object, Object>emptyMap))
-		
+
 		domainAwareResourceSet.createResource(aet2ResourceUri).load(emptyMap)
 		assertThat(TestResource.lastLoadOptions, is(<Object, Object>emptyMap))
-		
+
 		val contentStream = domainAwareResourceSet.URIConverter.createInputStream(aet2ResourceUri)
 		domainAwareResourceSet.createResource(aet2ResourceUri).load(contentStream, emptyMap)
 		assertThat(TestResource.lastLoadOptions, is(<Object, Object>emptyMap))
 	}
-	
+
 	@Test
 	@DisplayName("does not affect save options for other domains")
 	def void noInfluenceOnSavingOtherDomains() {
@@ -88,94 +88,94 @@ class DomainAwareResourceSetTest {
 			save(emptyMap)
 		]
 		assertThat(TestResource.lastSaveOptions, is(<Object, Object>emptyMap))
-		
-		val outputStream = domainAwareResourceSet.URIConverter.createOutputStream(aetResourceUri)
-		domainAwareResourceSet.createResource(aet2ResourceUri) => [
-			contents += aet2.Root2
-			save(outputStream, emptyMap)
-		]
-		outputStream.close
-		
+
+		try(val outputStream = domainAwareResourceSet.URIConverter.createOutputStream(aetResourceUri)) {
+			domainAwareResourceSet.createResource(aet2ResourceUri) => [
+				contents += aet2.Root2
+				save(outputStream, emptyMap)
+			]
+		}
+
 		assertThat(TestResource.lastSaveOptions, is(<Object, Object>emptyMap))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain load options when loading through ResourceSet#getResource")
 	def void loadThroughResourceSetGetResource() {
 		TestDomain.instance.defaultLoadOptions = Map.of("key1", 1)
-		domainAwareResourceSet.getResource(aetResourceUri, true)	
-		
+		domainAwareResourceSet.getResource(aetResourceUri, true)
+
 		assertThat(TestResource.lastLoadOptions, is(Map.of("key1", 1)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain load options and resource set default load options when loading through ResourceSet#getResource")
 	def void loadThroughResourceSetGetResourceWithResourceSetDefault() {
 		TestDomain.instance.defaultLoadOptions = Map.of("key1", 1, "commonKey", 2)
 		domainAwareResourceSet.loadOptions += Map.of("commonKey", "overridden", "key2", 2)
-		domainAwareResourceSet.getResource(aetResourceUri, true)	
-		
+		domainAwareResourceSet.getResource(aetResourceUri, true)
+
 		assertThat(TestResource.lastLoadOptions, is(Map.of("key1", 1, "commonKey", "overridden", "key2", 2)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain load options when loading through ResourceSet#getEObject")
 	def void loadThroughResourceSetGetEObject() {
 		TestDomain.instance.defaultLoadOptions = Map.of("key1", 1)
 		domainAwareResourceSet.getEObject(aetResourceUri.appendFragment('/'), true)
-		
+
 		assertThat(TestResource.lastLoadOptions, is(Map.of("key1", 1)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain load options and resource set default load options when loading through ResourceSet#getEObject")
 	def void loadThroughResourceSetGetEObjectWithResourceSetDefault() {
 		TestDomain.instance.defaultLoadOptions = Map.of("key1", 1, "commonKey", 2)
 		domainAwareResourceSet.loadOptions += Map.of("commonKey", "overridden", "key2", 2)
 		domainAwareResourceSet.getEObject(aetResourceUri.appendFragment('/'), true)
-		
+
 		assertThat(TestResource.lastLoadOptions, is(Map.of("key1", 1, "commonKey", "overridden", "key2", 2)))
 	}
-		
+
 	@Test
 	@DisplayName("respects domain load options when loading through Resource#load")
 	def void loadThroughResourceLoad() {
 		TestDomain.instance.defaultLoadOptions = Map.of("key1", 1)
 		domainAwareResourceSet.createResource(aetResourceUri).load(emptyMap)
-		
+
 		assertThat(TestResource.lastLoadOptions, is(Map.of("key1", 1)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain load options and direct options when loading through Resource#load")
 	def void loadThroughResourceLoadWithDirectOptions() {
 		TestDomain.instance.defaultLoadOptions = Map.of("key1", 1, "commonKey", 2)
 		domainAwareResourceSet.createResource(aetResourceUri).load(Map.of("commonKey", "overridden", "key2", 2))
-		
+
 		assertThat(TestResource.lastLoadOptions, is(Map.of("key1", 1, "commonKey", "overridden", "key2", 2)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain load options when loading through Resource#load with an input stream")
 	def void loadThroughResourceLoadInputStream() {
 		TestDomain.instance.defaultLoadOptions = Map.of("key1", 1)
 		val contentStream = domainAwareResourceSet.URIConverter.createInputStream(aetResourceUri)
 		domainAwareResourceSet.createResource(aetResourceUri).load(contentStream, emptyMap)
-		
+
 		assertThat(TestResource.lastLoadOptions, is(Map.of("key1", 1)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain load options and direct options when loading through Resource#load with an input stream")
 	def void loadThroughResourceLoadInpputStreamWithDirectOptions() {
 		TestDomain.instance.defaultLoadOptions = Map.of("key1", 1, "commonKey", 2)
 		val contentStream = domainAwareResourceSet.URIConverter.createInputStream(aetResourceUri)
-		domainAwareResourceSet.createResource(aetResourceUri)
-			.load(contentStream, Map.of("commonKey", "overridden", "key2", 2))
-		
+		domainAwareResourceSet.createResource(aetResourceUri).load(contentStream,
+			Map.of("commonKey", "overridden", "key2", 2))
+
 		assertThat(TestResource.lastLoadOptions, is(Map.of("key1", 1, "commonKey", "overridden", "key2", 2)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain save options when saving through Resource#save")
 	def void saveThroughResourceSave() {
@@ -184,10 +184,10 @@ class DomainAwareResourceSetTest {
 			contents += aet.Root
 			save(emptyMap)
 		]
-		
+
 		assertThat(TestResource.lastSaveOptions, is(Map.of("key1", 1)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain save options and direct options when saving through Resource#save")
 	def void saveThroughResourceSaveWithDirectOptions() {
@@ -196,38 +196,38 @@ class DomainAwareResourceSetTest {
 			contents += aet.Root
 			save(Map.of("commonKey", "overridden", "key2", 2))
 		]
-		
+
 		assertThat(TestResource.lastSaveOptions, is(Map.of("key1", 1, "commonKey", "overridden", "key2", 2)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain save options when saving through Resource#save with an OutputStream")
 	def void saveThroughResourceSaveWithOutputStream() {
 		TestDomain.instance.defaultSaveOptions = Map.of("key1", 1)
-		val outputStream = domainAwareResourceSet.URIConverter.createOutputStream(aetResourceUri)
-		domainAwareResourceSet.createResource(aetResourceUri) => [
-			contents += aet.Root
-			save(outputStream, emptyMap)
-		]
-		outputStream.close
-		
+		try(val outputStream = domainAwareResourceSet.URIConverter.createOutputStream(aetResourceUri)) {
+			domainAwareResourceSet.createResource(aetResourceUri) => [
+				contents += aet.Root
+				save(outputStream, emptyMap)
+			]
+		}
+
 		assertThat(TestResource.lastSaveOptions, is(Map.of("key1", 1)))
 	}
-	
+
 	@Test
 	@DisplayName("respects domain save options and direct options when saving through Resource#save with an OutputStream")
 	def void saveThroughResourceSaveWithOutputStreamWithDirectOptions() {
 		TestDomain.instance.defaultSaveOptions = Map.of("key1", 1)
-		val outputStream = domainAwareResourceSet.URIConverter.createOutputStream(aetResourceUri)
-		domainAwareResourceSet.createResource(aetResourceUri) => [
-			contents += aet.Root
-			save(outputStream, Map.of("commonKey", "overridden", "key2", 2))
-		]
-		outputStream.close
-		
+		try(val outputStream = domainAwareResourceSet.URIConverter.createOutputStream(aetResourceUri)) {
+			domainAwareResourceSet.createResource(aetResourceUri) => [
+				contents += aet.Root
+				save(outputStream, Map.of("commonKey", "overridden", "key2", 2))
+			]
+		}
+
 		assertThat(TestResource.lastSaveOptions, is(Map.of("key1", 1, "commonKey", "overridden", "key2", 2)))
 	}
-	
+
 	static class TestDomain implements VitruvDomain {
 		static val instance = new TestDomain
 		static val repository = new VitruvDomainRepositoryImpl(List.of(instance))
@@ -237,48 +237,48 @@ class DomainAwareResourceSetTest {
 		var Map<Object, Object> defaultSaveOptions
 		@Delegate val VitruvDomain delegate = aet.domain
 	}
-	
+
 	static class TestResource implements Resource.Internal {
 		@Delegate val Resource.Internal delegate
 		static var Map<?, ?> lastLoadOptions
 		static var Map<?, ?> lastSaveOptions
-		
-		new (URI uri) {
+
+		new(URI uri) {
 			delegate = new XMIResourceImpl(uri)
 		}
-		
+
 		override load(Map<?, ?> options) throws IOException {
 			lastLoadOptions = options
 			delegate.load(options)
 		}
-		
+
 		override load(InputStream inputStream, Map<?, ?> options) throws IOException {
 			lastLoadOptions = options
 			delegate.load(inputStream, options)
 		}
-		
+
 		override save(Map<?, ?> options) {
 			lastSaveOptions = options
 			delegate.save(options)
 		}
-		
+
 		override save(OutputStream outputStream, Map<?, ?> options) {
 			lastSaveOptions = options
 			delegate.save(outputStream, options)
 		}
-		
+
 		static class Factory implements Resource.Factory {
 			override createResource(URI uri) {
 				new TestResource(uri)
 			}
-			
+
 			static class Registry implements Resource.Factory.Registry {
 				@Delegate val Resource.Factory.Registry delegate = Resource.Factory.Registry.INSTANCE
-				
+
 				override getFactory(URI uri) {
 					new TestResource.Factory
 				}
-				
+
 				override getFactory(URI uri, String contentType) {
 					new TestResource.Factory
 				}

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/repository/DomainAwareResourceSetTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/repository/DomainAwareResourceSetTest.xtend
@@ -94,6 +94,8 @@ class DomainAwareResourceSetTest {
 			contents += aet2.Root2
 			save(outputStream, emptyMap)
 		]
+		outputStream.close
+		
 		assertThat(TestResource.lastSaveOptions, is(<Object, Object>emptyMap))
 	}
 	
@@ -207,6 +209,7 @@ class DomainAwareResourceSetTest {
 			contents += aet.Root
 			save(outputStream, emptyMap)
 		]
+		outputStream.close
 		
 		assertThat(TestResource.lastSaveOptions, is(Map.of("key1", 1)))
 	}
@@ -220,6 +223,7 @@ class DomainAwareResourceSetTest {
 			contents += aet.Root
 			save(outputStream, Map.of("commonKey", "overridden", "key2", 2))
 		]
+		outputStream.close
 		
 		assertThat(TestResource.lastSaveOptions, is(Map.of("key1", 1, "commonKey", "overridden", "key2", 2)))
 	}


### PR DESCRIPTION
Avoids file access exceptions on Windows systems due to unclosed `OutputStream`s in tests.