### PR TITLE
Restrict Access to VirtualModel and CorrespondenceModel in Tests

### DIFF
--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/InternalVirtualModel.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/InternalVirtualModel.xtend
@@ -1,12 +1,9 @@
 package tools.vitruv.framework.vsum
 
-import tools.vitruv.framework.vsum.modelsynchronization.ChangePropagationListener
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 interface InternalVirtualModel extends VirtualModel {
 	def CorrespondenceModel getCorrespondenceModel()
-	def void addChangePropagationListener(ChangePropagationListener propagationListener)
-	def void removeChangePropagationListener(ChangePropagationListener propagationListener)
 	def void addPropagatedChangeListener(PropagatedChangeListener propagatedChangeListener)
 	def void removePropagatedChangeListener(PropagatedChangeListener propagatedChangeListener)
 	def void dispose()

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModel.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModel.xtend
@@ -7,11 +7,15 @@ import tools.vitruv.framework.change.description.VitruviusChange
 import org.eclipse.emf.common.util.URI
 import java.nio.file.Path
 import tools.vitruv.framework.uuid.UuidResolver
+import tools.vitruv.framework.vsum.modelsynchronization.ChangePropagationListener
 
 interface VirtualModel {
-	def Path getFolder();
+	def Path getFolder()
 
-	def List<PropagatedChange> propagateChange(VitruviusChange change);
+	def void addChangePropagationListener(ChangePropagationListener propagationListener)
+	def void removeChangePropagationListener(ChangePropagationListener propagationListener)
+	
+	def List<PropagatedChange> propagateChange(VitruviusChange change)
 
 	/**
 	 * Propagates delta-based changes as long as the location and the name of the resource was not changed.
@@ -19,7 +23,7 @@ interface VirtualModel {
 	 * of a model.
 	 * @param newState is the resource of the new state.
 	 */
-	def List<PropagatedChange> propagateChangedState(Resource newState);
+	def List<PropagatedChange> propagateChangedState(Resource newState)
 
 	/**
 	 * Propagates delta-based changes. Allows to change the location and the name of the resource.
@@ -28,11 +32,11 @@ interface VirtualModel {
 	 * @param newState is the resource of the new state.
 	 * @param oldLocation specifies the previous location of the resource to avoid problems with renaming or moving elements.
 	 */
-	def List<PropagatedChange> propagateChangedState(Resource newState, URI oldLocation);
+	def List<PropagatedChange> propagateChangedState(Resource newState, URI oldLocation)
 
-	def void reverseChanges(List<PropagatedChange> changes);
+	def void reverseChanges(List<PropagatedChange> changes)
 
-	def ModelInstance getModelInstance(URI modelUri);
+	def ModelInstance getModelInstance(URI modelUri)
 
-	def UuidResolver getUuidResolver();
+	def UuidResolver getUuidResolver()
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/LegacyCorrespondenceRetriever.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/LegacyCorrespondenceRetriever.xtend
@@ -1,0 +1,22 @@
+package tools.vitruv.testutils
+
+import org.eclipse.emf.ecore.EObject
+
+/** 
+ * DO NOT USE THIS CLASS!
+ * <p>
+ * This is a temporary class for providing access to correspondences in the outdated {@link LegacyVitruvApplicationTest}.
+ * It should not be used in any other/new scenario scenario but only when using that legacy test class.
+ */
+interface LegacyCorrespondenceRetriever {
+	/**
+	 * Retrieves objects corresponding to the given {@link EObject} having the specified type.
+	 */
+	def <T extends EObject> Iterable<T> getCorrespondingEObjects(EObject eObject, Class<T> type)
+
+	/**
+	 * Retrieves objects corresponding to the given {@link EObject} having the specified type
+	 * and whose correspondence is tagged with the given String tag.
+	 */
+	def <T extends EObject> Iterable<T> getCorrespondingEObjects(EObject eObject, Class<T> type, String tag)
+}

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/LegacyVitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/LegacyVitruvApplicationTest.xtend
@@ -4,6 +4,8 @@ import tools.vitruv.testutils.VitruvApplicationTest
 import java.nio.file.Path
 import edu.kit.ipd.sdq.activextendannotations.DelegateExcept
 import tools.vitruv.framework.domains.repository.VitruvDomainRepository
+import org.eclipse.emf.ecore.EObject
+import java.util.List
 
 /** 
  * DO NOT USE THIS CLASS! Use {@link VitruvApplicationTest} instead.
@@ -13,7 +15,7 @@ import tools.vitruv.framework.domains.repository.VitruvDomainRepository
  * This class serves as a temporary proxy to be removed after their adaptation and should not be used to implement any 
  * new application tests.
  */
-abstract class LegacyVitruvApplicationTest extends VitruvApplicationTest implements NonTransactionalTestView {
+abstract class LegacyVitruvApplicationTest extends VitruvApplicationTest implements NonTransactionalTestView, LegacyCorrespondenceRetriever {
 	@DelegateExcept(TestView)
 	NonTransactionalTestView testView
 
@@ -22,4 +24,25 @@ abstract class LegacyVitruvApplicationTest extends VitruvApplicationTest impleme
 		testView.renewResourceCacheAfterPropagation = false
 		this.testView = testView
 	}
+	
+	override <T extends EObject> Iterable<T> getCorrespondingEObjects(EObject eObject, Class<T> type) {
+		// TODO Catching exceptions is only necessary because element UUIDs may not be resolvable by the correspondence model
+		// which becomes obsolete as soon as correspondences do not use UUIDs anymore
+		try {
+			return correspondenceModel.getCorrespondingEObjects(List.of(eObject)).flatten.filter(type)	
+		} catch (IllegalStateException e) {
+			return emptyList
+		}
+	}
+	
+	override <T extends EObject> Iterable<T> getCorrespondingEObjects(EObject eObject, Class<T> type, String tag) {
+		// TODO Catching exceptions is only necessary because element UUIDs may not be resolvable by the correspondence model
+		// which becomes obsolete as soon as correspondences do not use UUIDs anymore
+		try {
+			return correspondenceModel.getCorrespondingEObjects(List.of(eObject), tag).flatten.filter(type)	
+		} catch (IllegalStateException e) {
+			return emptyList
+		}
+	}
+	
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/VitruvApplicationTest.xtend
@@ -6,9 +6,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.^extension.ExtendWith
 import tools.vitruv.framework.propagation.ChangePropagationSpecification
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import tools.vitruv.framework.vsum.InternalVirtualModel
-import tools.vitruv.testutils.matchers.CorrespondenceModelContainer
 
 import org.eclipse.xtend.lib.annotations.Delegate
 import static tools.vitruv.testutils.UriMode.*
@@ -16,9 +14,11 @@ import java.util.List
 import tools.vitruv.framework.vsum.VirtualModelBuilder
 import tools.vitruv.framework.domains.repository.VitruvDomainRepository
 import tools.vitruv.framework.domains.repository.VitruvDomainRepositoryImpl
+import tools.vitruv.framework.vsum.VirtualModel
+import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 @ExtendWith(TestLogging, TestProjectManager)
-abstract class VitruvApplicationTest implements CorrespondenceModelContainer, TestView {
+abstract class VitruvApplicationTest implements TestView {
 	InternalVirtualModel virtualModel
 	@Delegate
 	TestView testView
@@ -60,7 +60,8 @@ abstract class VitruvApplicationTest implements CorrespondenceModelContainer, Te
 		testView?.close()
 	}
 
-	override CorrespondenceModel getCorrespondenceModel() { virtualModel.correspondenceModel }
-
-	def protected InternalVirtualModel getVirtualModel() { virtualModel }
+	def package CorrespondenceModel getCorrespondenceModel() { virtualModel.correspondenceModel }
+	
+	def protected VirtualModel getVirtualModel() { virtualModel }
+	
 }

--- a/tests/applications/tools.vitruv.applications.demo.familiespersons.tests/src/tools/vitruv/applications/demo/familiespersons/tests/families2Persons/FamiliesPersonsTest.xtend
+++ b/tests/applications/tools.vitruv.applications.demo.familiespersons.tests/src/tools/vitruv/applications/demo/familiespersons/tests/families2Persons/FamiliesPersonsTest.xtend
@@ -2,19 +2,18 @@ package tools.vitruv.applications.demo.familiespersons.tests.families2Persons
 
 import edu.kit.ipd.sdq.metamodels.families.FamiliesFactory
 import edu.kit.ipd.sdq.metamodels.families.FamilyRegister
-import edu.kit.ipd.sdq.metamodels.persons.Person
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tools.vitruv.domains.demo.families.FamiliesDomainProvider
 import tools.vitruv.domains.demo.persons.PersonsDomainProvider
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 
-import static org.hamcrest.CoreMatchers.is
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.testutils.matchers.ModelMatchers.exists
 import tools.vitruv.testutils.VitruvApplicationTest
 import tools.vitruv.testutils.domains.DomainUtil
 import tools.vitruv.applications.demo.familiespersons.families2persons.FamiliesToPersonsChangePropagationSpecification
+import edu.kit.ipd.sdq.metamodels.persons.PersonRegister
+import static org.junit.jupiter.api.Assertions.assertEquals
 
 class FamiliesPersonsTest extends VitruvApplicationTest {
 	static val FAMILY_NAME = "Mustermann"
@@ -138,10 +137,8 @@ class FamiliesPersonsTest extends VitruvApplicationTest {
 		]
 
 		daughter.propagate[firstName = FIRST_NAME_MOTHER]
-		val corrObjs = CorrespondenceModelUtil.getCorrespondingEObjects(correspondenceModel, daughter).filter(Person)
-		assertThat(corrObjs.length, is(1))
-		val corrMember = corrObjs.get(0)
-		assertThat(corrMember.fullName.split(" ").get(0), is(FIRST_NAME_MOTHER))
+		val personsWithMothersName = PersonRegister.from(PERSONS_MODEL).persons.filter[fullName.split(" ").get(0) == FIRST_NAME_MOTHER]
+		assertEquals(1, personsWithMothersName.length) 
 	}
 
 	@Test

--- a/tests/applications/tools.vitruv.applications.demo.familiespersons.tests/src/tools/vitruv/applications/demo/familiespersons/tests/families2Persons/FamiliesPersonsTest.xtend
+++ b/tests/applications/tools.vitruv.applications.demo.familiespersons.tests/src/tools/vitruv/applications/demo/familiespersons/tests/families2Persons/FamiliesPersonsTest.xtend
@@ -137,7 +137,8 @@ class FamiliesPersonsTest extends VitruvApplicationTest {
 		]
 
 		daughter.propagate[firstName = FIRST_NAME_MOTHER]
-		val personsWithMothersName = PersonRegister.from(PERSONS_MODEL).persons.filter[fullName.split(" ").get(0) == FIRST_NAME_MOTHER]
+		val personsWithMothersName = PersonRegister.from(PERSONS_MODEL).persons
+			.filter[fullName.split(" ").get(0) == FIRST_NAME_MOTHER]
 		assertEquals(1, personsWithMothersName.length) 
 	}
 

--- a/tests/applications/tools.vitruv.applications.demo.familiespersons.tests/src/tools/vitruv/applications/demo/familiespersons/tests/persons2families/PersonsToFamiliesTest.xtend
+++ b/tests/applications/tools.vitruv.applications.demo.familiespersons.tests/src/tools/vitruv/applications/demo/familiespersons/tests/persons2families/PersonsToFamiliesTest.xtend
@@ -85,7 +85,9 @@ class PersonsToFamiliesTest extends VitruvApplicationTest {
 		person.propagate[fullName = SECOND_MALE_PERSON_NAME]
 		
 		val personFirstName = person.fullName.split(" ").get(0)
-		val membersWithFirstName = FamilyRegister.from(FAMILIES_MODEL).families.flatMap[daughters + sons + List.of(mother) + List.of(father)].filter[personFirstName == it?.firstName]
+		val membersWithFirstName = FamilyRegister.from(FAMILIES_MODEL).families
+			.flatMap[daughters + sons + List.of(mother) + List.of(father)]
+			.filter[personFirstName == it?.firstName]
 		assertEquals(1, membersWithFirstName.length)
 	}
 }

--- a/tests/applications/tools.vitruv.applications.demo.familiespersons.tests/src/tools/vitruv/applications/demo/familiespersons/tests/persons2families/PersonsToFamiliesTest.xtend
+++ b/tests/applications/tools.vitruv.applications.demo.familiespersons.tests/src/tools/vitruv/applications/demo/familiespersons/tests/persons2families/PersonsToFamiliesTest.xtend
@@ -1,6 +1,5 @@
 package tools.vitruv.applications.demo.familiespersons.tests.persons2families
 
-import edu.kit.ipd.sdq.metamodels.families.Member
 import edu.kit.ipd.sdq.metamodels.persons.PersonRegister
 import edu.kit.ipd.sdq.metamodels.persons.PersonsFactory
 import org.junit.jupiter.api.BeforeEach
@@ -8,13 +7,15 @@ import org.junit.jupiter.api.Test
 import tools.vitruv.domains.demo.families.FamiliesDomainProvider
 import tools.vitruv.domains.demo.persons.PersonsDomainProvider
 
-import static org.hamcrest.CoreMatchers.is
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.testutils.matchers.ModelMatchers.exists
 import org.junit.jupiter.api.Disabled
 import tools.vitruv.testutils.VitruvApplicationTest
 import tools.vitruv.testutils.domains.DomainUtil
 import tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesChangePropagationSpecification
+import edu.kit.ipd.sdq.metamodels.families.FamilyRegister
+import java.util.List
+import static org.junit.jupiter.api.Assertions.assertEquals
 
 class PersonsToFamiliesTest extends VitruvApplicationTest {
 	static val MALE_PERSON_NAME = "Max Mustermann"
@@ -82,10 +83,9 @@ class PersonsToFamiliesTest extends VitruvApplicationTest {
 		]
 		PersonRegister.from(PERSONS_MODEL).propagate[persons += person]
 		person.propagate[fullName = SECOND_MALE_PERSON_NAME]
-		val Iterable<Member> members = correspondenceModel.getCorrespondingEObjects(#[person]).filter(Member)
-
-		assertThat(members.length, is(1))
-		val member = members.get(0)
-		assertThat(member.firstName, is(person.fullName.split(" ").get(0)))
+		
+		val personFirstName = person.fullName.split(" ").get(0)
+		val membersWithFirstName = FamilyRegister.from(FAMILIES_MODEL).families.flatMap[daughters + sons + List.of(mother) + List.of(father)].filter[personFirstName == it?.firstName]
+		assertEquals(1, membersWithFirstName.length)
 	}
 }

--- a/tests/domains/tools.vitruv.domains.emf.ui.tests/src/tools/vitruv/domains/emf/monitorededitor/test/utils/DefaultImplementations.java
+++ b/tests/domains/tools.vitruv.domains.emf.ui.tests/src/tools/vitruv/domains/emf/monitorededitor/test/utils/DefaultImplementations.java
@@ -31,6 +31,7 @@ import static tools.vitruv.framework.uuid.UuidGeneratorAndResolverFactory.create
 import tools.vitruv.framework.uuid.UuidResolver;
 import tools.vitruv.framework.vsum.ModelInstance;
 import tools.vitruv.framework.vsum.VirtualModel;
+import tools.vitruv.framework.vsum.modelsynchronization.ChangePropagationListener;
 
 public class DefaultImplementations {
     public static final ResourceChangeSynchronizing EFFECTLESS_CHANGESYNC = new ResourceChangeSynchronizing() {
@@ -132,6 +133,14 @@ public class DefaultImplementations {
         public List<PropagatedChange> propagateChangedState(Resource newState, URI oldLocation) {
             return null;
         }
+
+		@Override
+		public void addChangePropagationListener(ChangePropagationListener propagationListener) {
+		}
+
+		@Override
+		public void removeChangePropagationListener(ChangePropagationListener propagationListener) {
+		}
 
     }
 }


### PR DESCRIPTION
Restricts access to the `CorrespondenceModel` in tests, such that only correspondence resolution methods are provided rather than complete access to the model. This avoids unintended changes to the correspondence model and is thus reasonable by itself.
In addition, it prepares for coming changes to the `CorrespondenceModel` that require adapter logic for resolving correspondences for objects not in the resource set of the `VirtualModel`, which will then be embedded into the access methods in the `LegacyVitruvApplicationTest`.

In addition, the PR reduces access in tests to the `VirtualModel` rather than the `InternalVirtualModel`.