### PR TITLE
Log UUIDs of Changes and Reduce UUID Addition Log Level

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteChangeImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/description/impl/ConcreteChangeImpl.xtend
@@ -205,31 +205,40 @@ class ConcreteChangeImpl implements ConcreteChange {
     	}
     }
     
-    def private getNewValueString(EObjectAddedEChange<?> change) {
-    	change.newValue?.toString ?: "id=" + change.newValueID
-    }
-    
-    def private getOldValueString(EObjectSubtractedEChange<?> change) {
-    	change.oldValue?.toString ?: "id=" + change.oldValueID
-    }
+	def private getNewValueString(EObjectAddedEChange<?> change) {
+		formatValueString(change.newValue, change.newValueID)
+	}
+	
+	def private getOldValueString(EObjectSubtractedEChange<?> change) {
+		formatValueString(change.oldValue, change.oldValueID)
+	}
+	
+	def private getAffectedObjectString(EObjectExistenceEChange<?> change) {
+		formatValueString(change.affectedEObject, change.affectedEObjectID)
+	}
+	
+	def private getAffectedObjectString(FeatureEChange<?, ?> change) {
+		formatValueString(change.affectedEObject, change.affectedEObjectID)
+	}
+	
+	def private getAffectedFeatureString(FeatureEChange<?, ?> change) {
+		'''«change.affectedObjectString».«change.affectedFeature.name»'''
+	}
+	
+	def private newValueString(AdditiveReferenceEChange<?, ?> change) {
+		formatValueString(change.newValue, change.newValueID)
+	}
+	
+	def private oldValueString(SubtractiveReferenceEChange<?, ?> change) {
+		formatValueString(change.oldValue, change.oldValueID)
+	}
+	
+	def private formatValueString(Object value, String id) {
+		if (value !== null) {
+			'''«value» (id=«id»)'''
+		} else {
+			'''id=«id»'''
+		}
+	}
 
-    def private getAffectedObjectString(EObjectExistenceEChange<?> change) {
-    	change.affectedEObject?.toString ?: change.affectedEObjectType.name + " id=" + change.affectedEObjectID
-    }
-    
-    def private getAffectedObjectString(FeatureEChange<?, ?> change) {
-    	change.affectedEObject?.toString ?: "id=" + change.affectedEObjectID
-    }
-    
-    def private getAffectedFeatureString(FeatureEChange<?, ?> change) {
-    	'''«change.affectedObjectString».«change.affectedFeature.name»'''
-    }
-    
-    def private newValueString(AdditiveReferenceEChange<?, ?> change) {
-    	change.newValue?.toString ?: "id=" + change.newValueID
-    }
-    
-    def private oldValueString(SubtractiveReferenceEChange<?, ?> change) {
-    	change.oldValue?.toString ?: "id=" + change.oldValueID
-    }
 }

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -187,7 +187,7 @@ class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 
 	override registerEObject(String uuid, EObject eObject) {
 		checkState(eObject !== null, "Object must not be null")
-		if (logger.isDebugEnabled) logger.debug('''Adding UUID «uuid» for EObject: «eObject»''')
+		if (logger.isTraceEnabled) logger.trace('''Adding UUID «uuid» for EObject: «eObject»''')
 		
 		val uuidMapped = repository.uuidToEObject.put(uuid, eObject)
 		if (uuidMapped !== null) {


### PR DESCRIPTION
1. Adds UUIDs to the log output of changes, even if the change is resolved. This is especially useful to trace which elements are the same, even if their contents have changed (or which are not the same although they should be).
2. Reduces the log level for UUID additions to the `UuidGeneratorAndResolverImpl` to trace level, as the information conforms to what we usually consider trace information (such as called reactions/routines etc.) and is usually not necessary for ordinary debugging (which is also the reason why we had an `enableIdLoggers` system argument and explicitly disabled the logging when it was not set in the past).