### PR TITLE
UUID Resolver Element Cleanup and Placement in Separate ResourceSet

### DIFF
--- a/bundles/domains/tools.vitruv.domains.emf.ui/src/tools/vitruv/domains/emf/monitorededitor/monitor/EMFModelChangeRecordingEditorSaveListener.java
+++ b/bundles/domains/tools.vitruv.domains.emf.ui/src/tools/vitruv/domains/emf/monitorededitor/monitor/EMFModelChangeRecordingEditorSaveListener.java
@@ -25,9 +25,9 @@ import tools.vitruv.domains.emf.monitorededitor.tools.SaveEventListenerMgr;
 import tools.vitruv.framework.change.description.TransactionalChange;
 import tools.vitruv.framework.change.recording.ChangeRecorder;
 import tools.vitruv.framework.uuid.UuidGeneratorAndResolver;
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl;
 import tools.vitruv.framework.uuid.UuidResolver;
 import tools.vitruv.framework.vsum.VirtualModel;
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver;
 
 /**
  * <p>
@@ -150,7 +150,7 @@ public abstract class EMFModelChangeRecordingEditorSaveListener {
         UuidResolver globalUuidGeneratorAndResolver = virtualModel != null
                 ? virtualModel.getUuidResolver()
                 : null;
-        UuidGeneratorAndResolver localUuidResolver = new UuidGeneratorAndResolverImpl(globalUuidGeneratorAndResolver,
+        UuidGeneratorAndResolver localUuidResolver = createUuidGeneratorAndResolver(globalUuidGeneratorAndResolver,
                 targetResource.getResourceSet());
 
         changeRecorder = new ChangeRecorder(localUuidResolver);

--- a/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/DefaultStateBasedChangeResolutionStrategy.xtend
+++ b/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/DefaultStateBasedChangeResolutionStrategy.xtend
@@ -15,10 +15,10 @@ import org.eclipse.emf.ecore.util.EcoreUtil
 import tools.vitruv.framework.change.description.TransactionalChange
 import tools.vitruv.framework.change.description.VitruviusChangeFactory
 import tools.vitruv.framework.uuid.UuidGeneratorAndResolver
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 import tools.vitruv.framework.change.recording.ChangeRecorder
 import org.eclipse.emf.ecore.resource.ResourceSet
 import tools.vitruv.framework.uuid.UuidResolver
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
 
 /**
  * This default strategy for diff based state changes uses EMFCompare to resolve a 
@@ -43,7 +43,7 @@ class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResol
 		}
 		// Setup resolver and copy state:
 		val copyResourceSet = new ResourceSetImpl
-		val uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resolver, copyResourceSet)
+		val uuidGeneratorAndResolver = createUuidGeneratorAndResolver(resolver, copyResourceSet)
 		val currentStateCopy = currentState.copyInto(copyResourceSet)
 		// Create change sequences:
 		val diffs = compareStates(newState, currentStateCopy)

--- a/bundles/framework/tools.vitruv.framework.uuid/model/Uuid.ecore
+++ b/bundles/framework/tools.vitruv.framework.uuid/model/Uuid.ecore
@@ -9,10 +9,12 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="UuidToEObjectMapEntry" instanceClassName="java.util.Map$Entry">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" eType="#//Uuid"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="value" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="value" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"
+        resolveProxies="false"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EObjectToUuidMapEntry" instanceClassName="java.util.Map$Entry">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="key" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="key" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"
+        resolveProxies="false"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//Uuid"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="Uuid" instanceClassName="java.lang.String"/>

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
@@ -10,7 +10,7 @@ import org.eclipse.emf.ecore.EObject
  * It registers a notifier on that {@link ResourceSet}, which informs about newly added/loaded {@link Resource}s
  * and automatically loads the assigned {@link Uuid}s for contained elements from the parent resolver.
  */
