### PR TITLE
Record Move from Removed Element Containment

### DIFF
--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2RemoveEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2RemoveEReferenceTest.xtend
@@ -90,15 +90,68 @@ class ChangeDescription2RemoveEReferenceTest extends ChangeDescription2ChangeTra
 			.assertUnsetFeature(uniquePersistedRoot, ROOT__MULTI_VALUED_UNSETTABLE_CONTAINMENT_EREFERENCE)
 			.assertEmpty
 	}
+	
+	@Test
+	def void testRemoveElementAndReinsertContainedOne() {
+		// prepare
+		val containedRoot = aet.Root
+		val nonRoot = aet.NonRoot
+		uniquePersistedRoot => [
+			recursiveRoot = containedRoot => [
+				singleValuedContainmentEReference = nonRoot
+			]
+		]
 
+		// test
+		val result = uniquePersistedRoot.record [
+			recursiveRoot = null
+			singleValuedContainmentEReference = nonRoot
+		]
+
+		// assert
+		result.assertChangeCount(4)
+			.assertReplaceAndDeleteNonRoot(containedRoot, uniquePersistedRoot, ROOT__RECURSIVE_ROOT, false)
+			.assertReplaceSingleValuedEReference(containedRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, nonRoot, null, true, false, false)
+			.assertReplaceSingleValuedEReference(uniquePersistedRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, null, nonRoot, true, false, false)
+			.assertEmpty
+	}
+	
+	@Test
+	def void testRemoveElementAndReinsertContainedInContainedOne() {
+		// prepare
+		val containedRoot = aet.Root
+		val innerContainedRoot = aet.Root
+		val nonRoot = aet.NonRoot
+		uniquePersistedRoot => [
+			recursiveRoot = containedRoot => [
+				recursiveRoot = innerContainedRoot => [
+					singleValuedContainmentEReference = nonRoot
+				]
+			]
+		]
+
+		// test
+		val result = uniquePersistedRoot.record [
+			recursiveRoot = null
+			singleValuedContainmentEReference = nonRoot
+		]
+
+		// assert
+		result.assertChangeCount(4)
+			.assertReplaceAndDeleteNonRoot(containedRoot, uniquePersistedRoot, ROOT__RECURSIVE_ROOT, false)
+			.assertReplaceSingleValuedEReference(innerContainedRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, nonRoot, null, true, false, false)
+			.assertReplaceSingleValuedEReference(uniquePersistedRoot, ROOT__SINGLE_VALUED_CONTAINMENT_EREFERENCE, null, nonRoot, true, false, false)
+			.assertEmpty
+	}
+	
 	@Test
 	def void testClearEReferences() {
 		// prepare
 		val nonRoot1 = aet.NonRoot
 		val nonRoot2 = aet.NonRoot
 		uniquePersistedRoot => [
-			multiValuedContainmentEReference +=  nonRoot1
-			multiValuedContainmentEReference +=  nonRoot2
+			multiValuedContainmentEReference += nonRoot1
+			multiValuedContainmentEReference += nonRoot2
 		]
 
 		// test


### PR DESCRIPTION
The `ChangeRecorder` removes the recording adapter from elements as soon as they are removed from a containment. If, however, elements contained within the removed elements (or any of its transitively contained elements) are then moved to another container, only the insertion change is recorded without recording the change for removing the element from the previous container. In consequence, applying the changes backwards for assigning appropriate IDs fails, because the elements is not inserted into its original container.
This was not recognized before as we have no situation in which we re-insert an element contained in the tree that was removed from a model containment. It first came up when re-enabling layout information in Java in #468.

This PR adapts the `ChangeRecorder` such that it defers the removal from recording to after the current transactions, such that further changes in the removed elements are still recorded. As soon as the transaction ends, elements will not be inserted again (the same assumption it made for identifying delete changes) and then the recording adapter is removed.
It also adds according regression tests.