### PR TITLE
Simplify UUID Calculation for Readonly Resources

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/EChangeIdManager.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/EChangeIdManager.xtend
@@ -59,13 +59,6 @@ class EChangeIdManager {
 		return create;
 	}
 	
-	private def String getOrGenerateUuid(EObject object) {
-		if (uuidGeneratorAndResolver.hasUuid(object)) {
-			return uuidGeneratorAndResolver.getUuid(object);
-		}
-		return uuidGeneratorAndResolver.generateUuidWithoutCreate(object);
-	}
-	
 	private def String getUuid(EObject object) {
 		return uuidGeneratorAndResolver.getUuid(object);
 	}
@@ -74,7 +67,7 @@ class EChangeIdManager {
 		if(addedEChange.newValue === null) {
 			return;
 		}
-		addedEChange.newValueID = getOrGenerateUuid(addedEChange.newValue)
+		addedEChange.newValueID = addedEChange.newValue.uuid
 	}	
 
 	private def void setOrGenerateOldValueId(EObjectSubtractedEChange<?> subtractedEChange) {

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/EmptyUuidResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/EmptyUuidResolver.xtend
@@ -34,10 +34,6 @@ class EmptyUuidResolver implements UuidResolver {
 		throw new UnsupportedOperationException("This resolver is empty.");
 	}
 	
-	override registerUuidForGlobalUri(String uuid, URI uri) {
-		return true;
-	}
-	
 	override getPotentiallyCachedEObject(String uuid) {
 		throw new IllegalStateException("This resolver is empty.");
 	}

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
@@ -17,13 +17,6 @@ interface UuidGeneratorAndResolver extends UuidResolver, AutoCloseable {
 	def String generateUuid(EObject eObject)
 
 	/**
-	 * Registers an object that was not created before and thus has no UUID.
-	 * This is only successful if the element is globally accessible (third party element) or if
-	 * we are not in strict mode. Otherwise an exception is thrown, because a previous create is missing. 
-	 */
-	def String generateUuidWithoutCreate(EObject eObject)
-
-	/**
 	 * Loads the mapping between UUIDs and {@link EObject}s from the persistence at the {@link URI}
 	 * given in the constructor and resolves the referenced {@link EObject}s in the {@link ResourceSet}
 	 * given in the constructor.

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolver.xtend
@@ -13,6 +13,7 @@ import org.eclipse.emf.ecore.EObject
 interface UuidGeneratorAndResolver extends UuidResolver, AutoCloseable {
 	/**
 	 * Registers an object and returns the generated UUID for it.
+	 * Object must not be a proxy.
 	 */
 	def String generateUuid(EObject eObject)
 

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -24,6 +24,8 @@ import static extension tools.vitruv.framework.util.ResourceSetUtil.withGlobalFa
  */
 package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	static val logger = Logger.getLogger(UuidGeneratorAndResolverImpl)
+	static val NON_READONLY_PREFIX = "ord_"
+	
 	val ResourceSet resourceSet
 	val Resource uuidResource
 	val UuidResolver parentUuidResolver
@@ -159,9 +161,8 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	}
 	
 	private def getEObjectIfReadonlyUri(String uuid) {
-		val potentialURI = URI.createURI(uuid);
-		if (potentialURI.readOnly) {
-			return resolve(potentialURI)
+		if (!uuid.startsWith(NON_READONLY_PREFIX)) {
+			return resolve(URI.createURI(uuid))
 		}
 	}
 	
@@ -191,7 +192,7 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	}
 
 	private def String generateUuid() {
-		return EcoreUtil.generateUUID()
+		return NON_READONLY_PREFIX + EcoreUtil.generateUUID()
 	}
 
 	override registerEObject(String uuid, EObject eObject) {

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -167,17 +167,7 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	}
 	
 	private def getStoredEObject(String uuid) {
-		val eObject = repository.uuidToEObject.get(uuid)
-		if (eObject === null) {
-			return null
-		}
-		if (eObject.eIsProxy) {
-			// Try to resolve the proxy. This can still lead to a valid proxy element if it is a proxy on purpose
-			val resolvedObject = EcoreUtil.resolve(eObject, resourceSet)
-			return resolvedObject
-		} else {
-			return eObject
-		}
+		return repository.uuidToEObject.get(uuid)
 	}
 
 	override String generateUuid(EObject eObject) {

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -108,10 +108,9 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	}
 	
 	private def getUuidIfObjectReadonly(EObject eObject) {
-		if (eObject.eResource !== null) {
-			if (eObject.eResource.URI.readOnly) {
-				return eObject.resolvableUri.toString
-			}
+		val uri = EcoreUtil.getURI(eObject)
+		if (uri.isReadOnly()) {
+			return uri.toString
 		}
 	}
 	

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -253,7 +253,9 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 		// Only load UUIDs if resource exists and is not read only
 		if (!uri.readOnly && uri.existsResourceAtUri) {
 			val childContents = childResolver.resourceSet.getResource(uri, true).allContents
-			val ourContents = this.resourceSet.getResource(uri, true).allContents
+			val ourResource = this.resourceSet.getResource(uri, false)
+			checkState(ourResource !== null, "no matching resource at '%s' in parent resolver", uri)
+			val ourContents = ourResource.allContents
 			while (childContents.hasNext) {
 				val childObject = childContents.next
 				checkState(ourContents.hasNext, "Cannot find %s in our resource set!", childObject)

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidGeneratorAndResolverImpl.xtend
@@ -180,6 +180,7 @@ package class UuidGeneratorAndResolverImpl implements UuidGeneratorAndResolver {
 	}
 
 	override String generateUuid(EObject eObject) {
+		checkState(!eObject.eIsProxy, "Cannot generate UUID for proxy object: " + eObject)
 		val cachedUuid = cache.EObjectToUuid.removeKey(eObject)
 		if (cachedUuid !== null) {
 			cache.uuidToEObject.remove(cachedUuid)

--- a/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidResolver.xtend
+++ b/bundles/framework/tools.vitruv.framework.uuid/src/tools/vitruv/framework/uuid/UuidResolver.xtend
@@ -44,14 +44,6 @@ interface UuidResolver {
 	def void registerEObject(String uuid, EObject eObject);
 	
 	/**
-	 * Registers the given UUID for the element at the given {@link URI} in the
-	 * {@link ResourceSet} of this resolver.
-	 * If the object cannot be resolved in the {@link ResourceSet} of this resolver,
-	 * <code>false</code> is returned, otherwise <code>true</code>.
-	 */
-	def boolean registerUuidForGlobalUri(String uuid, URI uri);
-	
-	/**
 	 * Returns the {@link ResourceSet} used in this UUID resolver.
 	 */
 	def ResourceSet getResourceSet();

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/ReferenceEChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/feature/reference/ReferenceEChangeTest.xtend
@@ -27,7 +27,9 @@ abstract class ReferenceEChangeTest extends EChangeTest {
 		affectedEObject = rootObject
 		uuidGeneratorAndResolver.generateUuid(affectedEObject)
 		newValue = aet.NonRoot
+		uuidGeneratorAndResolver.generateUuid(newValue)
 		newValue2 = aet.NonRoot
+		uuidGeneratorAndResolver.generateUuid(newValue2)
 	}
 
 	/**

--- a/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/root/RootEChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.echange.tests/src/tools/vitruv/framework/tests/echange/root/RootEChangeTest.xtend
@@ -22,6 +22,8 @@ abstract class RootEChangeTest extends EChangeTest {
 	@BeforeEach
 	def final void beforeTest() {
 		newRootObject = aet.Root
+		uuidGeneratorAndResolver.generateUuid(newRootObject)
 		newRootObject2 = aet.Root
+		uuidGeneratorAndResolver.generateUuid(newRootObject2)
 	}
 }

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
@@ -701,7 +701,7 @@ class ChangeRecorderTest {
 				]
 			]
 		]
-		resourceSet.createResource(URI.createURI('test://test.aet')) => [
+		resourceSet.createResource(URI.createURI('file://test.aet')) => [
 			contents += root
 		]
 		root.nonRootObjectContainerHelper


### PR DESCRIPTION
* Removes the UUID logic for generating UUIDs for pre-existing elements (archive and pathmap resources, such as the Java standard library or type libraries) and for storing the UUIDs for these elements. Replaces it by simply using the (immutable) URI as the UUID.
* Removes all logic related to UUIDs for pre-existing elements and their propagation to parent `UuidResolvers`
* Removes obsolete logic for resolving proxies in `UuidGeneratorAndResolverImpl`
* Requires objects for which UUIDs are generated to not be proxy elements
* Replaces logic that silently and unintentionally loads resources into the resource set of a parent `UuidResolver`