### PR TITLE
State-Based Propagation Improvement

### DIFF
--- a/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/AbstractVitruvDomain.xtend
+++ b/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/AbstractVitruvDomain.xtend
@@ -53,7 +53,7 @@ abstract class AbstractVitruvDomain extends AbstractURIHaving implements VitruvD
 		this.nsURIs = (metamodelRootPackage.nsURIsRecursive + furtherRootPackages.map[nsURIsRecursive].flatten).toSet
 		this.defaultLoadOptions = new HashMap(defaultLoadOptions)
 		this.defaultSaveOptions = new HashMap(defaultSaveOptions)
-		stateChangePropagationStrategy = new DefaultStateBasedChangeResolutionStrategy()
+		stateChangePropagationStrategy = new DefaultStateBasedChangeResolutionStrategy(#{this})
 	}
 
 	override StateBasedChangeResolutionStrategy getStateChangePropagationStrategy() {

--- a/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/StateBasedChangeResolutionStrategy.xtend
+++ b/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/StateBasedChangeResolutionStrategy.xtend
@@ -12,8 +12,8 @@ interface StateBasedChangeResolutionStrategy {
 
 	/**
 	 * Resolves the state-based delta of two resources and returns the correlating change sequences.
-	 * @param newState is the new state of the resource, must not be <code>null</code>.
-	 * @param oldState is the current or old state of the resource, must not be <code>null</code>.
+	 * @param newState is the new state of the resource, must not be <code>null</code> and must not contain proxies.
+	 * @param oldState is the current or old state of the resource, must not be <code>null</code> and must not contain proxies.
 	 * @param uuidResolver is the UUID resolver of the virtual model using this propagation strategy, must not be <code>null</code>.
 	 * @return a {@link VitruviusChange} that contains the individual change sequence.
 	 */
@@ -21,7 +21,7 @@ interface StateBasedChangeResolutionStrategy {
 	
 	/**
 	 * Resolves the state-based delta for creating the given resource and returns the correlating change sequences.
-	 * @param newState is the new state of the resource, must not be <code>null</code>.
+	 * @param newState is the new state of the resource, must not be <code>null</code> and must not contain proxies.
 	 * @param uuidResolver is the UUID resolver of the virtual model using this propagation strategy, must not be <code>null</code>.
 	 * @return a {@link VitruviusChange} that contains the individual change sequence.
 	 */
@@ -29,7 +29,7 @@ interface StateBasedChangeResolutionStrategy {
 	
 	/**
 	 * Resolves the state-based delta for deleting the given resource and returns the correlating change sequences.
-	 * @param oldState is the new state of the resource, must not be <code>null</code>.
+	 * @param oldState is the new state of the resource, must not be <code>null</code> and must not contain proxies.
 	 * @param uuidResolver is the UUID resolver of the virtual model using this propagation strategy, must not be <code>null</code>.
 	 * @return a {@link VitruviusChange} that contains the individual change sequence.
 	 */

--- a/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/StateBasedChangeResolutionStrategy.xtend
+++ b/bundles/framework/tools.vitruv.framework.domains/src/tools/vitruv/framework/domains/StateBasedChangeResolutionStrategy.xtend
@@ -12,10 +12,26 @@ interface StateBasedChangeResolutionStrategy {
 
 	/**
 	 * Resolves the state-based delta of two resources and returns the correlating change sequences.
-	 * @param newState is the new state of the resource.
-	 * @param currentState is the current or old state of the resource.
-	 * @param uuidResolver is the UUID resolver of the virtual model using this propagation strategy.
-	 * @return a {@link VitruviusChange} that contains the individual change sequences.
+	 * @param newState is the new state of the resource, must not be <code>null</code>.
+	 * @param oldState is the current or old state of the resource, must not be <code>null</code>.
+	 * @param uuidResolver is the UUID resolver of the virtual model using this propagation strategy, must not be <code>null</code>.
+	 * @return a {@link VitruviusChange} that contains the individual change sequence.
 	 */
-	def VitruviusChange getChangeSequences(Resource newState, Resource currentState, UuidResolver resolver)
+	def VitruviusChange getChangeSequenceBetween(Resource newState, Resource oldState, UuidResolver resolver)
+	
+	/**
+	 * Resolves the state-based delta for creating the given resource and returns the correlating change sequences.
+	 * @param newState is the new state of the resource, must not be <code>null</code>.
+	 * @param uuidResolver is the UUID resolver of the virtual model using this propagation strategy, must not be <code>null</code>.
+	 * @return a {@link VitruviusChange} that contains the individual change sequence.
+	 */
+	def VitruviusChange getChangeSequenceForCreated(Resource newState, UuidResolver resolver)
+	
+	/**
+	 * Resolves the state-based delta for deleting the given resource and returns the correlating change sequences.
+	 * @param oldState is the new state of the resource, must not be <code>null</code>.
+	 * @param uuidResolver is the UUID resolver of the virtual model using this propagation strategy, must not be <code>null</code>.
+	 * @return a {@link VitruviusChange} that contains the individual change sequence.
+	 */
+	def VitruviusChange getChangeSequenceForDeleted(Resource oldState, UuidResolver resolver)
 }

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/bridges/EcoreResourceBridge.xtend
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/bridges/EcoreResourceBridge.xtend
@@ -1,76 +1,71 @@
-/*******************************************************************************
+/** 
  * Copyright (c) 2012 University of Luxembourg and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
  * Contributors:
- *     Max E. Kramer - initial API and implementation
- ******************************************************************************/
-package tools.vitruv.framework.util.bridges;
+ * Max E. Kramer - initial API and implementation
+ */
+package tools.vitruv.framework.util.bridges
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.util.Collections
+import java.util.List
+import java.util.Map
+import java.util.Set
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.EPackage
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.ecore.resource.ResourceSet
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl
+import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil
+import static com.google.common.base.Preconditions.checkArgument
 
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EPackage;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
-
-import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil;
-
-/**
+/** 
  * A utility class hiding details of the resources part of the Eclipse Modeling
  * Framework API related for recurring tasks that are not project-specific.<br/>
  * <br/>
  * (Note that it is disputable whether this class conforms to the bridge pattern
  * as we are currently only providing one implementation and the "abstractions"
  * can be regarded as low-level.)
- *
  * @author Max E. Kramer
  */
-public final class EcoreResourceBridge {
-	/** Utility classes should not have a public or default constructor. */
-	private EcoreResourceBridge() {
+final class EcoreResourceBridge {
+	/** 
+	 * Utility classes should not have a public or default constructor. 
+	 */
+	private new() {
 	}
 
-	/**
+	/** 
 	 * Returns a {@link Resource} that is either already loaded into and retrieved from
 	 * the given {@link ResourceSet}, or creates a new {@link Resource} if it does 
 	 * not exist yet.
-	 *
 	 * @param resourceSet the {@link ResourceSet} to load the {@link Resource} into
 	 * @param uri         the {@link URI} of the {@link Resource} to get or create
 	 * @return a {@link Resource} created for or retrieved from the given {@link URI}
 	 */
-	public static Resource getOrCreateResource(ResourceSet resourceSet, URI uri) {
-		var resource = resourceSet.getResource(uri, false);
-		if (resource == null) {
-			resource = resourceSet.createResource(uri);
+	def static Resource getOrCreateResource(ResourceSet resourceSet, URI uri) {
+		var resource = resourceSet.getResource(uri, false)
+		if (resource === null) {
+			resource = resourceSet.createResource(uri)
 		}
-		return resource;
+		return resource
 	}
-	
-	/**
-	 * Returns a {@link Resource} that is either loaded from the given {@link URI}
-	 * if some model is persisted at that {@link URI}, or creates a new
-	 * {@link Resource} if it does not exist yet.
-	 *
+
+	/** 
+	 * Returns a {@link Resource} that is either loaded from the given {@link URI}if some model is persisted at that {@link URI}, or creates a new{@link Resource} if it does not exist yet.
 	 * @param resourceSet the {@link ResourceSet} to load the {@link Resource} into
 	 * @param uri         the {@link URI} of the {@link Resource} to load
 	 * @return a {@link Resource} created for or loaded from the given {@link URI}
 	 * @throws RuntimeException if some exception occurred during loading the file
 	 */
-	public static Resource loadOrCreateResource(ResourceSet resourceSet, URI uri) throws RuntimeException {
+	def static Resource loadOrCreateResource(ResourceSet resourceSet, URI uri) throws RuntimeException {
 		try {
-			return resourceSet.getResource(uri, true);
+			return resourceSet.getResource(uri, true)
 		} catch (RuntimeException e) {
 			// EMF failed during demand creation, usually because the file did not exist. If
 			// it has created an empty resource, retrieve it.
@@ -78,222 +73,227 @@ public final class EcoreResourceBridge {
 			// FileNotFoundException, but at least also a ResourceException can occur. Since
 			// it that exception is internal, we match the message ("not exist") instead.
 			if (e.getCause() instanceof FileNotFoundException || e.getMessage().contains("not exist")) {
-				return resourceSet.getResource(uri, false);
+				return resourceSet.getResource(uri, false)
 			} else {
-				throw e;
+				throw e
 			}
 		}
+
 	}
 
-	/**
+	/** 
 	 * Returns the root element of the content of the given resource if it is unique
 	 * (exactly one root element) and {@code null} otherwise.
-	 *
 	 * @param resource a resource
 	 * @return the unique root element (if existing) otherwise {@code null}
 	 */
-	public static EObject getResourceContentRootIfUnique(final Resource resource) {
-		final List<EObject> resourceContents = resource.getContents();
-		if (resourceContents.size() == 1) {
-			return resourceContents.get(0);
+	def static EObject getResourceContentRootIfUnique(Resource resource) {
+		val List<EObject> resourceContents = resource.getContents()
+		if (resourceContents.size() === 1) {
+			return resourceContents.get(0)
 		} else {
-			return null;
+			return null
 		}
 	}
 
-	/**
+	/** 
 	 * Returns the root element of the content of the given resource if it is unique
-	 * (exactly one root element) and throws a {@link java.lang.RuntimeException
-	 * RuntimeException} otherwise.
-	 *
+	 * (exactly one root element) and throws a {@link java.lang.RuntimeExceptionRuntimeException} otherwise.
 	 * @param resource  a resource
 	 * @param modelName the name of the model represented by this resource (for
-	 *                  logging and error output)
+	 * logging and error output)
 	 * @return the root content element of the given resource
 	 */
-	public static EObject getUniqueContentRoot(final Resource resource, final String modelName) {
-		final EObject uniqueResourceContentRootElement = getResourceContentRootIfUnique(resource);
-		if (uniqueResourceContentRootElement != null) {
-			return uniqueResourceContentRootElement;
+	def static EObject getUniqueContentRoot(Resource resource, String modelName) {
+		val EObject uniqueResourceContentRootElement = getResourceContentRootIfUnique(resource)
+		if (uniqueResourceContentRootElement !== null) {
+			return uniqueResourceContentRootElement
 		} else {
 			throw new RuntimeException(
-					"The " + modelName + " '" + resource + "' has to contain exactly one root element!");
+				'''The «modelName» '«»«resource»' has to contain exactly one root element!'''.toString)
 		}
 	}
 
-	/**
+	/** 
 	 * Returns the root element of the content of the model at the given URI if it
 	 * is unique (exactly one root element) and has the type of the given class and
 	 * throws a {@link java.lang.RuntimeException RuntimeException} otherwise
-	 *
 	 * @param resource         a resource
 	 * @param modelName        the name of the model represented by this resource
-	 *                         (for logging and error output)
+	 * (for logging and error output)
 	 * @param rootElementClass the class of which the root element has to be an
-	 *                         instance of
-	 * @param <T>              the type of the root element
+	 * instance of
+	 * @param<T>
+	 *               the type of the root element
 	 * @return the root element
 	 */
-	public static <T extends EObject> T getUniqueContentRootIfCorrectlyTyped(final Resource resource,
-			final String modelName, final Class<T> rootElementClass) {
-		final EObject rootElement = getUniqueContentRoot(resource, modelName);
-		return JavaBridge.dynamicCast(rootElement, rootElementClass,
-				"root element '" + rootElement + "' of the " + modelName + " '" + resource + "'");
+	def static <T extends EObject> T getUniqueContentRootIfCorrectlyTyped(Resource resource, String modelName,
+		Class<T> rootElementClass) {
+		val EObject rootElement = getUniqueContentRoot(resource, modelName)
+		return JavaBridge::dynamicCast(rootElement, rootElementClass,
+			'''root element '«»«rootElement»' of the «modelName» '«»«resource»'«»'''.toString)
 	}
 
-	/**
+	/** 
 	 * Returns the root element of the model instance if it is the only one with a
 	 * compatible type. It is NOT necessary to have exactly one root element as long
 	 * as only one of these element matches the given type. If there is not exactly
 	 * one such element a {@link java.lang.RuntimeException RuntimeException} is
 	 * thrown.
-	 *
 	 * @param resource         a resource
 	 * @param modelName        the name of the model represented by this resource
-	 *                         (for logging and error output)
+	 * (for logging and error output)
 	 * @param rootElementClass the class of which the root element has to be an
-	 *                         instance of
-	 * @param <T>              the type of the root element
+	 * instance of
+	 * @param<T>
+	 *               the type of the root element
 	 * @return the root element
 	 */
-	@SuppressWarnings("unchecked")
-	public static <T extends EObject> T getUniqueTypedRootEObject(final Resource resource, final String modelName,
-			final Class<T> rootElementClass) {
-		T typedRootObject = null;
-		for (final EObject rootObject : resource.getContents()) {
+	@SuppressWarnings("unchecked") def static <T extends EObject> T getUniqueTypedRootEObject(Resource resource,
+		String modelName, Class<T> rootElementClass) {
+		var T typedRootObject = null
+		for (EObject rootObject : resource.getContents()) {
 			if (rootElementClass.isInstance(rootObject)) {
-				if (typedRootObject != null) {
+				if (typedRootObject !== null) {
 					throw new RuntimeException(
-							"There are more than one root objects in " + modelName + ", which match the given type.");
+						'''There are more than one root objects in «modelName», which match the given type.'''.toString)
 				}
-				typedRootObject = (T) rootObject;
+				typedRootObject = rootObject as T
 			}
 		}
-		if (typedRootObject == null) {
+		if (typedRootObject === null) {
 			throw new RuntimeException(
-					"The resource " + modelName + " does not contain a correctly typed root element.");
+				'''The resource «modelName» does not contain a correctly typed root element.'''.toString)
 		}
-		return typedRootObject;
+		return typedRootObject
 	}
 
-	/**
+	/** 
 	 * Returns the root element of the model instance, which is the first one. It is
 	 * NOT necessary to have exactly one root element. If there is not at least one
 	 * root element a {@link java.lang.IllegalStateException IllegalStateException} is thrown.
-	 *
 	 * @param resource  a resource
 	 * @param modelName the name of the model represented by this resource (for
-	 *                  logging and error output)
+	 * logging and error output)
 	 * @return the root element
 	 */
-	public static EObject getFirstRootEObject(final Resource resource, final String modelName) {
+	def static EObject getFirstRootEObject(Resource resource, String modelName) {
 		if (resource.getContents().size() < 1) {
-			throw new IllegalStateException("The resource " + modelName + " does not contain a root element.");
+			throw new IllegalStateException('''The resource «modelName» does not contain a root element.'''.toString)
 		}
-		return resource.getContents().get(0);
+		return resource.getContents().get(0)
 	}
-	
-	/**
+
+	/** 
 	 * Returns the root element of the model instance, which is the first one. It is
 	 * NOT necessary to have exactly one root element. If there is not at least one
 	 * root element a {@link java.lang.IllegalStateException IllegalStateException} is thrown.
-	 *
 	 * @param resource  a resource
 	 * @return the root element
 	 */
-	public static EObject getFirstRootEObject(final Resource resource) {
-		return getFirstRootEObject(resource, resource.getURI().toString());
-	}	
+	def static EObject getFirstRootEObject(Resource resource) {
+		return getFirstRootEObject(resource, resource.getURI().toString())
+	}
 
-	/**
+	/** 
 	 * Returns a set containing all contents of the given resource.
-	 *
 	 * @param resource a resource
 	 * @return a set containing all resource contents
 	 */
-	public static Set<EObject> getAllContentsSet(final Resource resource) {
-		return EcoreBridge.getAllContentsSet(resource.getAllContents());
+	def static Set<EObject> getAllContentsSet(Resource resource) {
+		return EcoreBridge::getAllContentsSet(resource.getAllContents())
 	}
 
-	/**
+	/** 
 	 * Saves the given eObject as the only content of the model at the given
 	 * URI.<br/>
 	 * <br/>
 	 * <b>Attention</b>: If a resource already exists at the given URI it will be
 	 * overwritten!
-	 *
 	 * @param eObject     the new root element
 	 * @param resourceURI the URI of the resource for which the content should be
-	 *                    replaced or created
+	 * replaced or created
 	 * @throws IOException if an error occurred during saving
 	 */
-	public static void saveEObjectAsOnlyContent(final EObject eObject, final URI resourceURI,
-			final ResourceSet resourceSet) throws IOException {
-		Resource resource = URIUtil.loadResourceAtURI(resourceURI, resourceSet);
-		saveEObjectAsOnlyContent(eObject, resource);
+	def static void saveEObjectAsOnlyContent(EObject eObject, URI resourceURI,
+		ResourceSet resourceSet) throws IOException {
+		var Resource resource = URIUtil::loadResourceAtURI(resourceURI, resourceSet)
+		saveEObjectAsOnlyContent(eObject, resource)
 	}
 
-	/**
+	/** 
 	 * Saves the given eObject as the only content of the given resource.
-	 *
 	 * @param eObject  the new root element
 	 * @param resource the resource for which the content should be replaced or
-	 *                 created
+	 * created
 	 * @throws IOException if an error occurred during saving
 	 */
-	public static void saveEObjectAsOnlyContent(final EObject eObject, final Resource resource) throws IOException {
-		resource.getContents().clear();
-		resource.getContents().add(eObject);
-		saveResource(resource);
+	def static void saveEObjectAsOnlyContent(EObject eObject, Resource resource) throws IOException {
+		resource.getContents().clear()
+		resource.getContents().add(eObject)
+		saveResource(resource)
 	}
 
-	/**
+	/** 
 	 * Saves the given resource.
-	 *
 	 * @param resource the resource to be saved
 	 * @throws IOException if an error occurred during saving
 	 */
-	public static void saveResource(final Resource resource) throws IOException {
-		saveResource(resource, Collections.emptyMap());
+	def static void saveResource(Resource resource) throws IOException {
+		saveResource(resource, Collections::emptyMap())
 	}
 
-	/**
+	/** 
 	 * Saves the given resource with the given options. Requires that the resource
 	 * URI is either a file URI or a platform URI. Resources with other URI types
 	 * (e.g. with a "pathmap" prefix) will not be saved
-	 *
 	 * @param resource    the resource to be saved
 	 * @param saveOptions the options for saving the resource
 	 * @throws IOException if an error occurred during saving
 	 */
-	public static void saveResource(final Resource resource, final Map<?, ?> saveOptions) throws IOException {
+	def static void saveResource(Resource resource, Map<?, ?> saveOptions) throws IOException {
 		if (resource.getURI().isPlatform() || resource.getURI().isFile()) {
-			resource.save(saveOptions);
+			resource.save(saveOptions)
 		}
 	}
 
-	public static void registerMetamodelPackageOn(ResourceSet rs, Object pckg, String... nsURIs) {
+	def static void registerMetamodelPackageOn(ResourceSet rs, Object pckg, String... nsURIs) {
 		for (String nsURI : nsURIs) {
-			rs.getPackageRegistry().put(nsURI, pckg);
+			rs.getPackageRegistry().put(nsURI, pckg)
 		}
 	}
 
-	public static void registerGlobalMetamodelPackage(String nsURI, Object pckg) {
-		EPackage.Registry.INSTANCE.put(nsURI, pckg);
+	def static void registerGlobalMetamodelPackage(String nsURI, Object pckg) {
+		EPackage::Registry::INSTANCE.put(nsURI, pckg)
 	}
 
-	public static void registerExtensionFactoryOn(ResourceSet rs, Object resourceFactory, String... fileExtensions) {
+	def static void registerExtensionFactoryOn(ResourceSet rs, Object resourceFactory, String... fileExtensions) {
 		for (String fileExtension : fileExtensions) {
-			rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put(fileExtension, resourceFactory);
+			rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put(fileExtension, resourceFactory)
 		}
 	}
 
-	public static void registerGlobalExtensionFactory(String fileExtension, Object resourceFactory) {
-		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put(fileExtension, resourceFactory);
+	def static void registerGlobalExtensionFactory(String fileExtension, Object resourceFactory) {
+		Resource::Factory::Registry::INSTANCE.getExtensionToFactoryMap().put(fileExtension, resourceFactory)
 	}
 
-	public static void registerDefaultXMIExtensionFactory(String fileExtension) {
-		registerGlobalExtensionFactory(fileExtension, new XMIResourceFactoryImpl());
+	def static void registerDefaultXMIExtensionFactory(String fileExtension) {
+		registerGlobalExtensionFactory(fileExtension, new XMIResourceFactoryImpl())
 	}
-
+	
+	/**
+	 * Retrieves all proxy elements referenced within the given {@link Resource}.
+	 * The {@link Resource} must not be <code>null</code>.
+	 */
+	def static Iterable<EObject> getReferencedProxies(Resource resource) {
+		checkArgument(resource !== null, "resource must not be null")
+		resource.allContents.toIterable.flatMap[object | object.eClass.EReferences.flatMap[
+			val contents = object.eGet(it);
+			return switch contents { 
+				List<EObject>: contents 
+				EObject: List.of(contents)
+				default: emptyList
+			}
+		].filter[eIsProxy]].toList
+	}
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.vsum/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 2.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.apache.log4j,
  tools.vitruv.framework.domains;visibility:=reexport,
+ tools.vitruv.framework.change;visibility:=reexport,
  tools.vitruv.framework.change.processing,
  org.eclipse.xtend.lib,
  org.eclipse.emf.ecore.xmi,

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/ModelRepository.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/ModelRepository.xtend
@@ -12,6 +12,8 @@ interface ModelRepository extends ResourceAccess, AutoCloseable {
 
 	def CorrespondenceModel getCorrespondenceModel()
 
+	def boolean hasModel(VURI modelVuri)
+	
 	def ModelInstance getModel(VURI modelVuri)
 
 	def void loadExistingModels()

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelImpl.xtend
@@ -1,6 +1,5 @@
 package tools.vitruv.framework.vsum
 
-import java.util.Collections
 import java.util.List
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.Resource
@@ -20,6 +19,7 @@ import java.nio.file.Path
 import static com.google.common.base.Preconditions.checkNotNull
 import java.util.LinkedList
 import static com.google.common.base.Preconditions.checkArgument
+import static com.google.common.base.Preconditions.checkState
 import tools.vitruv.framework.vsum.modelsynchronization.ChangePropagator
 
 class VirtualModelImpl implements InternalVirtualModel {
@@ -31,7 +31,7 @@ class VirtualModelImpl implements InternalVirtualModel {
 	val List<ChangePropagationListener> changePropagationListeners = new LinkedList()
 	val List<PropagatedChangeListener> propagatedChangeListeners = new LinkedList()
 	val extension ChangeDomainExtractor changeDomainExtractor
-
+	
 	package new(VsumFileSystemLayout fileSystemLayout, InternalUserInteractor userInteractor,
 		VitruvDomainRepository domainRepository,
 		ChangePropagationSpecificationProvider changePropagationSpecificationProvider) {
@@ -116,19 +116,34 @@ class VirtualModelImpl implements InternalVirtualModel {
 	 * @see tools.vitruv.framework.vsum.VirtualModel#propagateChangedState(Resource, URI)
 	 */
 	override synchronized propagateChangedState(Resource newState, URI oldLocation) {
-		if (newState === null || oldLocation === null) {
-			throw new IllegalArgumentException("New state and old location cannot be null!")
+		checkArgument(oldLocation !== null || newState !== null, "either new state or old location must not be null")
+		val currentState = oldLocation.retrieveCurrentModelState()
+		if (currentState === null) {
+			checkState(newState !== null, "new state must not be null if no resource exists for old location " + oldLocation)
 		}
-		val vuri = VURI.getInstance(oldLocation) // using the URI of a resource allows using the model resource, the model root, or any model element as input.
-		val vitruvDomain = domainRepository.getDomain(vuri.fileExtension)
-		val currentState = resourceRepository.getModel(vuri).resource
-		if (currentState.isValid(newState)) {
-			val strategy = vitruvDomain.stateChangePropagationStrategy
-			val compositeChange = strategy.getChangeSequences(newState, currentState, uuidResolver)
-			return propagateChange(compositeChange)
+		val vitruvDomain = domainRepository.getDomain(if (oldLocation !== null) oldLocation.fileExtension else newState.URI.fileExtension)
+		val strategy = vitruvDomain.stateChangePropagationStrategy
+		val compositeChange = if (currentState === null) {
+				strategy.getChangeSequenceForCreated(newState, uuidResolver)
+			} else if (newState === null) {
+				strategy.getChangeSequenceForDeleted(currentState, uuidResolver)
+			} else {
+				strategy.getChangeSequenceBetween(newState, currentState, uuidResolver)
+			}
+		if (!compositeChange.containsConcreteChange) {
+			LOGGER.warn("State-based change for " + oldLocation + " was empty")
+			return emptyList
 		}
-		LOGGER.error("Could not load current state for new state. No changes were propagated!")
-		return emptyList
+		return propagateChange(compositeChange)
+	}
+	
+	private def retrieveCurrentModelState(URI location) {
+		if (location !== null) {
+			val vuri = VURI.getInstance(location)
+			if (resourceRepository.hasModel(vuri)) { // Only retrieve the model if it already exists
+				resourceRepository.getModel(vuri).resource
+			}
+		}
 	}
 
 	override synchronized reverseChanges(List<PropagatedChange> changes) {
@@ -205,13 +220,6 @@ class VirtualModelImpl implements InternalVirtualModel {
 		for (PropagatedChangeListener propagatedChangeListener : this.propagatedChangeListeners) {
 			propagatedChangeListener.postChanges(name, sourceDomain, targetDomain, propagationResult)
 		}
-	}
-
-	/**
-	 * Confirms whether the current state is retrievable via its URI from the resource set of the new state.
-	 */
-	private def boolean isValid(Resource currentState, Resource newState) {
-		newState.resourceSet.URIConverter.exists(currentState.URI, Collections.emptyMap)
 	}
 
 	override void dispose() {

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/repositories/ResourceRepositoryImpl.xtend
@@ -171,5 +171,9 @@ class ResourceRepositoryImpl implements ModelRepository {
 		correspondencesResourceSet.resources.clear()
 		uuidGeneratorAndResolver.close()
 	}
+	
+	override hasModel(VURI modelVuri) {
+		modelInstances.containsKey(modelVuri)
+	}
 
 }

--- a/bundles/testutils/tools.vitruv.testutils.domains/src/tools/vitruv/testutils/domains/TestDomainsRepository.xtend
+++ b/bundles/testutils/tools.vitruv.testutils.domains/src/tools/vitruv/testutils/domains/TestDomainsRepository.xtend
@@ -7,9 +7,11 @@ import static tools.vitruv.testutils.metamodels.AllElementTypes2Creators.aet2
 import static tools.vitruv.testutils.metamodels.PcmMockupCreators.pcm
 import static tools.vitruv.testutils.metamodels.UmlMockupCreators.uml
 import tools.vitruv.framework.domains.repository.VitruvDomainRepositoryImpl
-import java.util.List
+import tools.vitruv.framework.domains.VitruvDomain
+import java.util.Set
 
 @Utility
 class TestDomainsRepository {
-	public static val INSTANCE = new VitruvDomainRepositoryImpl(List.of(aet.domain, aet2.domain, pcm.domain, uml.domain))
+	public static val Set<VitruvDomain> DOMAINS = Set.of(aet.domain, aet2.domain, pcm.domain, uml.domain)
+	public static val INSTANCE = new VitruvDomainRepositoryImpl(DOMAINS)
 }

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/BasicStateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/BasicStateChangePropagationTest.xtend
@@ -164,6 +164,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 					id = "Root"
 					recursiveRoot = containedRoot => [
 						id = "ContainedRoot"
+						singleValuedEAttribute = 0
 					]
 				]
 			] >> modelResource
@@ -171,7 +172,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		EcoreResourceBridge.saveResource(-modelResource)
 
 		resourceSet.record [
-			containedRoot.id = "Changed"
+			containedRoot.singleValuedEAttribute = 1
 		]
 
 		val validationResourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/BasicStateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/BasicStateChangePropagationTest.xtend
@@ -85,21 +85,23 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 	}
 
 	@Test
-	@DisplayName("change a root element id and calculate state-based difference")
-	def void changeRootElementId() {
+	@DisplayName("replace root element and calculate state-based difference")
+	def void replaceRootElement() {
 		val modelResource = new Capture<Resource>
-		val root = aet.Root
 		resourceSet.record [
 			createResource(testUri) => [
-				contents += root => [
+				contents += aet.Root => [
 					id = "Root"
 				]
 			] >> modelResource
 		]
 		EcoreResourceBridge.saveResource(-modelResource)
 
-		resourceSet.record [
-			root.id = "Change"
+		(-modelResource).record [
+			contents.clear()
+			contents += aet.Root => [
+					id = "Root2"
+				]
 		]
 
 		val validationResourceSet = new ResourceSetImpl().withGlobalFactories().awareOfDomains(

--- a/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/EdgeCaseStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.domains.tests/src/tools/vitruv/framework/tests/domains/EdgeCaseStateChangeTest.xtend
@@ -5,7 +5,6 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertThrows
-import static org.junit.jupiter.api.Assertions.assertTrue
 import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.createUuidGeneratorAndResolver
 
 class EdgeCaseStateChangeTest extends StateChangePropagationTest {
@@ -25,7 +24,7 @@ class EdgeCaseStateChangeTest extends StateChangePropagationTest {
 	def void testNoPcmChange() {
 		compareChanges(umlModel, umlCheckpoint)
 	}
-	
+
 	/**
 	 * Tests invalid input: null instead of state resources.
 	 */
@@ -34,8 +33,7 @@ class EdgeCaseStateChangeTest extends StateChangePropagationTest {
 		val resourceSet = new ResourceSetImpl
 		val resolver = createUuidGeneratorAndResolver(resourceSet)
 		val Resource nullResource = null
-		val change = strategyToTest.getChangeSequences(nullResource, nullResource, resolver)
-		assertTrue(change.EChanges.empty, "Composite change contains children!")
+		assertThrows(IllegalArgumentException)[strategyToTest.getChangeSequenceBetween(nullResource, nullResource, resolver)]
 	}
 
 	/**
@@ -44,7 +42,7 @@ class EdgeCaseStateChangeTest extends StateChangePropagationTest {
 	@Test
 	def void testNullResolver() {
 		assertThrows(IllegalArgumentException) [
-			strategyToTest.getChangeSequences(umlCheckpoint, umlCheckpoint, null)
+			strategyToTest.getChangeSequenceBetween(umlCheckpoint, umlCheckpoint, null)
 		]
 	}
 }


### PR DESCRIPTION
This PR fixes and improves the state-based change propagation. It prepares for state-based propagation of changes in Java by the Java code monitor.
* Fixes essential bugs in the default state-based propagation strategy preventing Java state comparison
* Adds support for creating and deleting resources rather than only for their modification and extends the API accordingly
* Properly extracts the information passed to the `VirtualModel` to perform state-based change propagation
* Adds a bunch of basic test cases for the state-based change propagation

⚠️ depends on #455 to ensure that UUIDs for readonly resources work properly for state comparison.

Closes #269