### PR TITLE
Make EObject References in UUID Repository Derived

### DIFF
--- a/bundles/framework/tools.vitruv.framework.uuid/model/Uuid.ecore
+++ b/bundles/framework/tools.vitruv.framework.uuid/model/Uuid.ecore
@@ -9,10 +9,12 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="UuidToEObjectMapEntry" instanceClassName="java.util.Map$Entry">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" eType="#//Uuid"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="value" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="value" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"
+        derived="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EObjectToUuidMapEntry" instanceClassName="java.util.Map$Entry">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="key" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="key" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"
+        derived="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//Uuid"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="Uuid" instanceClassName="java.lang.String"/>


### PR DESCRIPTION
In the `UuidGeneratoraAndResolverImpl`, an Ecore-based model is used for mapping UUIDs to `EObjects` and vice versa. Since this is handled as an ordinary Ecore model, removing elements from its references leads to the removal from this UUID repository. This will always occur when using the cross-referencer to remove elements from references, such as calling `destroy()` on UML model elements. To avoid this, the PR sets the `EObject` references in this repository to as `derived`, which avoids that their values are replaced from anywhere else than from our code. Since we define the entries of the repository map anyway, this change does not degrade operation of the repository.