### PR TITLE
Further Utilities Cleanup

### DIFF
--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/TypeProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/TypeProvider.xtend
@@ -12,7 +12,7 @@ import org.eclipse.xtext.xbase.XFeatureCall
 import org.eclipse.xtext.xbase.XbaseFactory
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypeReferenceBuilder
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 
 import static tools.vitruv.dsls.reactions.codegen.ReactionsLanguageConstants.*
 

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/model/Resources.ecore
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/model/Resources.ecore
@@ -37,7 +37,7 @@
         unique="false" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
         defaultValueLiteral="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EDataType" name="ResourceAccess" instanceClassName="tools.vitruv.framework.util.command.ResourceAccess"/>
+  <eClassifiers xsi:type="ecore:EDataType" name="ResourceAccess" instanceClassName="tools.vitruv.framework.change.processing.ResourceAccess"/>
   <eClassifiers xsi:type="ecore:EDataType" name="CorrespondenceModel" instanceClassName="tools.vitruv.framework.correspondence.CorrespondenceModel"/>
   <eClassifiers xsi:type="ecore:EDataType" name="URI" instanceClassName="org.eclipse.emf.common.util.URI"/>
   <eClassifiers xsi:type="ecore:EDataType" name="EmfResource" instanceClassName="org.eclipse.emf.ecore.resource.Resource"

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/helper/IntermediateModelHelper.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/helper/IntermediateModelHelper.xtend
@@ -5,7 +5,6 @@ import org.eclipse.emf.ecore.EObject
 import tools.vitruv.extensions.dslruntime.commonalities.intermediatemodelbase.Intermediate
 import tools.vitruv.extensions.dslruntime.commonalities.resources.IntermediateResourceBridge
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.util.VitruviusConstants
 
 import static com.google.common.base.Preconditions.*
 
