### PR TITLE
Do not Execute Tests in GH Action for Application Validation

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Adapt Updatesite
+      - name: Adapt Updatesites
         run: |
           sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/framework/#file:///${maven.multiModuleProjectDirectory}/../framework/releng/tools.vitruv.updatesite.aggregated/target/final#wresult' cbsdomains/releng/tools.vitruv.domains.cbs.parent/pom.xml
           if [ ! -s result ]; then exit 1; fi;

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           working-directory: ./framework
           run: >
-            ./mvnw -B package
+            ./mvnw -B package -Dmaven.test.skip=true
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -17,12 +17,14 @@ jobs:
           path: cbsdomains
           repository: vitruv-tools/Vitruv-Domains-ComponentBasedSystems
           ref: master
+          fetch-depth: 0
       - name: Checkout CBS Applications
         uses: actions/checkout@v2
         with:
           path: cbsapplications
           repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
           ref: master
+          fetch-depth: 0
       - name: Checkout Matching Domains/Applications Branches
         run: |
           cd cbsdomains

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Checkout Matching Domains/Applications Branches
         run: |
           cd cbsdomains
-          git checkout -B ${{ github.head_ref }}
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
           cd ../cbsapplications
-          git checkout -B ${{ github.head_ref }}
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           working-directory: ./framework
           run: >
-            ./mvnw -B clean verify 
+            ./mvnw -B package
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn


### PR DESCRIPTION
Only runs `package` instead of `verify` for the framework projects in application validation GitHub action.
See proposal in #445.

In addition, fixes the checkout of branches from the domains and applications repositories, which was not working properly before.