### PR TITLE
Improve the Test Logging Setup

### DIFF
--- a/bundles/domains/tools.vitruv.domains.emf.ui/src/tools/vitruv/domains/emf/builder/VitruvEmfBuilder.java
+++ b/bundles/domains/tools.vitruv.domains.emf.ui/src/tools/vitruv/domains/emf/builder/VitruvEmfBuilder.java
@@ -30,7 +30,7 @@ import tools.vitruv.framework.util.datatypes.VURI;
 
 public class VitruvEmfBuilder extends VitruvProjectBuilder {
 	public static final String BUILDER_ID = "tools.vitruv.domains.emf.builder.VitruvEmfBuilder.id";
-    private static final Logger LOGGER = Logger.getLogger(VitruvEmfBuilder.class.getSimpleName());
+    private static final Logger LOGGER = Logger.getLogger(VitruvEmfBuilder.class);
 
     private final VitruviusEMFDeltaVisitor vitruviusEMFDeltaVisitor;
 

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.mappings/src/tools/vitruv/extensions/dslsruntime/mappings/impl/HashMapCandidatesAndInstanceHalvesRegistry.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.mappings/src/tools/vitruv/extensions/dslsruntime/mappings/impl/HashMapCandidatesAndInstanceHalvesRegistry.xtend
@@ -14,7 +14,7 @@ import tools.vitruv.extensions.dslsruntime.mappings.interfaces.IMappingInstanceH
  * mapping instantiation and each mapping instantiation candidate.
  */
 class HashMapCandidatesAndInstanceHalvesRegistry<H extends IMappingInstanceHalf> {
-	static extension Logger LOGGER = Logger.getLogger(HashMapCandidatesAndInstanceHalvesRegistry.getSimpleName())
+	static extension Logger LOGGER = Logger.getLogger(HashMapCandidatesAndInstanceHalvesRegistry)
 	val String mappingName
 	val String sideName
 	val Map<List<EObject>,H> candidatesRegistry = newHashMap()

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
@@ -42,7 +42,7 @@ import tools.vitruv.framework.util.command.CommandCreatorAndExecutor
 
 // TODO move all methods that don't need direct instance variable access to some kind of util class
 class InternalCorrespondenceModelImpl extends ModelInstance implements InternalCorrespondenceModel, TuidUpdateListener {
-	static final Logger logger = Logger::getLogger(typeof(InternalCorrespondenceModelImpl).getSimpleName())
+	static val logger = Logger.getLogger(InternalCorrespondenceModelImpl)
 	final CommandCreatorAndExecutor modelCommandExecutor
 	final VitruvDomainRepository domainRepository;
 	final Correspondences correspondences

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/VitruviusRecordingCommand.java
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/command/VitruviusRecordingCommand.java
@@ -15,7 +15,7 @@ import tools.vitruv.framework.util.bridges.JavaBridge;
 
 public abstract class VitruviusRecordingCommand extends RecordingCommand implements Command {
 
-	protected static final Logger logger = Logger.getLogger(VitruviusRecordingCommand.class.getSimpleName());
+	protected static final Logger logger = Logger.getLogger(VitruviusRecordingCommand.class);
 
 	private RuntimeException runtimeException;
 	private TransactionalEditingDomain domain;

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/datatypes/ModelInstance.java
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/datatypes/ModelInstance.java
@@ -14,7 +14,7 @@ import tools.vitruv.framework.util.ResourceSetUtil;
 import tools.vitruv.framework.util.bridges.EcoreResourceBridge;
 
 public class ModelInstance extends AbstractURIHaving {
-	private static final Logger LOGGER = Logger.getLogger(ModelInstance.class.getSimpleName());
+	private static final Logger LOGGER = Logger.getLogger(ModelInstance.class);
 	private Resource resource;
 
 	public ModelInstance(final VURI uri, final Resource resource) {

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
@@ -37,7 +37,7 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import tools.vitruv.framework.vsum.helper.VsumFileSystemLayout
 
 class ResourceRepositoryImpl implements ModelRepository {
-	static val logger = Logger.getLogger(ResourceRepositoryImpl.simpleName)
+	static val logger = Logger.getLogger(ResourceRepositoryImpl)
 	val ResourceSet resourceSet
 	val VitruvDomainRepository domainRepository
 	val Map<VURI, ModelInstance> modelInstances = new HashMap()

--- a/bundles/testutils/tools.vitruv.testutils/META-INF/MANIFEST.MF
+++ b/bundles/testutils/tools.vitruv.testutils/META-INF/MANIFEST.MF
@@ -17,7 +17,10 @@ Require-Bundle: tools.vitruv.framework.vsum;visibility:=reexport,
  org.eclipse.emf.compare,
  org.eclipse.emf.compare.rcp,
  org.junit.jupiter.params,
- org.eclipse.xtext.ui.testing
+ org.eclipse.xtext.ui.testing,
+ org.slf4j.api,
+ ch.qos.logback.classic,
+ ch.qos.logback.core
 Export-Package: tools.vitruv.testutils,
  tools.vitruv.testutils.activeannotations,
  tools.vitruv.testutils.change.processing,

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestLogging.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestLogging.xtend
@@ -1,43 +1,92 @@
 package tools.vitruv.testutils
 
-import org.junit.jupiter.api.^extension.BeforeAllCallback
-import org.junit.jupiter.api.^extension.ExtensionContext
-
-import static org.apache.log4j.Level.*
-import static org.apache.log4j.Logger.getLogger
-import static org.apache.log4j.Logger.getRootLogger
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
+import edu.kit.ipd.sdq.activextendannotations.Lazy
 import org.apache.log4j.ConsoleAppender
 import org.apache.log4j.PatternLayout
+import org.junit.jupiter.api.^extension.BeforeAllCallback
+import org.junit.jupiter.api.^extension.ExtensionContext
+import org.slf4j.LoggerFactory
+
+import static org.apache.log4j.Level.*
+import static org.apache.log4j.Logger.getRootLogger
+import static org.slf4j.Logger.ROOT_LOGGER_NAME
+
+import static extension org.apache.log4j.Logger.getLogger
 import tools.vitruv.framework.tuid.TuidManager
 import tools.vitruv.framework.tuid.TuidCalculatorAndResolverBase
+import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
+import java.util.List
 
 /** 
- * Initializes console logger for tests. Sets the logger level to{@link Level#ERROR} by default. If the VM property
- * <i>logOutputLevel</i> is specified, it is used to determine the logger level.
+ * Initializes console logger for tests. Sets the logger level to {@code WARN} by default. If the VM property
+ * {@link VM_ARGUMENT_LOG_LEVEL} is specified, it is used to determine the logger level.
  */
 class TestLogging implements BeforeAllCallback {
-	static val VM_ARGUMENT_LOG_OUTPUT_LEVEL = "logOutputLevel"
-	static val VM_ARGUMENT_LOG_OUTPUT_ID_INFO = "logOutputIdInfo"
+	@Lazy static val String desiredLogLevel = System.getProperty(VM_ARGUMENT_LOG_LEVEL) ?: "WARN"
+	/**
+	 * The default root log level. Defaults to {@link Level#WARN}. 
+	 */
+	public static val VM_ARGUMENT_LOG_LEVEL = "vitruv.logLevel"
+	public static val VM_ARGUMENT_ENABLE_ID_LOGGERS = "vitruv.enableIdLoggers"
+	static val LOG_PATTERN = "%d{HH:mm:ss.SSS} [%35.35c{1}] %5p: %m%n"
+	static val VITRUV_LOG_ROOTS = List.of("tools.vitruv", "mir.reactions", "mir.routines")
 
 	override beforeAll(ExtensionContext context) throws Exception {
-		rootLogger.removeAllAppenders()
-		rootLogger.addAppender(new ConsoleAppender(new PatternLayout("[%-5p] %d{HH:mm:ss,SSS} %-30C{1} - %m%n")))
-		var outputLevelProperty = System.getProperty(VM_ARGUMENT_LOG_OUTPUT_LEVEL)
-		if (outputLevelProperty !== null) {
-			if (!rootLogger.allAppenders.hasMoreElements()) {
-				rootLogger.addAppender(new ConsoleAppender())
-			}
-			rootLogger.level = toLevel(outputLevelProperty)
-		} else {
-			rootLogger.level = ERROR
+		configureLog4J()
+		
+		// Vitruv currently (2021-02-12) doesn’t use slf4j. So we only want to configure it if it is on the classpath,
+		// without forcing clients to have it on the classpath.
+		val logbackAvailable = try {
+			ch.qos.logback.classic.Logger.name
+			LoggerFactory.name
+			true
+		} catch (ClassNotFoundException | NoClassDefFoundError e) {
+			false
 		}
-		var String outputIdInfoProperty = System.getProperty(VM_ARGUMENT_LOG_OUTPUT_ID_INFO)
-		if (outputIdInfoProperty === null) {
-			getLogger(typeof(TuidManager)).level = OFF
-			getLogger(typeof(TuidCalculatorAndResolverBase)).level = OFF
-			getLogger(typeof(UuidGeneratorAndResolverImpl)).level = OFF
+		if (logbackAvailable) {
+			new LogbackConfiguration().apply()
 		}
 	}
-
+	
+	def private static configureLog4J() {
+		rootLogger.removeAllAppenders()
+		rootLogger.addAppender(new ConsoleAppender(new PatternLayout(LOG_PATTERN)))
+		rootLogger.level = ERROR
+		VITRUV_LOG_ROOTS.forEach [logger.level = toLevel(desiredLogLevel, WARN)]
+		if (System.getProperty(VM_ARGUMENT_ENABLE_ID_LOGGERS) != "true") {
+			TuidManager.logger.level = ERROR
+			TuidCalculatorAndResolverBase.logger.level = OFF
+			UuidGeneratorAndResolverImpl.logger.level = ERROR
+		}	
+		TestProjectManager.logger.level = INFO
+	}
+	
+	// must be its own class so that the logback types are not required when loading the parent class
+	private static class LogbackConfiguration {
+		def void apply() {
+			val root = LoggerFactory.ILoggerFactory.getLogger(ROOT_LOGGER_NAME)
+			if (root instanceof ch.qos.logback.classic.Logger) {
+				val consoleAppender = new ch.qos.logback.core.ConsoleAppender => [
+					name = "console"
+					context = root.loggerContext
+					encoder = new PatternLayoutEncoder => [
+						context = root.loggerContext
+						pattern = LOG_PATTERN
+						start()
+					]
+					start()
+				]
+				root.detachAndStopAllAppenders()
+				root.level = Level.toLevel(desiredLogLevel, Level.WARN)
+				root.addAppender(consoleAppender)
+				// there are currently (2021-02-12) no Vitruv loggers, but let's set this up anyway to be prepared
+				VITRUV_LOG_ROOTS.forEach [
+				(LoggerFactory.ILoggerFactory.getLogger(it) as ch.qos.logback.classic.Logger)
+					.level = Level.toLevel(desiredLogLevel, Level.WARN)
+				]
+			}
+		}
+	}
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestProjectManager.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestProjectManager.xtend
@@ -18,7 +18,6 @@ import static java.nio.file.Files.createDirectories
 import static java.nio.file.Files.createDirectory
 import static java.nio.file.Files.walk
 import static java.util.Comparator.reverseOrder
-import static org.apache.log4j.Level.INFO
 import static tools.vitruv.framework.util.VitruviusConstants.getTestProjectMarkerFileName
 import java.util.regex.Pattern
 import org.eclipse.core.resources.ResourcesPlugin
@@ -46,7 +45,7 @@ class TestProjectManager implements ParameterResolver, AfterEachCallback {
 	 * Set this system property to overwrite the workspace path 
 	 */
 	public static val WORKSPACE_PATH_SYSTEM_PROPERTY = "vitruv.workspace"
-	static val log = Logger.getLogger(TestProjectManager) => [level = INFO]
+	static val log = Logger.getLogger(TestProjectManager)
 	static val namespace = ExtensionContext.Namespace.create(TestProjectManager)
 	static val observedFailure = "observedFailure"
 	static val projectNamespace = ExtensionContext.Namespace.create(TestProjectManager, "projects")

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
@@ -18,7 +18,7 @@ import tools.vitruv.framework.vsum.VirtualModelBuilder
 import tools.vitruv.framework.domains.repository.VitruvDomainRepository
 import tools.vitruv.framework.domains.repository.VitruvDomainRepositoryImpl
 
-@ExtendWith(TestProjectManager, TestLogging)
+@ExtendWith(TestLogging, TestProjectManager)
 abstract class VitruvApplicationTest implements CorrespondenceModelContainer, TestView {
 	InternalVirtualModel virtualModel
 	@Delegate

--- a/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/CorrespondenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/CorrespondenceTest.xtend
@@ -25,7 +25,7 @@ import static extension tools.vitruv.framework.correspondence.CorrespondenceMode
 import org.junit.jupiter.api.Test
 
 class CorrespondenceTest extends VsumTest {
-	static final Logger LOGGER = Logger.getLogger(CorrespondenceTest.getSimpleName())
+	static final Logger LOGGER = Logger.getLogger(CorrespondenceTest)
 
 	@Test
 	def void testAllInCommand() {

--- a/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/TuidCacheTest.java
+++ b/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/TuidCacheTest.java
@@ -35,7 +35,7 @@ import tools.vitruv.testutils.TestLogging;
  */
 @ExtendWith({TestLogging.class, RegisterMetamodelsInStandalone.class})
 public class TuidCacheTest {
-	private static final Logger LOGGER = Logger.getLogger(TuidCacheTest.class.getSimpleName());
+	private static final Logger LOGGER = Logger.getLogger(TuidCacheTest.class);
 
 	List<File> filesToDelete = new ArrayList<>();
 

--- a/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/VsumFileSystemLayoutTest.java
+++ b/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/VsumFileSystemLayoutTest.java
@@ -10,7 +10,7 @@ import tools.vitruv.framework.util.datatypes.VURI;
 import tools.vitruv.framework.vsum.helper.VsumFileSystemLayout;
 
 public class VsumFileSystemLayoutTest extends VsumTest {
-	private static final Logger logger = Logger.getLogger(VsumFileSystemLayoutTest.class.getSimpleName());
+	private static final Logger logger = Logger.getLogger(VsumFileSystemLayoutTest.class);
 
 	@Test
 	public void testSaveAndLoadVURIs() throws IOException {


### PR DESCRIPTION
 * fix that some classes didn’t use their fully qualified name as logger name (thus circumventing the logger hierarchy)
 * also setup logback to mute info messages from other plugins
 * report the logger name (`c`) instead of the calling class (`C`) because:
    * it’s usually more relevant to know which class contains the logging code, and not what the dynamic type of the instance was
    * determining the calling class is expensive.
 * change the layout to have the log level directly before the message (allows to skip the constant part of the log line) 
 * set the default level to `WARN` because `ERROR` can easily hide bugs