-interface UuidGeneratorAndResolver extends UuidResolver {
+interface UuidGeneratorAndResolver extends UuidResolver, AutoCloseable {
 	/**
 	 * Registers an object and returns the generated UUID for it.
 	 */

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
@@ -15,11 +15,16 @@ interface UuidGeneratorAndResolver extends UuidResolver {
 	 * Registers an object and returns the generated UUID for it.
 	 */
 	def String generateUuid(EObject eObject);
-	
+
 	/**
 	 * Registers an object that was not created before and thus has no UUID.
 	 * This is only successful if the element is globally accessible (third party element) or if
 	 * we are not in strict mode. Otherwise an exception is thrown, because a previous create is missing. 
 	 */
 	def String generateUuidWithoutCreate(EObject eObject);
+
+	/**
+	 * Cleans up elements that have been removed, i.e., that are not contained in a resource anymore
+	 */
+	def void cleanupRemovedElements()
 }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
@@ -24,7 +24,7 @@ interface UuidGeneratorAndResolver extends UuidResolver {
 	def String generateUuidWithoutCreate(EObject eObject);
 
 	/**
-	 * Cleans up elements that have been removed, i.e., that are not contained in a resource anymore
+	 * Saves the mapping between {@link Uuids}s and {@link EObject}s to an underlying resource.
 	 */
-	def void cleanupRemovedElements()
+	def void save()
 }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverFactory.xtend
@@ -45,8 +45,8 @@ class UuidGeneratorAndResolverFactory {
 	 * 		the parent {@link UuidResolver} used to resolve UUID if this contains no appropriate mapping, may 
 	 * 		be {@link null}
 	 * @param resourceSet -
-	 * 		the {@link ResourceSet} to load model elements from, may not be {@link null}
-	 * @throws IllegalArgumentException if given {@link ResourceSet} is {@link null}
+	 * 		the {@link ResourceSet} to load model elements from, may not be {@code null}
+	 * @throws IllegalArgumentException if given {@link ResourceSet} is {@code null}
 	 */
 	static def UuidGeneratorAndResolver createUuidGeneratorAndResolver(UuidResolver parentUuidResolver, ResourceSet resourceSet) {
 		return new UuidGeneratorAndResolverImpl(parentUuidResolver, resourceSet, null)
@@ -58,7 +58,7 @@ class UuidGeneratorAndResolverFactory {
 	 * 
 	 * @param resourceSet -
 	 * 		the {@link ResourceSet} to load model elements from, may not be {@code null}
-	 * @throws IllegalArgumentException if given {@link ResourceSet} is {@link null}
+	 * @throws IllegalArgumentException if given {@link ResourceSet} is {@code null}
 	 */
 	static def UuidGeneratorAndResolver createUuidGeneratorAndResolver(ResourceSet resourceSet) {
 		return new UuidGeneratorAndResolverImpl(null, resourceSet, null)

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverFactory.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverFactory.xtend
@@ -1,0 +1,67 @@
+package tools.vitruv.framework.uuid
+
+import org.eclipse.emf.ecore.resource.ResourceSet
+import org.eclipse.emf.common.util.URI
+
+class UuidGeneratorAndResolverFactory {
+	/**
+	 * Instantiates a {@link UuidGeneratorAndResolver} with no parent resolver, the given {@link ResourceSet} 
+	 * for resolving objects and a resource at the given {@link URI} for storing the mapping in.
+	 * It loads an existing repository from the given {@link URI} and resolves the referenced objects
+	 * in the given {@link ResourceSet}.
+	 * 
+	 * @param resourceSet -
+	 * 		the {@link ResourceSet} to load model elements from, may not be {@code null}
+	 * @param resourceUri -
+	 * 		the {@link URI} to place a resource for storing the mapping in, may be {@code null}
+	 * @throws IllegalArgumentException if given {@link ResourceSet} is {@code null}
+	 */
+	static def UuidGeneratorAndResolver createAndLoadUuidGeneratorAndResolver(ResourceSet resourceSet, URI resourceUri) {
+		val generatorAndResolver = new UuidGeneratorAndResolverImpl(null, resourceSet, resourceUri)
+		generatorAndResolver.loadUuidsAndModelsFromSerializedUuidRepository()
+		return generatorAndResolver
+	}
+
+	/**
+	 * Instantiates a {@link UuidGeneratorAndResolver} with no parent resolver, the given {@link ResourceSet} 
+	 * for resolving objects and a resource at the given {@link URI} for storing the mapping in.
+	 * 
+	 * @param resourceSet -
+	 * 		the {@link ResourceSet} to load model elements from, may not be {@code null}
+	 * @param resourceUri -
+	 * 		the {@link URI} to place a resource for storing the mapping in, may be {@code null}
+	 * @throws IllegalArgumentException if given {@link ResourceSet} is {@code null}
+	 */
+	static def UuidGeneratorAndResolver createUuidGeneratorAndResolver(ResourceSet resourceSet, URI resourceUri) {
+		return new UuidGeneratorAndResolverImpl(null, resourceSet, resourceUri)
+	}
+		
+	/**
+	 * Instantiates a {@link UuidGeneratorAndResolver} with the given parent resolver, used when this resolver 
+	 * cannot resolve a UUID, the given {@link ResourceSet} for resolving objects and no {@link Resource} in 
+	 * which the mapping is stored.
+	 * 
+	 * @param parentUuidResolver -
+	 * 		the parent {@link UuidResolver} used to resolve UUID if this contains no appropriate mapping, may 
+	 * 		be {@link null}
+	 * @param resourceSet -
+	 * 		the {@link ResourceSet} to load model elements from, may not be {@link null}
+	 * @throws IllegalArgumentException if given {@link ResourceSet} is {@link null}
+	 */
+	static def UuidGeneratorAndResolver createUuidGeneratorAndResolver(UuidResolver parentUuidResolver, ResourceSet resourceSet) {
+		return new UuidGeneratorAndResolverImpl(parentUuidResolver, resourceSet, null)
+	}
+	
+	/**
+	 * Instantiates a {@link UuidGeneratorAndResolver} with no parent resolver, the given {@link ResourceSet} 
+	 * for resolving objects and no {@link Resource} in which the mapping is stored.
+	 * 
+	 * @param resourceSet -
+	 * 		the {@link ResourceSet} to load model elements from, may not be {@code null}
+	 * @throws IllegalArgumentException if given {@link ResourceSet} is {@link null}
+	 */
+	static def UuidGeneratorAndResolver createUuidGeneratorAndResolver(ResourceSet resourceSet) {
+		return new UuidGeneratorAndResolverImpl(null, resourceSet, null)
+	}
+	
+}

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -62,7 +62,8 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * @param resourceSet -
 	 * 		the {@link ResourceSet} to load model elements from, may not be null
 	 * @param resourceUri -
-	 * 		the {@link URI} to place a resource for storing the mapping in, may be null
+	 * 		the {@link URI} to persist this repository to when {@link #save} is called. If {@code null}, this 
+	 * 		UUID repository will not be persisted.
 	 * @throws IllegalArgumentException if given {@link ResourceSet} is null
 	 */
 	new(ResourceSet resourceSet, URI resourceUri) {
@@ -78,7 +79,8 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * @param resourceSet -
 	 * 		the {@link ResourceSet} to load model elements from, may not be null
 	 * @param resourceUri -
-	 * 		the {@link URI} to place a resource for storing the mapping in, may be null
+	 * 		the {@link URI} to persist this repository to when {@link #save} is called. If {@code null}, this 
+	 * 		UUID repository will not be persisted.
 	 * @throws IllegalArgumentException if given {@link ResourceSet} is null
 	 */
 	new(UuidResolver parentUuidResolver, ResourceSet resourceSet, URI resourceUri) {

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -310,4 +310,15 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		}
 	}
 	
+	override cleanupRemovedElements() {
+		for (val iterator = repository.EObjectToUuid.keySet.iterator(); iterator.hasNext(); ) {
+			val object = iterator.next()
+			if (object.eResource === null) {
+				val uuid = repository.EObjectToUuid.get(object)
+				repository.uuidToEObject.removeKey(uuid)
+				iterator.remove()
+			}
+		}
+	}
+
 }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -34,37 +34,40 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * Instantiates a UUID generator and resolver with the given parent resolver, used when
 	 * this resolver cannot resolve a UUID, the given {@link ResourceSet} for resolving objects
 	 * and a resource at the given {@link URI} for storing the mapping in.
-	 * When loading an existing repository from the given {@link URI}, the referenced objects
-	 * are resolved in the given {@link ResourceSet}.
+	 * 
 	 * @param parentUuidResolver -
-	 * 		the parent {@link UuidResolver} used to resolve UUID if this contains no appropriate mapping, may be null
+	 * 		the parent {@link UuidResolver} used to resolve UUID if this contains no appropriate 
+	 * 		mapping, may be {@code null}
 	 * @param resourceSet -
-	 * 		the {@link ResourceSet} to load model elements from, may not be null
+	 * 		the {@link ResourceSet} to load model elements from, may not be {@code null}
 	 * @param resourceUri -
-	 * 		the {@link URI} to place a resource for storing the mapping in, may be null
-	 * @throws IllegalArgumentExceptionif given {@link ResourceSet} is null
+	 * 		the {@link URI} to place a resource for storing the mapping in, may be {@code null}
+	 * @throws IllegalArgumentExceptionif given {@link ResourceSet} is {@code null}
 	 */
 	new(UuidResolver parentUuidResolver, ResourceSet resourceSet, URI resourceUri) {
 		checkArgument(resourceSet !== null, "Resource set may not be null")
 		this.resourceSet = resourceSet
 		this.parentUuidResolver = parentUuidResolver ?: UuidResolver.EMPTY
 		this.cache = UuidFactory.eINSTANCE.createUuidToEObjectRepository
-		this.repository =  UuidFactory.eINSTANCE.createUuidToEObjectRepository
-		this.uuidResource = if (resourceUri !== null) new ResourceSetImpl().withGlobalFactories.createResource(resourceUri) => [
-			contents += repository
-		]
+		this.repository = UuidFactory.eINSTANCE.createUuidToEObjectRepository
+		this.uuidResource = if (resourceUri !== null)
+			new ResourceSetImpl().withGlobalFactories.createResource(resourceUri) => [
+				contents += repository
+			]
 		this.resourceSet.eAdapters += new ResourceRegistrationAdapter[resource|loadUuidsFromParent(resource)]
 	}
-	
+
 	/**
-	 * Loads the mapping between UUIDs and {@link EObject}s from an underlying resource and resolves 
-	 * the referenced {@link EObject}s.
+	 * Loads the mapping between UUIDs and {@link EObject}s from the persistence at the {@link URI}
+	 * given in the constructor and resolves the referenced {@link EObject}s in the {@link ResourceSet}
+	 * given in the constructor.
 	 */
 	def loadUuidsAndModelsFromSerializedUuidRepository() {
 		checkState(uuidResource !== null, "UUID resource must be specified to load existing UUIDs")
 		val loadedResource = new ResourceSetImpl().withGlobalFactories.loadOrCreateResource(uuidResource.URI)
-		val loadedRepository = checkNotNull(loadedResource.resourceContentRootIfUnique, "UUID resource does not contain a root element")
-			.dynamicCast(UuidToEObjectRepository, "UUID provider and resolver model")
+		val loadedRepository = checkNotNull(loadedResource.resourceContentRootIfUnique,
+			"UUID resource does not contain a root element").dynamicCast(UuidToEObjectRepository,
+			"UUID provider and resolver model")
 		for (proxyEntry : loadedRepository.EObjectToUuid.entrySet) {
 			val resolvedObject = EcoreUtil.resolve(proxyEntry.key, resourceSet)
 			if (resolvedObject.eIsProxy) {
@@ -85,7 +88,7 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		if (localResult !== null) {
 			return localResult
 		}
-		
+
 		// If the object already has a resource, but is not from the resolver’s resource set, resolve it and try again
 		val objectResource = eObject.eResource
 		if (objectResource !== null && objectResource.resourceSet != resourceSet) {
@@ -117,8 +120,7 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	}
 
 	override getPotentiallyCachedEObject(String uuid) {
-		cache.uuidToEObject.get(uuid)
-			?: getEObject(uuid)
+		cache.uuidToEObject.get(uuid) ?: getEObject(uuid)
 	}
 
 	private def EObject internalGetEObject(String uuid) {
@@ -162,8 +164,8 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 
 	override registerEObject(String uuid, EObject eObject) {
 		checkState(eObject !== null, "Object must not be null")
-		if (logger.isTraceEnabled) logger.trace('''Adding UUID «uuid» for EObject: «eObject»''')
-		
+		if(logger.isTraceEnabled) logger.trace('''Adding UUID «uuid» for EObject: «eObject»''')
+
 		val uuidMapped = repository.uuidToEObject.put(uuid, eObject)
 		if (uuidMapped !== null) {
 			repository.EObjectToUuid.remove(uuidMapped)
@@ -172,8 +174,7 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	}
 
 	override hasPotentiallyCachedEObject(String uuid) {
-		cache.uuidToEObject.containsKey(uuid)
-			|| internalGetEObject(uuid) !== null
+		cache.uuidToEObject.containsKey(uuid) || internalGetEObject(uuid) !== null
 	}
 
 	override hasUuid(EObject object) {
@@ -209,14 +210,12 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	}
 
 	override getPotentiallyCachedUuid(EObject eObject) {
-		return cache.EObjectToUuid.get(eObject)
-			?: cache.EObjectToUuid.findFirst [EcoreUtil.equals(eObject, key)]?.value
-			?: getUuid(eObject)
+		return cache.EObjectToUuid.get(eObject) ?:
+			cache.EObjectToUuid.findFirst[EcoreUtil.equals(eObject, key)]?.value ?: getUuid(eObject)
 	}
 
 	override hasPotentiallyCachedUuid(EObject eObject) {
-		cache.EObjectToUuid.containsKey(eObject) 
-			|| hasUuid(eObject)
+		cache.EObjectToUuid.containsKey(eObject) || hasUuid(eObject)
 	}
 
 	override registerCachedEObject(EObject eObject) {
@@ -236,16 +235,16 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 				val childObject = childContents.next
 				checkState(ourContents.hasNext, "Cannot find %s in our resource set!", childObject)
 				val ourObject = ourContents.next
-				
+
 				var objectUuid = repository.EObjectToUuid.get(ourObject)
 				// Not having a UUID is only supported for pathmap resources
 				if (objectUuid === null && uri.isPathmap) {
 					objectUuid = generateUuid(ourObject)
-				}		
+				}
 				if (objectUuid === null) {
 					throw new IllegalStateException('''Element does not have a UUID but should have one: «ourObject»''')
 				}
-				
+
 				childResolver.registerEObject(objectUuid, childObject)
 			}
 		}
@@ -254,7 +253,7 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	def void loadUuidsFromParent(Resource resource) {
 		parentUuidResolver.loadUuidsToChild(this, resource.URI)
 	}
-	
+
 	private def EObject resolve(URI uri) {
 		resourceSet.getEObject(uri, true)
 	}
@@ -267,29 +266,29 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		val resource = object.eResource
 		var rootElementIndex = 0;
 		val resourceRoot = if (resource.contents.size <= 1) {
-			object.eResource.firstRootEObject
-		} else {
-			// move up containment hierarchy until some container is one of the resource's root elements
-			var container = object
-			while (container !== null && (rootElementIndex = resource.contents.indexOf(container)) == -1) {
-    			container = container.eContainer
+				object.eResource.firstRootEObject
+			} else {
+				// move up containment hierarchy until some container is one of the resource's root elements
+				var container = object
+				while (container !== null && (rootElementIndex = resource.contents.indexOf(container)) == -1) {
+					container = container.eContainer
+				}
+				checkState(container !== null, "some container of %s must be a root element of its resource", object)
+				container
 			}
-			checkState(container !== null, "some container of %s must be a root element of its resource", object)
-			container
-		}  
 		val fragmentPath = EcoreUtil.getRelativeURIFragmentPath(resourceRoot, object)
 		if (fragmentPath.isEmpty) {
-			resource.URI.appendFragment('/' +  rootElementIndex)
+			resource.URI.appendFragment('/' + rootElementIndex)
 		} else {
-			resource.URI.appendFragment('/' +  rootElementIndex + '/' + fragmentPath)
+			resource.URI.appendFragment('/' + rootElementIndex + '/' + fragmentPath)
 		}
 	}
-	
+
 	override save() {
 		cleanupRemovedElements()
 		uuidResource?.save(null)
 	}
-	
+
 	private def cleanupRemovedElements() {
 		for (val iterator = repository.EObjectToUuid.keySet.iterator(); iterator.hasNext();) {
 			val object = iterator.next()
@@ -300,7 +299,7 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 			}
 		}
 	}
-	
+
 	override close() {
 		this.uuidResource.unload
 	}

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -62,7 +62,7 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * given in the constructor and resolves the referenced {@link EObject}s in the {@link ResourceSet}
 	 * given in the constructor.
 	 */
-	def loadUuidsAndModelsFromSerializedUuidRepository() {
+	def package loadUuidsAndModelsFromSerializedUuidRepository() {
 		checkState(uuidResource !== null, "UUID resource must be specified to load existing UUIDs")
 		val loadedResource = new ResourceSetImpl().withGlobalFactories.loadOrCreateResource(uuidResource.URI)
 		val loadedRepository = loadedResource.resourceContentRootIfUnique?.dynamicCast(UuidToEObjectRepository,

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -65,15 +65,17 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	def loadUuidsAndModelsFromSerializedUuidRepository() {
 		checkState(uuidResource !== null, "UUID resource must be specified to load existing UUIDs")
 		val loadedResource = new ResourceSetImpl().withGlobalFactories.loadOrCreateResource(uuidResource.URI)
-		val loadedRepository = checkNotNull(loadedResource.resourceContentRootIfUnique,
-			"UUID resource does not contain a root element").dynamicCast(UuidToEObjectRepository,
+		val loadedRepository = loadedResource.resourceContentRootIfUnique?.dynamicCast(UuidToEObjectRepository,
 			"UUID provider and resolver model")
-		for (proxyEntry : loadedRepository.EObjectToUuid.entrySet) {
-			val resolvedObject = EcoreUtil.resolve(proxyEntry.key, resourceSet)
-			if (resolvedObject.eIsProxy) {
-				throw new IllegalStateException("Object " + proxyEntry.key + " has a UUID but could not be resolved")
+		if (loadedRepository !== null) {
+			for (proxyEntry : loadedRepository.EObjectToUuid.entrySet) {
+				val resolvedObject = EcoreUtil.resolve(proxyEntry.key, resourceSet)
+				if (resolvedObject.eIsProxy) {
+					throw new IllegalStateException("Object " + proxyEntry.key +
+						" has a UUID but could not be resolved")
+				}
+				registerEObject(proxyEntry.value, resolvedObject)
 			}
-			registerEObject(proxyEntry.value, resolvedObject)
 		}
 	}
 

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -64,8 +64,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * @param resourceSet -
 	 * 		the {@link ResourceSet} to load model elements from, may not be null
 	 * @param resourceUri -
-	 * 		the {@link URI} to persist this repository to when {@link #save} is called. If {@code null}, this 
-	 * 		UUID repository will not be persisted.
+	 * 		the {@link URI} to place a resource for storing the mapping in, may be null
 	 * @throws IllegalArgumentException if given {@link ResourceSet} is null
 	 */
 	new(ResourceSet resourceSet, URI resourceUri) {
@@ -83,9 +82,8 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	 * @param resourceSet -
 	 * 		the {@link ResourceSet} to load model elements from, may not be null
 	 * @param resourceUri -
-	 * 		the {@link URI} to persist this repository to when {@link #save} is called. If {@code null}, this 
-	 * 		UUID repository will not be persisted.
-	 * @throws IllegalArgumentException if given {@link ResourceSet} is null
+	 * 		the {@link URI} to place a resource for storing the mapping in, may be null
+	 * @throws IllegalArgumentExceptionif given {@link ResourceSet} is null
 	 */
 	new(UuidResolver parentUuidResolver, ResourceSet resourceSet, URI resourceUri) {
 		checkArgument(resourceSet !== null, "Resource set may not be null")
@@ -111,6 +109,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 			}
 		}
 		if (uuidResource !== null) {
+			uuidResource.contents.clear
 			uuidResource.contents += repository
 		}
 	}

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -104,6 +104,9 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		if (loadedRepository !== null) {
 			for (proxyEntry : loadedRepository.EObjectToUuid.entrySet) {
 				val resolvedObject = EcoreUtil.resolve(proxyEntry.key, resourceSet)
+				if (resolvedObject.eIsProxy) {
+					throw new IllegalStateException("Object " + proxyEntry.key + " has a UUID but could not be resolved")
+				}
 				registerEObject(proxyEntry.value, resolvedObject)
 			}
 		}
@@ -337,6 +340,10 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 				iterator.remove()
 			}
 		}
+	}
+	
+	override close() {
+		this.uuidResource.unload
 	}
 
 }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -81,6 +81,11 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	new(UuidResolver parentUuidResolver, ResourceSet resourceSet, Resource uuidResource) {
 		checkArgument(resourceSet !== null, "Resource set may not be null")
 		this.resourceSet = resourceSet
+		if (uuidResource?.resourceSet == resourceSet) {
+			// Using the same resource set for models and the UUID resource can lead to accidental
+			// UUID removals, such as EcoreUtil.delete(element) removing the UUID mapping for element
+			logger.warn("UUID resource should not be placed into the same resource set as the models")
+		}
 		this.parentUuidResolver = parentUuidResolver ?: UuidResolver.EMPTY
 		loadAndRegisterUuidProviderAndResolver(uuidResource)
 		this.resourceSet.eAdapters += new ResourceRegistrationAdapter[resource|loadUuidsFromParent(resource)]

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
@@ -14,7 +14,6 @@ import tools.vitruv.framework.domains.repository.VitruvDomainRepository
 import tools.vitruv.framework.util.datatypes.ModelInstance
 import tools.vitruv.framework.util.datatypes.VURI
 import tools.vitruv.framework.uuid.UuidGeneratorAndResolver
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 import tools.vitruv.framework.vsum.ModelRepository
 
 import static extension tools.vitruv.framework.util.bridges.EcoreResourceBridge.loadOrCreateResource
@@ -28,6 +27,7 @@ import static com.google.common.base.Preconditions.checkState
 import tools.vitruv.framework.util.ResourceRegistrationAdapter
 import tools.vitruv.framework.correspondence.CorrespondenceModelFactory
 import tools.vitruv.framework.correspondence.CorrespondenceModel
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createAndLoadUuidGeneratorAndResolver
 
 class ResourceRepositoryImpl implements ModelRepository {
 	static val logger = Logger.getLogger(ResourceRepositoryImpl)
@@ -47,7 +47,7 @@ class ResourceRepositoryImpl implements ModelRepository {
 		this.fileSystemLayout = fileSystemLayout
 		this.modelsResourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(domainRepository)
 		this.correspondencesResourceSet = new ResourceSetImpl().withGlobalFactories()
-		this.uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.modelsResourceSet, fileSystemLayout.uuidProviderAndResolverVURI.EMFUri)
+		this.uuidGeneratorAndResolver = createAndLoadUuidGeneratorAndResolver(this.modelsResourceSet, fileSystemLayout.uuidProviderAndResolverVURI.EMFUri)
 		this.correspondenceModel = initializeCorrespondenceModel().genericView
 		this.modelsResourceSet.eAdapters += new ResourceRegistrationAdapter [getModel(VURI.getInstance(it))]
 		loadVURIsOfVSMUModelInstances()

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
@@ -179,8 +179,9 @@ class ResourceRepositoryImpl implements ModelRepository {
 	override close() {
 		modelsResourceSet.resources.forEach[unload]
 		correspondencesResourceSet.resources.forEach[unload]
-		modelsResourceSet.resources.clear
-		correspondencesResourceSet.resources.clear
+		modelsResourceSet.resources.clear()
+		correspondencesResourceSet.resources.clear()
+		uuidGeneratorAndResolver.close()
 	}
 
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
@@ -124,7 +124,6 @@ class ResourceRepositoryImpl implements ModelRepository {
 			}
 		}
 		uuidGeneratorAndResolver.save()
-		saveVURIsOfVsumModelInstances()
 	}
 
 	def private initializeCorrespondenceModel() {
@@ -141,11 +140,6 @@ class ResourceRepositoryImpl implements ModelRepository {
 		for (VURI vuri : fileSystemLayout.loadVsumVURIs()) {
 			createOrLoadModel(vuri, true)
 		}
-	}
-
-	def private void saveVURIsOfVsumModelInstances() {
-		// TODO Reimplement saving of V-SUM with a proper reload mechanism
-		// fileSystemHelper.saveVsumVURIsToFile(modelInstances.keySet)
 	}
 
 	def private VitruvDomain getDomainForURI(VURI uri) {

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/ChangePublishingTestView.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/ChangePublishingTestView.xtend
@@ -4,7 +4,6 @@ import org.eclipse.emf.common.notify.Notifier
 import java.util.function.Consumer
 import java.nio.file.Path
 import org.eclipse.emf.ecore.resource.ResourceSet
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 import tools.vitruv.framework.uuid.UuidGeneratorAndResolver
 import static com.google.common.base.Preconditions.checkState
 import static com.google.common.base.Preconditions.checkArgument
@@ -24,6 +23,7 @@ import static extension tools.vitruv.framework.domains.repository.DomainAwareRes
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import tools.vitruv.framework.change.recording.ChangeRecorder
 import tools.vitruv.framework.uuid.UuidResolver
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
 
 /**
  * A test view that will record and publish the changes created in it.
@@ -64,7 +64,7 @@ class ChangePublishingTestView implements NonTransactionalTestView {
 	) {
 		this.resourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(targetDomains)
 		this.delegate = new BasicTestView(persistenceDirectory, resourceSet, userInteraction, uriMode)
-		val uuidResolver = new UuidGeneratorAndResolverImpl(parentResolver, resourceSet)
+		val uuidResolver = createUuidGeneratorAndResolver(parentResolver, resourceSet)
 		this.changeRecorder = new ChangeRecorder(uuidResolver)
 		changeRecorder.beginRecording()
 	}

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/EChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/EChangeTest.xtend
@@ -8,7 +8,6 @@ import tools.vitruv.framework.change.echange.TypeInferringAtomicEChangeFactory
 import tools.vitruv.framework.change.echange.TypeInferringCompoundEChangeFactory
 import tools.vitruv.framework.change.echange.TypeInferringUnresolvingAtomicEChangeFactory
 import tools.vitruv.framework.change.echange.TypeInferringUnresolvingCompoundEChangeFactory
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 import tools.vitruv.framework.uuid.UuidGeneratorAndResolver
 import java.util.List
 import tools.vitruv.framework.change.echange.EChange
@@ -22,6 +21,7 @@ import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
 import java.nio.file.Path
 import tools.vitruv.framework.util.bridges.EMFBridge
 import org.junit.jupiter.api.io.TempDir
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
 
 /**
  * Default class for testing EChange changes.
@@ -66,7 +66,7 @@ abstract class EChangeTest {
 		resource.save(null)
 
 		// Factories for creating changes
-		this.uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet)
+		this.uuidGeneratorAndResolver = createUuidGeneratorAndResolver(resourceSet)
 		atomicFactory = new TypeInferringUnresolvingAtomicEChangeFactory(uuidGeneratorAndResolver)
 		compoundFactory = new TypeInferringUnresolvingCompoundEChangeFactory(uuidGeneratorAndResolver)
 	}

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/FeatureEChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/FeatureEChangeTest.xtend
@@ -13,7 +13,6 @@ import tools.vitruv.framework.tests.echange.EChangeTest
 import static extension tools.vitruv.framework.change.echange.resolve.EChangeResolverAndApplicator.*
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import tools.vitruv.framework.uuid.UuidResolver
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 import static extension tools.vitruv.framework.util.ResourceSetUtil.withGlobalFactories
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -24,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame
 import static org.junit.jupiter.api.Assertions.assertNotSame
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
 
 /**
  * Test class for {@link FeatureEChange} which is used by every {@link EChange} which modifies {@link EStructuralFeature}s 
@@ -45,7 +45,7 @@ class FeatureEChangeTest extends EChangeTest {
 		// Load model in second resource
 		val resourceSet2 = new ResourceSetImpl().withGlobalFactories
 		this.resource2 = resourceSet2.getResource(resource.URI, true)
-		this.uuidResolver2 = new UuidGeneratorAndResolverImpl(resourceSet2)
+		this.uuidResolver2 = createUuidGeneratorAndResolver(resourceSet2)
 	}
 
 	/**

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/ChangeDescription2ChangeTransformationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/ChangeDescription2ChangeTransformationTest.xtend
@@ -5,7 +5,6 @@ import java.util.List
 
 import tools.vitruv.framework.change.echange.EChange
 import tools.vitruv.framework.util.bridges.EMFBridge
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 import static extension tools.vitruv.framework.change.echange.resolve.EChangeResolverAndApplicator.*
 import tools.vitruv.framework.uuid.UuidGeneratorAndResolver
 import tools.vitruv.framework.change.echange.resolve.EChangeUnresolver
@@ -29,6 +28,7 @@ import static extension tools.vitruv.framework.util.ResourceSetUtil.withGlobalFa
 import static extension tools.vitruv.framework.domains.repository.DomainAwareResourceSet.awareOfDomains
 import tools.vitruv.framework.change.recording.ChangeRecorder
 import tools.vitruv.framework.change.description.TransactionalChange
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
 
 @ExtendWith(TestProjectManager, RegisterMetamodelsInStandalone)
 abstract class ChangeDescription2ChangeTransformationTest {
@@ -44,7 +44,7 @@ abstract class ChangeDescription2ChangeTransformationTest {
 	def void beforeTest(@TestProject Path tempFolder) {
 		this.tempFolder = tempFolder
 		this.resourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(TestDomainsRepository.INSTANCE)
-		this.uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet)
+		this.uuidGeneratorAndResolver = createUuidGeneratorAndResolver(resourceSet)
 		this.changeRecorder = new ChangeRecorder(uuidGeneratorAndResolver)
 		this.resourceSet.startRecording
 	}

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
@@ -2,7 +2,6 @@ package tools.vitruv.framework.tests.change.recording
 
 import org.junit.jupiter.api.Test
 import tools.vitruv.framework.change.recording.ChangeRecorder
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.resource.ResourceSet
 import org.junit.jupiter.api.DisplayName
@@ -36,13 +35,14 @@ import tools.vitruv.testutils.RegisterMetamodelsInStandalone
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
 import org.eclipse.emf.ecore.InternalEObject
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
 
 @ExtendWith(TestProjectManager, RegisterMetamodelsInStandalone)
 class ChangeRecorderTest {
 	// this test only covers general behaviour of ChangeRecorder. Whether it always produces correct change sequences
 	// is covered by other tests
 	val ResourceSet resourceSet = new ResourceSetImpl().withGlobalFactories()
-	var ChangeRecorder changeRecorder = new ChangeRecorder(new UuidGeneratorAndResolverImpl(resourceSet))
+	var ChangeRecorder changeRecorder = new ChangeRecorder(createUuidGeneratorAndResolver(resourceSet))
 	
 	@Test
 	@DisplayName("records direct changes to an object")
@@ -660,8 +660,8 @@ class ChangeRecorderTest {
 	@Test
 	@DisplayName("registers the recorded object and all its contents at the UUID resolver")
 	def void registersAtUuidResolver() {
-		val parentResolver = new UuidGeneratorAndResolverImpl(new ResourceSetImpl)
-		val localResolver = new UuidGeneratorAndResolverImpl(parentResolver, resourceSet)
+		val parentResolver = createUuidGeneratorAndResolver(new ResourceSetImpl())
+		val localResolver = createUuidGeneratorAndResolver(parentResolver, resourceSet)
 		var ChangeRecorder changeRecorder = new ChangeRecorder(localResolver)
 		
 		val root = aet.Root => [

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/EdgeCaseStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/EdgeCaseStateChangeTest.xtend
@@ -3,10 +3,10 @@ package tools.vitruv.framework.tests.domains
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.junit.jupiter.api.Test
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
 
 class EdgeCaseStateChangeTest extends StateChangePropagationTest {
 
@@ -32,7 +32,7 @@ class EdgeCaseStateChangeTest extends StateChangePropagationTest {
 	@Test
 	def void testNullResources() {
 		val resourceSet = new ResourceSetImpl
-		val resolver = new UuidGeneratorAndResolverImpl(resourceSet)
+		val resolver = createUuidGeneratorAndResolver(resourceSet)
 		val Resource nullResource = null
 		val change = strategyToTest.getChangeSequences(nullResource, nullResource, resolver)
 		assertTrue(change.EChanges.empty, "Composite change contains children!")

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/StateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/StateChangePropagationTest.xtend
@@ -11,7 +11,6 @@ import tools.vitruv.framework.change.description.VitruviusChangeFactory
 import tools.vitruv.framework.util.bridges.EMFBridge
 import tools.vitruv.framework.util.bridges.EcoreResourceBridge
 import tools.vitruv.framework.uuid.UuidGeneratorAndResolver
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 import uml_mockup.UPackage
 import tools.vitruv.framework.domains.StateBasedChangeResolutionStrategy
 import tools.vitruv.framework.domains.DefaultStateBasedChangeResolutionStrategy
@@ -32,6 +31,7 @@ import static extension tools.vitruv.framework.util.ResourceSetUtil.withGlobalFa
 import static extension tools.vitruv.framework.domains.repository.DomainAwareResourceSet.awareOfDomains
 import tools.vitruv.framework.change.recording.ChangeRecorder
 import org.eclipse.emf.ecore.util.EcoreUtil
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
 
 @ExtendWith(TestProjectManager, TestLogging, RegisterMetamodelsInStandalone)
 abstract class StateChangePropagationTest {
@@ -61,7 +61,7 @@ abstract class StateChangePropagationTest {
 		strategyToTest = new DefaultStateBasedChangeResolutionStrategy
 		resourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(TestDomainsRepository.INSTANCE)
 		checkpointResourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(TestDomainsRepository.INSTANCE)
-		setupResolver = new UuidGeneratorAndResolverImpl(resourceSet)
+		setupResolver = createUuidGeneratorAndResolver(resourceSet)
 		changeRecorder = new ChangeRecorder(setupResolver)
 		// Create mockup models:
 		resourceSet.startRecording
@@ -69,7 +69,7 @@ abstract class StateChangePropagationTest {
 		createUmlMockupModel()
 		endRecording
 		// change to new recorder with test resolver, create model checkpoints and start recording:
-		checkpointResolver = new UuidGeneratorAndResolverImpl(setupResolver, checkpointResourceSet)
+		checkpointResolver = createUuidGeneratorAndResolver(setupResolver, checkpointResourceSet)
 		umlCheckpoint = umlModel.createCheckpoint
 		pcmCheckpoint = pcmModel.createCheckpoint
 		umlModel.startRecording

--- a/tests/framework/tools.vitruv.framework.uuid.tests/src/tools/vitruv/framework/uuid/tests/UuidGeneratorAndResolverImplTest.xtend
+++ b/tests/framework/tools.vitruv.framework.uuid.tests/src/tools/vitruv/framework/uuid/tests/UuidGeneratorAndResolverImplTest.xtend
@@ -9,7 +9,6 @@ import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.aet
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import static extension tools.vitruv.framework.util.ResourceSetUtil.withGlobalFactories
 import org.eclipse.emf.common.util.URI
-import tools.vitruv.framework.uuid.UuidGeneratorAndResolverImpl
 import tools.vitruv.testutils.TestProject
 import java.nio.file.Path
 import static org.junit.jupiter.api.Assertions.assertEquals
@@ -24,6 +23,8 @@ import tools.vitruv.framework.uuid.UuidGeneratorAndResolver
 import static tools.vitruv.testutils.matchers.ModelMatchers.containsModelOf
 import static org.hamcrest.MatcherAssert.assertThat
 import allElementTypes.Root
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
+import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createAndLoadUuidGeneratorAndResolver
 
 @ExtendWith(TestProjectManager, RegisterMetamodelsInStandalone)
 class UuidGeneratorAndResolverImplTest {
@@ -35,14 +36,14 @@ class UuidGeneratorAndResolverImplTest {
 	def void setup(@TestProject Path testProjectPath) {
 		this.testProjectPath = testProjectPath
 		this.resourceSet = new ResourceSetImpl().withGlobalFactories()
-		this.uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet)
+		this.uuidGeneratorAndResolver = createUuidGeneratorAndResolver(resourceSet)
 	}
 
 	@Test
 	@DisplayName("resolve UUID in parent resolver for object with root container not being its resource root")
 	def void parentResolveRootContainerNotResourceRoot() {
 		val childResourceSet = new ResourceSetImpl().withGlobalFactories()
-		val childUuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(uuidGeneratorAndResolver, childResourceSet)
+		val childUuidGeneratorAndResolver = createUuidGeneratorAndResolver(uuidGeneratorAndResolver, childResourceSet)
 
 		// Model generation
 		val nonRoot = aet.NonRoot
@@ -72,7 +73,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("resolve UUID in parent resolver for multiple root elements")
 	def void parentResolveOneOfMultipleRootElements() {
 		val childResourceSet = new ResourceSetImpl().withGlobalFactories()
-		val childUuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(uuidGeneratorAndResolver, childResourceSet)
+		val childUuidGeneratorAndResolver = createUuidGeneratorAndResolver(uuidGeneratorAndResolver, childResourceSet)
 
 		// Model generation
 		val firstRoot = aet.Root
@@ -102,7 +103,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("resolve UUID in parent resolver for contents of multiple root elements")
 	def void parentResolveElementsContainedInOneOfMultipleRootElements() {
 		val childResourceSet = new ResourceSetImpl().withGlobalFactories()
-		val childUuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(uuidGeneratorAndResolver, childResourceSet)
+		val childUuidGeneratorAndResolver = createUuidGeneratorAndResolver(uuidGeneratorAndResolver, childResourceSet)
 
 		// Model generation
 		val firstNonRoot = aet.NonRoot
@@ -215,7 +216,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("load UUIDs stored to a resource")
 	def void existAllUuidsAfterReload() {
 		val uuidUri = URI.createFileURI(testProjectPath.resolve("uuid.uuid").toString)
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createUuidGeneratorAndResolver(this.resourceSet, uuidUri)
 		val root = aet.Root
 		val nonRoot = aet.NonRoot
 		resourceSet.createResource(URI.createFileURI(testProjectPath.resolve("root.aet").toString)) => [
@@ -226,7 +227,7 @@ class UuidGeneratorAndResolverImplTest {
 		val rootUuid = uuidGeneratorAndResolver.generateUuid(root)
 		val nonRootUuid = uuidGeneratorAndResolver.generateUuid(nonRoot)
 		uuidGeneratorAndResolver.save()
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createAndLoadUuidGeneratorAndResolver(this.resourceSet, uuidUri)
 		assertEquals(rootUuid, uuidGeneratorAndResolver.getUuid(root))
 		assertEquals(nonRootUuid, uuidGeneratorAndResolver.getUuid(nonRoot))
 	}
@@ -235,7 +236,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("load UUIDs stored to a resource for part of model")
 	def void existAllUuidsAfterReloadForPartOfModel() {
 		val uuidUri = URI.createFileURI(testProjectPath.resolve("uuid.uuid").toString)
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createUuidGeneratorAndResolver(this.resourceSet, uuidUri)
 		val root = aet.Root
 		val nonRoot = aet.NonRoot
 		resourceSet.createResource(URI.createFileURI(testProjectPath.resolve("root.aet").toString)) => [
@@ -245,7 +246,7 @@ class UuidGeneratorAndResolverImplTest {
 		]
 		val rootUuid = uuidGeneratorAndResolver.generateUuid(root)
 		uuidGeneratorAndResolver.save()
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createAndLoadUuidGeneratorAndResolver(this.resourceSet, uuidUri)
 		assertEquals(rootUuid, uuidGeneratorAndResolver.getUuid(root))
 		assertThrows(IllegalStateException) [uuidGeneratorAndResolver.getUuid(nonRoot)]
 	}
@@ -254,7 +255,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("load UUIDs stored to a resource after cleanup")
 	def void existAllUuidsAfterReloadWithCleanup() {
 		val uuidUri = URI.createFileURI(testProjectPath.resolve("uuid.uuid").toString)
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createUuidGeneratorAndResolver(this.resourceSet, uuidUri)
 		val root = aet.Root
 		val nonRoot = aet.NonRoot
 		resourceSet.createResource(URI.createFileURI(testProjectPath.resolve("root.aet").toString)) => [
@@ -266,7 +267,7 @@ class UuidGeneratorAndResolverImplTest {
 		uuidGeneratorAndResolver.generateUuid(nonRoot)
 		root.singleValuedContainmentEReference = null
 		uuidGeneratorAndResolver.save()
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createAndLoadUuidGeneratorAndResolver(this.resourceSet, uuidUri)
 		assertEquals(rootUuid, uuidGeneratorAndResolver.getUuid(root))
 		assertThrows(IllegalStateException) [uuidGeneratorAndResolver.getUuid(nonRoot)]
 	}
@@ -275,7 +276,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("load UUIDs stored to a resource and resolve elements in new resource set")
 	def void existAllUuidsAfterReloadWithNewResourceSet() {
 		val uuidUri = URI.createFileURI(testProjectPath.resolve("uuid.uuid").toString)
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createUuidGeneratorAndResolver(this.resourceSet, uuidUri)
 		val root = aet.Root
 		val nonRoot = aet.NonRoot
 		val originalResource = resourceSet.createResource(URI.createFileURI(testProjectPath.resolve("root.aet").toString)) => [
@@ -288,7 +289,7 @@ class UuidGeneratorAndResolverImplTest {
 		val nonRootUuid = uuidGeneratorAndResolver.generateUuid(nonRoot)
 		uuidGeneratorAndResolver.save()
 		val newResourceSet = new ResourceSetImpl().withGlobalFactories
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(newResourceSet , uuidUri)
+		uuidGeneratorAndResolver = createAndLoadUuidGeneratorAndResolver(newResourceSet , uuidUri)
 		assertFalse(newResourceSet.resources.empty)
 		val newResource = newResourceSet.resources.get(0) 
 		assertFalse(newResource.contents.empty)
@@ -304,7 +305,7 @@ class UuidGeneratorAndResolverImplTest {
 	@DisplayName("try load UUIDs referencing non-existent elements")
 	def void notIgnoreUuidsForNonExistentElements() {
 		val uuidUri = URI.createFileURI(testProjectPath.resolve("uuid.uuid").toString)
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createUuidGeneratorAndResolver(this.resourceSet, uuidUri)
 		val root = aet.Root
 		resourceSet.createResource(URI.createFileURI(testProjectPath.resolve("root.aet").toString)) => [
 			contents += root
@@ -312,14 +313,14 @@ class UuidGeneratorAndResolverImplTest {
 		uuidGeneratorAndResolver.generateUuid(root)
 		uuidGeneratorAndResolver.save()
 		val newResourceSet = new ResourceSetImpl().withGlobalFactories
-		assertThrows(IllegalStateException) [new UuidGeneratorAndResolverImpl(newResourceSet, uuidUri)]
+		assertThrows(IllegalStateException) [createAndLoadUuidGeneratorAndResolver(newResourceSet, uuidUri)]
 	}
 	
 	@Test
 	@DisplayName("try load UUIDs referencing elements in non-existent resource")
 	def void notIgnoreUuidsForNonExistentResource() {
 		val uuidUri = URI.createFileURI(testProjectPath.resolve("uuid.uuid").toString)
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(this.resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createUuidGeneratorAndResolver(this.resourceSet, uuidUri)
 		val root = aet.Root
 		resourceSet.createResource(URI.createFileURI(testProjectPath.resolve("root.aet").toString)) => [
 			contents += root
@@ -327,25 +328,44 @@ class UuidGeneratorAndResolverImplTest {
 		uuidGeneratorAndResolver.generateUuid(root)
 		uuidGeneratorAndResolver.save()
 		val newResourceSet = new ResourceSetImpl().withGlobalFactories
-		assertThrows(IllegalStateException) [new UuidGeneratorAndResolverImpl(newResourceSet, uuidUri)]
+		assertThrows(IllegalStateException) [createAndLoadUuidGeneratorAndResolver(newResourceSet, uuidUri)]
 	}
 	
 	@Test
 	@DisplayName("store and load UUIDs multiple times")
 	def void storeAndReloadUuidRepositoryMultipleTimes() {
 		val uuidUri = URI.createFileURI(testProjectPath.resolve("uuid.uuid").toString)
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createUuidGeneratorAndResolver(resourceSet, uuidUri)
 		val root = aet.Root
 		resourceSet.createResource(URI.createFileURI(testProjectPath.resolve("root.aet").toString)) => [
 			contents += root
 		]
 		val rootUuid = uuidGeneratorAndResolver.generateUuid(root)
 		uuidGeneratorAndResolver.save()
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createAndLoadUuidGeneratorAndResolver(resourceSet, uuidUri)
 		uuidGeneratorAndResolver.save()
 		assertEquals(1, new ResourceSetImpl().withGlobalFactories.getResource(uuidUri, true).contents.size)
-		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet, uuidUri)
+		uuidGeneratorAndResolver = createAndLoadUuidGeneratorAndResolver(resourceSet, uuidUri)
 		assertEquals(rootUuid, uuidGeneratorAndResolver.getUuid(root))
+	}
+	
+	@Test
+	@DisplayName("create second UUID resource and overwrite first one")
+	def void overwriteExistingUuidsWhenCreatingResolverWithoutLoading() {
+		val uuidUri = URI.createFileURI(testProjectPath.resolve("uuid.uuid").toString)
+		uuidGeneratorAndResolver = createUuidGeneratorAndResolver(resourceSet, uuidUri)
+		val root = aet.Root
+		resourceSet.createResource(URI.createFileURI(testProjectPath.resolve("root.aet").toString)) => [
+			contents += root
+		]
+		val rootUuid = uuidGeneratorAndResolver.generateUuid(root)
+		uuidGeneratorAndResolver.save()
+		uuidGeneratorAndResolver = createUuidGeneratorAndResolver(resourceSet, uuidUri)
+		val newRootUuid = uuidGeneratorAndResolver.generateUuid(root)
+		uuidGeneratorAndResolver.save()
+		uuidGeneratorAndResolver = createAndLoadUuidGeneratorAndResolver(resourceSet, uuidUri)
+		assertNotEquals(rootUuid, uuidGeneratorAndResolver.getUuid(root))
+		assertEquals(newRootUuid, uuidGeneratorAndResolver.getUuid(root))
 	}
 
 }

--- a/tests/framework/tools.vitruv.framework.uuid.tests/src/tools/vitruv/framework/uuid/tests/UuidGeneratorAndResolverImplTest.xtend
+++ b/tests/framework/tools.vitruv.framework.uuid.tests/src/tools/vitruv/framework/uuid/tests/UuidGeneratorAndResolverImplTest.xtend
@@ -312,7 +312,7 @@ class UuidGeneratorAndResolverImplTest {
 		uuidGeneratorAndResolver.generateUuid(root)
 		uuidGeneratorAndResolver.save()
 		val newResourceSet = new ResourceSetImpl().withGlobalFactories
-		assertThrows(IllegalStateException) [new UuidGeneratorAndResolverImpl(newResourceSet , uuidUri)]
+		assertThrows(IllegalStateException) [new UuidGeneratorAndResolverImpl(newResourceSet, uuidUri)]
 	}
 	
 	@Test
@@ -327,7 +327,25 @@ class UuidGeneratorAndResolverImplTest {
 		uuidGeneratorAndResolver.generateUuid(root)
 		uuidGeneratorAndResolver.save()
 		val newResourceSet = new ResourceSetImpl().withGlobalFactories
-		assertThrows(IllegalStateException) [new UuidGeneratorAndResolverImpl(newResourceSet , uuidUri)]
+		assertThrows(IllegalStateException) [new UuidGeneratorAndResolverImpl(newResourceSet, uuidUri)]
+	}
+	
+	@Test
+	@DisplayName("store and load UUIDs multiple times")
+	def void storeAndReloadUuidRepositoryMultipleTimes() {
+		val uuidUri = URI.createFileURI(testProjectPath.resolve("uuid.uuid").toString)
+		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet, uuidUri)
+		val root = aet.Root
+		resourceSet.createResource(URI.createFileURI(testProjectPath.resolve("root.aet").toString)) => [
+			contents += root
+		]
+		val rootUuid = uuidGeneratorAndResolver.generateUuid(root)
+		uuidGeneratorAndResolver.save()
+		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet, uuidUri)
+		uuidGeneratorAndResolver.save()
+		assertEquals(1, new ResourceSetImpl().withGlobalFactories.getResource(uuidUri, true).contents.size)
+		uuidGeneratorAndResolver = new UuidGeneratorAndResolverImpl(resourceSet, uuidUri)
+		assertEquals(rootUuid, uuidGeneratorAndResolver.getUuid(root))
 	}
 
 }

--- a/tests/framework/tools.vitruv.framework.uuid.tests/src/tools/vitruv/framework/uuid/tests/UuidGeneratorAndResolverImplTest.xtend
+++ b/tests/framework/tools.vitruv.framework.uuid.tests/src/tools/vitruv/framework/uuid/tests/UuidGeneratorAndResolverImplTest.xtend
@@ -161,7 +161,7 @@ class UuidGeneratorAndResolverImplTest {
 		]
 		assertEquals(uuid, uuidGeneratorAndResolver.getUuid(root))
 	}
-	
+
 	@Test
 	@DisplayName("resolve UUID during element movement to different container")
 	def void elementMovementWithResolutionInTransientStateKeepsUuid() {
@@ -177,7 +177,7 @@ class UuidGeneratorAndResolverImplTest {
 		]
 		assertEquals(uuid, uuidGeneratorAndResolver.getUuid(root))
 	}
-	
+
 	@Test
 	@DisplayName("cleanup resolver after element removal from resource")
 	def void cleanupAfterElementRemovalRemovesUuid() {
@@ -186,12 +186,12 @@ class UuidGeneratorAndResolverImplTest {
 			contents += root
 		]
 		val uuid = uuidGeneratorAndResolver.generateUuid(root)
-		uuidGeneratorAndResolver.cleanupRemovedElements
+		uuidGeneratorAndResolver.save()
 		assertEquals(uuid, uuidGeneratorAndResolver.getUuid(root))
 		resource.contents.clear
 		assertEquals(uuid, uuidGeneratorAndResolver.getUuid(root))
-		uuidGeneratorAndResolver.cleanupRemovedElements
-		assertThrows(IllegalStateException) [uuidGeneratorAndResolver.getUuid(root)]
+		uuidGeneratorAndResolver.save()
+		assertThrows(IllegalStateException)[uuidGeneratorAndResolver.getUuid(root)]
 	}
 
 }


### PR DESCRIPTION
This PR adds functionality for cleaning up and saving the `UuidGeneratorAndResolverImpl` while separating it from models resources and effects to them. In detail it provides the following:
* Functionality for cleaning up removed elements in `UuidGeneratorAndResolverImpl`, i.e., removing elements that are not placed in a resource anymore, which is automatically executed on saving the instance.
* Placement of the Uuid resource in a separate resource set, which was placed in the models' resource set before. This is useful because some Ecore functionality (such as `EcoreUtil.delete`) uses the cross referencer for a complete resource set, thus unintentionally affecting the UUID model. For example, calling `EcoreUtil.delete` on a model object will also remove it from the repository of the UUID resolver if placed in the same resource set. See also #441, for which this is a replacement. In addition, the resource in now managed within the `UuidGeneratorAndResolverImpl` (as it uses a separate resource set anyway).
* Have the resource of the `UuidGeneratorAndResolver` automatically saved (and cleaned up on save) in the `ResourceRepositoryImpl`. This only possible because of element cleanup, as otherwise orphan elements without a resource prevent the serialization of the resource.
* Proper implementation of load functionality for the `UuidGeneratorAndResolverImpl`, resolving the elements in the models' resource set. This also serves as a loading functionality for the model resources of a `VirtualModel`, such that storing them separately is not necessary. The UUID storage contains all necessary information about model resources to be loaded.
* Addition of UUID test cases for element movement, element deletion, resolver cleanup and saving, as well as different loading scenarios.

Replaces and closes #441.
Fixes #298.