### PR TITLE
UuidGeneratorAndResolver Non-Strict Mode Removal

### DIFF
--- a/bundles/domains/tools.vitruv.domains.emf.ui/src/tools/vitruv/domains/emf/monitorededitor/monitor/EMFModelChangeRecordingEditorSaveListener.java
+++ b/bundles/domains/tools.vitruv.domains.emf.ui/src/tools/vitruv/domains/emf/monitorededitor/monitor/EMFModelChangeRecordingEditorSaveListener.java
@@ -149,9 +149,8 @@ public abstract class EMFModelChangeRecordingEditorSaveListener {
         UuidGeneratorAndResolver globalUuidGeneratorAndResolver = virtualModel != null
                 ? virtualModel.getUuidGeneratorAndResolver()
                 : null;
-        // TODO Set strict mode to false
         UuidGeneratorAndResolver localUuidResolver = new UuidGeneratorAndResolverImpl(globalUuidGeneratorAndResolver,
-                targetResource.getResourceSet(), false);
+                targetResource.getResourceSet());
 
         changeRecorder = new ChangeRecorder(localUuidResolver);
         changeRecorder.addToRecording(targetResource);

--- a/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/DefaultStateBasedChangeResolutionStrategy.xtend
+++ b/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/DefaultStateBasedChangeResolutionStrategy.xtend
@@ -42,7 +42,7 @@ class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResol
 		}
 		// Setup resolver and copy state:
 		val copyResourceSet = new ResourceSetImpl
-		val uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resolver, copyResourceSet, true)
+		val uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resolver, copyResourceSet)
 		val currentStateCopy = currentState.copyInto(copyResourceSet)
 		// Create change sequences:
 		val diffs = compareStates(newState, currentStateCopy)

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -23,7 +23,6 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	static val logger = Logger.getLogger(UuidGeneratorAndResolverImpl)
 	final ResourceSet resourceSet
 	final UuidResolver parentUuidResolver
-	final boolean strictMode
 	UuidToEObjectRepository repository
 	UuidToEObjectRepository cache
 
@@ -33,15 +32,10 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * and no {@link Resource} in which the mapping is stored.
 	 * @param resourceSet -
 	 * 		the {@link ResourceSet} to load model elements from, may not be null
-	 * @param strictMode -
-	 * 		defines if the generator should run in strict mode, which throws {@link IllegalStateException}s 
-	 * 		if an element that should already have an ID as it was created before does no have one. 
-	 * 		Using non-strict mode can be necessary if model changes are not recorded from beginning of model creation.
-	 * 		Third party library are handled correctly (there is never a create change).
 	 * @throws IllegalArgumentException if given {@link ResourceSet} is null
 	 */