@@ -17,7 +16,7 @@ class IntermediateModelHelper {
 	static def getMetadataModelKey(String conceptDomainName) {
 		return #[
 			'commonalities',
-			conceptDomainName + VitruviusConstants.fileExtSeparator + conceptDomainName.toFirstLower
+			conceptDomainName + '.' + conceptDomainName.toFirstLower
 		]
 	}
 

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/matching/ParticipationMatcher.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.commonalities/src/tools/vitruv/extensions/dslruntime/commonalities/matching/ParticipationMatcher.xtend
@@ -12,7 +12,7 @@ import tools.vitruv.extensions.dslruntime.commonalities.resources.IntermediateRe
 import tools.vitruv.extensions.dslruntime.commonalities.resources.ResourcesFactory
 import tools.vitruv.extensions.dslsruntime.reactions.helper.ReactionsCorrespondenceHelper
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 
 import static com.google.common.base.Preconditions.*
 import static tools.vitruv.framework.util.XtendAssertHelper.*

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractReactionsExecutor.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractReactionsExecutor.xtend
@@ -7,7 +7,7 @@ import tools.vitruv.framework.change.echange.EChange
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 import tools.vitruv.framework.change.processing.impl.AbstractEChangePropagationSpecification
 import tools.vitruv.framework.domains.VitruvDomain
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 import java.util.List
 
 abstract class AbstractReactionsExecutor extends AbstractEChangePropagationSpecification {

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutineRealization.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/AbstractRepairRoutineRealization.xtend
@@ -14,7 +14,7 @@ import tools.vitruv.extensions.dslsruntime.reactions.structure.CallHierarchyHavi
 import tools.vitruv.extensions.dslsruntime.reactions.structure.Loggable
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 import tools.vitruv.framework.userinteraction.UserInteractor
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 import tools.vitruv.framework.util.datatypes.VURI
 
 abstract class AbstractRepairRoutineRealization extends CallHierarchyHaving implements RepairRoutine, ReactionElementsHandler {

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/ReactionExecutionState.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/ReactionExecutionState.xtend
@@ -4,7 +4,7 @@ import tools.vitruv.framework.userinteraction.UserInteractor
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 import tools.vitruv.framework.change.processing.ChangePropagationObservable
 import org.eclipse.xtend.lib.annotations.Data
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 
 @Data
 class ReactionExecutionState {

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/ChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/ChangePropagationSpecification.xtend
@@ -4,7 +4,7 @@ import tools.vitruv.framework.correspondence.CorrespondenceModel
 import tools.vitruv.framework.change.description.TransactionalChange
 import tools.vitruv.framework.userinteraction.UserInteractor
 import tools.vitruv.framework.domains.VitruvDomain
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 
 interface ChangePropagationSpecification extends ChangePropagationObservable {
 	def void setUserInteractor(UserInteractor userInteractor);

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/ResourceAccess.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/ResourceAccess.xtend
@@ -1,4 +1,4 @@
-package tools.vitruv.framework.util.command
+package tools.vitruv.framework.change.processing
 
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.Resource

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/AbstractEChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/AbstractEChangePropagationSpecification.xtend
@@ -5,7 +5,7 @@ import tools.vitruv.framework.change.echange.EChange
 import org.apache.log4j.Logger
 import tools.vitruv.framework.change.description.TransactionalChange
 import tools.vitruv.framework.domains.VitruvDomain
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 
 abstract class AbstractEChangePropagationSpecification extends AbstractChangePropagationSpecification {
 	static val LOGGER = Logger.getLogger(AbstractEChangePropagationSpecification);

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeChangePropagationSpecification.xtend
@@ -10,7 +10,7 @@ import org.apache.log4j.Logger
 import tools.vitruv.framework.domains.VitruvDomain
 import tools.vitruv.framework.change.processing.ChangePropagationObserver
 import org.eclipse.emf.ecore.EObject
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 import org.eclipse.xtend.lib.annotations.Accessors
 
 abstract class CompositeChangePropagationSpecification extends AbstractChangePropagationSpecification implements ChangePropagationObserver {

--- a/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeDecomposingChangePropagationSpecification.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.processing/src/tools/vitruv/framework/change/processing/impl/CompositeDecomposingChangePropagationSpecification.xtend
@@ -4,7 +4,7 @@ import tools.vitruv.framework.change.processing.impl.CompositeChangePropagationS
 import tools.vitruv.framework.domains.VitruvDomain
 import tools.vitruv.framework.change.description.TransactionalChange
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 import tools.vitruv.framework.change.description.CompositeTransactionalChange
 import org.apache.log4j.Logger
 

--- a/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.correspondence/src/tools/vitruv/framework/correspondence/impl/InternalCorrespondenceModelImpl.xtend
@@ -11,7 +11,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil
 import tools.vitruv.framework.correspondence.Correspondence
 import tools.vitruv.framework.correspondence.CorrespondenceFactory
 import tools.vitruv.framework.correspondence.Correspondences
-import tools.vitruv.framework.util.VitruviusConstants
 import tools.vitruv.framework.uuid.UuidResolver
 
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
@@ -27,8 +26,7 @@ import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resou
 import static com.google.common.base.Preconditions.checkState
 
 class InternalCorrespondenceModelImpl implements InternalCorrespondenceModel {
-	static val saveAndLoadOptions = Map.of(VitruviusConstants.optionProcessDanglingHref,
-		VitruviusConstants.optionProcessDanglingHrefDiscard)
+	static val saveAndLoadOptions = Map.of("PROCESS_DANGLING_HREF", "DISCARD")
 	val Correspondences correspondences
 	val UuidResolver uuidResolver
 	val Resource correspondencesResource

--- a/bundles/framework/tools.vitruv.framework.util/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.util/META-INF/MANIFEST.MF
@@ -6,8 +6,7 @@ Automatic-Module-Name: tools.vitruv.framework.util
 Bundle-Version: 2.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: tools.vitruv.framework.util,
- tools.vitruv.framework.util.datatypes,
- tools.vitruv.framework.util.command
+ tools.vitruv.framework.util.datatypes
 Require-Bundle: org.apache.log4j,
  org.eclipse.core.resources;visibility:=reexport,
  org.eclipse.core.runtime;visibility:=reexport,

--- a/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/VitruviusConstants.java
+++ b/bundles/framework/tools.vitruv.framework.util/src/tools/vitruv/framework/util/VitruviusConstants.java
@@ -2,43 +2,7 @@ package tools.vitruv.framework.util;
 
 public class VitruviusConstants {
 	private static final String TEST_PROJECT_MARKER_FILE_NAME = "test_project.marker_vitruv";
-	private static final String CORRESPONDENCES_FILE_EXT = "correspondence";
-	private static final String UUID_FILE_EXT = "uuid";
-	private static final String FILE_EXT_SEPARATOR = ".";
-	/**
-	 * Fields are needed as options to save correspondence instance (we need to
-	 * ignore dangling HREFs) Copied from XMLResource.java
-	 */
-	private static final String OPTION_PROCESS_DANGLING_HREF = "PROCESS_DANGLING_HREF";
-	private static final String OPTION_PROCESS_DANGLING_HREF_DISCARD = "DISCARD";
-
-	public static String getCorrespondencesFileExt() {
-		return CORRESPONDENCES_FILE_EXT;
-	}
-
-	public static String getUuidFileExt() {
-		return UUID_FILE_EXT;
-	}
-
-	public static String getFileExtSeparator() {
-		return FILE_EXT_SEPARATOR;
-	}
-
-	public static String getOptionProcessDanglingHref() {
-		return OPTION_PROCESS_DANGLING_HREF;
-	}
-
-	public static String getOptionProcessDanglingHrefDiscard() {
-		return OPTION_PROCESS_DANGLING_HREF_DISCARD;
-	}
-
-	/**
-	 * Returns the name of a file that is placed in every test project as a marker
-	 * for the test project. This enables tests to be run independent from Eclipse
-	 * but still be able to detect a project folder without having PlatformURIs.
-	 * 
-	 * @return the name of an identifier file placed in each test project
-	 */
+	
 	public static String getTestProjectMarkerFileName() {
 		return TEST_PROJECT_MARKER_FILE_NAME;
 	}

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/ModelRepository.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/ModelRepository.xtend
@@ -3,7 +3,7 @@ package tools.vitruv.framework.vsum
 import tools.vitruv.framework.util.datatypes.ModelInstance
 import tools.vitruv.framework.util.datatypes.VURI
 import tools.vitruv.framework.change.description.TransactionalChange
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 import tools.vitruv.framework.uuid.UuidResolver
 

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/helper/VsumFileSystemLayout.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/helper/VsumFileSystemLayout.xtend
@@ -9,11 +9,13 @@ import static com.google.common.base.Preconditions.checkArgument
 import static com.google.common.base.Preconditions.checkState
 import static java.nio.charset.StandardCharsets.UTF_8
 import static java.nio.file.Files.createDirectories
-import static tools.vitruv.framework.util.VitruviusConstants.*
 import static tools.vitruv.framework.vsum.VsumConstants.*
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil.createFileURI
 
 class VsumFileSystemLayout {
+	static final String CORRESPONDENCES_FILE_EXT = "correspondence";
+	static final String UUID_FILE_EXT = "uuid";
+	
 	val Path vsumProjectFolder
 	var prepared = false
 	
@@ -31,7 +33,7 @@ class VsumFileSystemLayout {
 	
 	def private Path getMetadataFilePath(String... metadataKey) {
 		checkArgument(metadataKey !== null || metadataKey.length > 0, "The key must have at least one part!")
-		checkArgument(metadataKey.get(metadataKey.length - 1).contains(fileExtSeparator), "metadataKey is missing a file extension!")
+		checkArgument(metadataKey.get(metadataKey.length - 1).contains('.'), "metadataKey is missing a file extension!")
 		
 		return metadataKey.fold(Path.of("")) [ last, keyPart |
 			checkArgument(keyPart !== null, "A key part must not be null!")
@@ -70,12 +72,12 @@ class VsumFileSystemLayout {
 	}
 	
 	def private getCorrespondenceModelPath() {
-		correspondenceFolder.resolve('''Correspondences«fileExtSeparator»«correspondencesFileExt»''')
+		correspondenceFolder.resolve('''Correspondences.«CORRESPONDENCES_FILE_EXT»''')
 	}
 	
 	def VURI getUuidProviderAndResolverVURI() {
 		checkPrepared()
-		val uuidPath = uuidProviderAndResolverFolder.resolve('''Uuid«fileExtSeparator»«uuidFileExt»''')
+		val uuidPath = uuidProviderAndResolverFolder.resolve('''Uuid.«UUID_FILE_EXT»''')
 		return VURI.getInstance(uuidPath.toFile.createFileURI) 
 	}
 	

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/change/processing/MetamodelRegisteringChangePropagationSpecification.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/change/processing/MetamodelRegisteringChangePropagationSpecification.xtend
@@ -8,7 +8,7 @@ import java.util.List
 import tools.vitruv.framework.change.processing.ChangePropagationSpecification
 import tools.vitruv.framework.change.description.TransactionalChange
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 
 /**
  * Xtext tests reset the metamodel registry between test runs. Hence, it might

--- a/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/VirtualModelTest.xtend
+++ b/tests/framework/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/tests/vsum/VirtualModelTest.xtend
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.DisplayName
 import tools.vitruv.framework.change.processing.impl.AbstractEChangePropagationSpecification
 import tools.vitruv.framework.change.echange.EChange
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.util.command.ResourceAccess
+import tools.vitruv.framework.change.processing.ResourceAccess
 import tools.vitruv.framework.domains.VitruvDomain
 import tools.vitruv.framework.change.echange.root.InsertRootEObject
 import allElementTypes.Root


### PR DESCRIPTION
* Moves most of the constants in `VitruviusConstants` to the (single) places where they belong to
* Moves the `RessourceAccess` class to the change propagation project to which it belongs, as it is supposed to encapsulate access to resources during change propagation