### PR TITLE
Add GitHub Action for Validation Against Applications

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -1,0 +1,92 @@
+name: Application Validation
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Framework
+        uses: actions/checkout@v2
+        with:
+          path: framework
+      - name: Checkout CBS Domains
+        uses: actions/checkout@v2
+        with:
+          path: cbsdomains
+          repository: vitruv-tools/Vitruv-Domains-ComponentBasedSystems
+          ref: master
+      - name: Checkout CBS Applications
+        uses: actions/checkout@v2
+        with:
+          path: cbsapplications
+          repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
+          ref: master
+      - name: Checkout Matching Domains/Applications Branches
+        run: |
+          cd cbsdomains
+          git checkout -B ${{ github.head_ref }}
+          cd ../cbsapplications
+          git checkout -B ${{ github.head_ref }}
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Adapt Updatesite
+        run: |
+          sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/framework/#file:///${maven.multiModuleProjectDirectory}/../framework/releng/tools.vitruv.updatesite.aggregated/target/final#wresult' cbsdomains/releng/tools.vitruv.domains.cbs.parent/pom.xml
+          if [ ! -s result ]; then exit 1; fi;
+          sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/framework/#file:///${maven.multiModuleProjectDirectory}/../framework/releng/tools.vitruv.updatesite.aggregated/target/final#wresult' cbsapplications/releng/tools.vitruv.applications.cbs.parent/pom.xml
+          if [ ! -s result ]; then exit 1; fi;
+          sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/#file:///${maven.multiModuleProjectDirectory}/../cbsdomains/releng/tools.vitruv.domains.cbs.updatesite.aggregated/target/final#wresult' cbsapplications/releng/tools.vitruv.applications.cbs.parent/pom.xml
+          if [ ! -s result ]; then exit 1; fi;
+      - name: Build Framework
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          working-directory: ./framework
+          run: >
+            ./mvnw -B clean verify 
+            -Dstyle.color=always
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env: 
+          MAVEN_OPTS: -Djansi.force=true
+      - name: Build Domains
+        working-directory: ./cbsdomains
+        run: >
+            ./mvnw -B clean verify
+            -Dstyle.color=always
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env: 
+          MAVEN_OPTS: -Djansi.force=true
+      - name: Build Applications
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          working-directory: ./cbsapplications
+          run: >
+            ./mvnw -B clean verify
+            -Dstyle.color=always
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env: 
+          MAVEN_OPTS: -Djansi.force=true


### PR DESCRIPTION
This PR adds a GitHub action that validates the [CBS applications](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems) against the framework changes propsed in a pull request. See the discussion in #427.

It uses the `master` branches of the CBS domains and applications or, if existing, the branches with the same name as the one of the pull request. This will currently only work if the branch is present in the repository of the `vitruv-tools` organization and not in a fork.

Closes #427.