-	new(ResourceSet resourceSet, boolean strictMode) {
-		this(null, resourceSet, null, strictMode)
+	new(ResourceSet resourceSet) {
+		this(null, resourceSet, null)
 	}
 
 	/**
@@ -52,15 +46,10 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * 		the parent {@link UuidResolver} used to resolve UUID if this contains no appropriate mapping, may be null
 	 * @param resourceSet -
 	 * 		the {@link ResourceSet} to load model elements from, may not be null
-	 * @param strictMode -
-	 * 		defines if the generator should run in strict mode, which throws {@link IllegalStateException}s 
-	 * 		if an element that should already have an ID as it was created before does no have one. 
-	 * 		Using non-strict mode can be necessary if model changes are not recorded from beginning of model creation.
-	 * 		Third party library are handled correctly (there is never a create change).
 	 * @throws IllegalArgumentException if given {@link ResourceSet} is null
 	 */
-	new(UuidResolver parentUuidResolver, ResourceSet resourceSet, boolean strictMode) {
-		this(parentUuidResolver, resourceSet, null, strictMode)
+	new(UuidResolver parentUuidResolver, ResourceSet resourceSet) {
+		this(parentUuidResolver, resourceSet, null)
 	}
 
 	/**
@@ -71,15 +60,10 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * 		the {@link ResourceSet} to load model elements from, may not be null
 	 * @param uuidResource -
 	 * 		the {@link Resource} to store the mapping in, may be null
-	 * @param strictMode -
-	 * 		defines if the generator should run in strict mode, which throws {@link IllegalStateException}s 
-	 * 		if an element that should already have an ID as it was created before does no have one. 
-	 * 		Using non-strict mode can be necessary if model changes are not recorded from beginning of model creation.
-	 * 		Third party library are handled correctly (there is never a create change).
 	 * @throws IllegalArgumentException if given {@link ResourceSet} is null
 	 */
-	new(ResourceSet resourceSet, Resource uuidResource, boolean strictMode) {
-		this(null, resourceSet, uuidResource, strictMode)
+	new(ResourceSet resourceSet, Resource uuidResource) {
+		this(null, resourceSet, uuidResource)
 	}
 
 	/**
@@ -92,17 +76,11 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * 		the {@link ResourceSet} to load model elements from, may not be null
 	 * @param uuidResource -
 	 * 		the {@link Resource} to store the mapping in, may be null
-	 * @param strictMode -
-	 * 		defines if the generator should run in strict mode, which throws {@link IllegalStateException}s 
-	 * 		if an element that should already have an ID as it was created before does no have one. 
-	 * 		Using non-strict mode can be necessary if model changes are not recorded from beginning of model creation.
-	 * 		Third party library are handled correctly (there is never a create change).
 	 * @throws IllegalArgumentException if given {@link ResourceSet} is null
 	 */
-	new(UuidResolver parentUuidResolver, ResourceSet resourceSet, Resource uuidResource, boolean strictMode) {
+	new(UuidResolver parentUuidResolver, ResourceSet resourceSet, Resource uuidResource) {
 		checkArgument(resourceSet !== null, "Resource set may not be null")
 		this.resourceSet = resourceSet
-		this.strictMode = strictMode
 		this.parentUuidResolver = parentUuidResolver ?: UuidResolver.EMPTY
 		loadAndRegisterUuidProviderAndResolver(uuidResource)
 		this.resourceSet.eAdapters += new ResourceRegistrationAdapter[resource|loadUuidsFromParent(resource)]
@@ -198,11 +176,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		// Since this is called in the moment when an element gets created, the object can only be globally resolved
 		// if it a third party element.
 		if (!parentUuidResolver.registerUuidForGlobalUri(uuid, EcoreUtil.getURI(eObject))) {
-			if (strictMode) {
-				throw new IllegalStateException("Object has no UUID and is not globally accessible: " + eObject)
-			} else {
-				logger.warn("Object is not statically accessible but also has no globally mapped UUID: " + eObject)
-			}
+			throw new IllegalStateException("Object has no UUID and is not globally accessible: " + eObject)
 		}
 		return uuid
 	}

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
@@ -124,11 +124,7 @@ class ResourceRepositoryImpl implements ModelRepository {
 		var uuidProviderVURI = fileSystemLayout.uuidProviderAndResolverVURI
 		logger.trace('''Creating or loading uuid provider and resolver model from: «uuidProviderVURI»''')
 		var Resource uuidProviderResource = resourceSet.loadOrCreateResource(uuidProviderVURI.EMFUri)
-		// TODO HK We cannot enable strict mode here, because for textual views we will not get
-		// create changes in any case. We should therefore use one monitor per model and turn on
-		// strict mode
-		// depending on the kind of model/view (textual vs. semantic)
-		new UuidGeneratorAndResolverImpl(this.resourceSet, uuidProviderResource, false)
+		new UuidGeneratorAndResolverImpl(this.resourceSet, uuidProviderResource)
 	}
 
 	def private void loadVURIsOfVSMUModelInstances() {

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/ChangePublishingTestView.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/ChangePublishingTestView.xtend
@@ -63,7 +63,7 @@ class ChangePublishingTestView implements NonTransactionalTestView {
 	) {
 		this.resourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(targetDomains)
 		this.delegate = new BasicTestView(persistenceDirectory, resourceSet, userInteraction, uriMode)
-		val uuidResolver = new UuidGeneratorAndResolverImpl(parentResolver, resourceSet, true)
+		val uuidResolver = new UuidGeneratorAndResolverImpl(parentResolver, resourceSet)
 		this.changeRecorder = new ChangeRecorder(uuidResolver)
 		changeRecorder.beginRecording()
 	}

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/EChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/EChangeTest.xtend
@@ -68,7 +68,7 @@ abstract class EChangeTest {
 		resource.save(null)
 
 		// Factories for creating changes
-		this.uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet, true)
+		this.uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet)
 		atomicFactory = new TypeInferringUnresolvingAtomicEChangeFactory(uuidGeneratorAndResolver)
 		compoundFactory = new TypeInferringUnresolvingCompoundEChangeFactory(uuidGeneratorAndResolver)
 	}

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/FeatureEChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/FeatureEChangeTest.xtend
@@ -45,7 +45,7 @@ class FeatureEChangeTest extends EChangeTest {
 		// Load model in second resource
 		val resourceSet2 = new ResourceSetImpl().withGlobalFactories
 		this.resource2 = resourceSet2.getResource(resource.URI, true)
-		this.uuidResolver2 = new UuidGeneratorAndResolverImpl(resourceSet2, true)
+		this.uuidResolver2 = new UuidGeneratorAndResolverImpl(resourceSet2)
 	}
 
 	/**

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/ChangeDescription2ChangeTransformationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/ChangeDescription2ChangeTransformationTest.xtend
@@ -44,7 +44,7 @@ abstract class ChangeDescription2ChangeTransformationTest {
 	def void beforeTest(@TestProject Path tempFolder) {
 		this.tempFolder = tempFolder
 		this.resourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(TestDomainsRepository.INSTANCE)
-		this.uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet, true)
+		this.uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet)
 		this.changeRecorder = new ChangeRecorder(uuidGeneratorAndResolver)
 		this.resourceSet.startRecording
 	}

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
@@ -42,7 +42,7 @@ class ChangeRecorderTest {
 	// this test only covers general behaviour of ChangeRecorder. Whether it always produces correct change sequences
 	// is covered by other tests
 	val ResourceSet resourceSet = new ResourceSetImpl().withGlobalFactories()
-	var ChangeRecorder changeRecorder = new ChangeRecorder(new UuidGeneratorAndResolverImpl(resourceSet, true))
+	var ChangeRecorder changeRecorder = new ChangeRecorder(new UuidGeneratorAndResolverImpl(resourceSet))
 	
 	@Test
 	@DisplayName("records direct changes to an object")
@@ -660,8 +660,8 @@ class ChangeRecorderTest {
 	@Test
 	@DisplayName("registers the recorded object and all its contents at the UUID resolver")
 	def void registersAtUuidResolver() {
-		val parentResolver = new UuidGeneratorAndResolverImpl(new ResourceSetImpl, true)
-		val localResolver = new UuidGeneratorAndResolverImpl(parentResolver, resourceSet, true)
+		val parentResolver = new UuidGeneratorAndResolverImpl(new ResourceSetImpl)
+		val localResolver = new UuidGeneratorAndResolverImpl(parentResolver, resourceSet)
 		var ChangeRecorder changeRecorder = new ChangeRecorder(localResolver)
 		
 		val root = aet.Root => [

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/EdgeCaseStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/EdgeCaseStateChangeTest.xtend
@@ -32,7 +32,7 @@ class EdgeCaseStateChangeTest extends StateChangePropagationTest {
 	@Test
 	def void testNullResources() {
 		val resourceSet = new ResourceSetImpl
-		val resolver = new UuidGeneratorAndResolverImpl(resourceSet, false)
+		val resolver = new UuidGeneratorAndResolverImpl(resourceSet)
 		val Resource nullResource = null
 		val change = strategyToTest.getChangeSequences(nullResource, nullResource, resolver)
 		assertTrue(change.EChanges.empty, "Composite change contains children!")

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/StateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/StateChangePropagationTest.xtend
@@ -60,7 +60,7 @@ abstract class StateChangePropagationTest {
 		strategyToTest = new DefaultStateBasedChangeResolutionStrategy
 		resourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(TestDomainsRepository.INSTANCE)
 		checkpointResourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(TestDomainsRepository.INSTANCE)
-		setupResolver = new UuidGeneratorAndResolverImpl(resourceSet, true)
+		setupResolver = new UuidGeneratorAndResolverImpl(resourceSet)
 		changeRecorder = new ChangeRecorder(setupResolver)
 		// Create mockup models:
 		resourceSet.startRecording
@@ -68,7 +68,7 @@ abstract class StateChangePropagationTest {
 		createUmlMockupModel()
 		endRecording
 		// change to new recorder with test resolver, create model checkpoints and start recording:
-		checkpointResolver = new UuidGeneratorAndResolverImpl(setupResolver, checkpointResourceSet, true)
+		checkpointResolver = new UuidGeneratorAndResolverImpl(setupResolver, checkpointResourceSet)
 		umlCheckpoint = umlModel.createCheckpoint
 		pcmCheckpoint = pcmModel.createCheckpoint
 		umlModel.startRecording

--- a/tests/framework/tools.vitruv.framework.uuid.tests/src/tools/vitruv/framework/uuid/tests/UuidGeneratorAndResolverImplTest.xtend
+++ b/tests/framework/tools.vitruv.framework.uuid.tests/src/tools/vitruv/framework/uuid/tests/UuidGeneratorAndResolverImplTest.xtend
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach
 @ExtendWith(TestProjectManager, RegisterMetamodelsInStandalone)
 class UuidGeneratorAndResolverImplTest {
 	val resourceSet = new ResourceSetImpl().withGlobalFactories()
-	val uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet, true)
+	val uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet)
 	var Path testProjectPath
 
 	@BeforeEach
@@ -32,8 +32,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("resolve UUID in parent resolver for object with root container not being its resource root")
 	def void parentResolveRootContainerNotResourceRoot() {
 		val childResourceSet = new ResourceSetImpl().withGlobalFactories()
-		val childUuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(uuidGeneratorAndResolver, childResourceSet,
-			true)
+		val childUuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(uuidGeneratorAndResolver, childResourceSet)
 
 		// Model generation
 		val nonRoot = aet.NonRoot
@@ -63,8 +62,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("resolve UUID in parent resolver for multiple root elements")
 	def void parentResolveOneOfMultipleRootElements() {
 		val childResourceSet = new ResourceSetImpl().withGlobalFactories()
-		val childUuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(uuidGeneratorAndResolver, childResourceSet,
-			true)
+		val childUuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(uuidGeneratorAndResolver, childResourceSet)
 
 		// Model generation
 		val firstRoot = aet.Root
@@ -94,7 +92,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("resolve UUID in parent resolver for contents of multiple root elements")
 	def void parentResolveElementsContainedInOneOfMultipleRootElements() {
 		val childResourceSet = new ResourceSetImpl().withGlobalFactories()
-		val childUuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(uuidGeneratorAndResolver, childResourceSet, true)
+		val childUuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(uuidGeneratorAndResolver, childResourceSet)
 
 		// Model generation
 		val firstNonRoot = aet.NonRoot


### PR DESCRIPTION
Removes the non-strict mode of the `UuidGeneratorAndResolverImpl`. It was able to tolerate non-existing UUIDs by setting the `strictMode` flag to `false` in the constructor. This was especially necessary for the `VirtualModel`, because _incomplete_ domains, i.e., domains in which no complete change sequences are tracked, reloaded resources in which elements occurred that did not have a UUID. Since we have removed that workaround, the resolver can run in strict mode also within the `VirtualModel`. Since no one else needs the non-strict mode, this PR completely removes it.

Apparently, the non-strict mode was used in some cases in monitors (see #195). We should, however, adapt the monitor there and not keep the non-strict mode that can hide further bugs.

Fixes #195.