### PR TITLE
Improve Correspondence Handling

### DIFF
--- a/bundles/applications/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/families2persons/FamiliesToPersons.reactions
+++ b/bundles/applications/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/families2persons/FamiliesToPersons.reactions
@@ -1,3 +1,5 @@
+import static extension tools.vitruv.domains.demo.families.FamiliesUtil.getMembers
+
 import "edu.kit.ipd.sdq.metamodels.persons" as persons
 import "edu.kit.ipd.sdq.metamodels.families" as families
 
@@ -124,27 +126,29 @@ reaction DeletedMember {
 	call deletePerson(affectedEObject)
 }
 
-routine deletePerson(families::Member member){
+routine deletePerson(families::Member member) {
 	match{
 		val person = retrieve persons::Person corresponding to member
+		val family = retrieve families::Family corresponding to person
 	}
-	
-	action{
+	action {
+		remove correspondence between family and person
 		delete person
 	}
 }
 
-//reaction DeletedFamily {
-//	after element families::Family deleted
-//	call deletePersonsOfFamily(affectedEObject)
-//}
+reaction DeletedFamily {
+	after element families::Family deleted
+	call deletePersonsOfFamily(affectedEObject)
+}
 
-//routine deletePersonsOfFamily(families::Family family){
-//	match{
-//		val father = retrieve persons::Person corresponding to family[]
-// Wie kriege ich hier alle Familienmitglieder
-//	}
-//}
+routine deletePersonsOfFamily(families::Family family){
+	action {
+		call {
+			family.members.forEach[deletePerson()]
+		}
+	}
+}
 
 reaction ChangedFirstName {
 	after attribute replaced at families::Member[firstName]

--- a/bundles/domains/tools.vitruv.domains.demo/src/tools/vitruv/domains/demo/families/FamiliesUtil.xtend
+++ b/bundles/domains/tools.vitruv.domains.demo/src/tools/vitruv/domains/demo/families/FamiliesUtil.xtend
@@ -1,0 +1,17 @@
+package tools.vitruv.domains.demo.families
+
+import edu.kit.ipd.sdq.activextendannotations.Utility
+import edu.kit.ipd.sdq.metamodels.families.Member
+import edu.kit.ipd.sdq.metamodels.families.Family
+import java.util.List
+
+@Utility
+class FamiliesUtil {
+	def static getFamily(Member member) {
+		return member.familyDaughter  ?: member.familySon ?: member.familyMother ?: member.familyFather 
+	}
+	
+	def static getMembers(Family family) {
+		return (family.daughters + family.sons + List.of(family.mother) + List.of(family.father)).filterNull.toList 
+	}
+}

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/model/LanguageElements.ecore
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/model/LanguageElements.ecore
@@ -54,7 +54,7 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EClassMetaclass" eSuperTypes="#//Metaclass">
     <eOperations name="forEClass" lowerBound="1" eType="#//EClassMetaclass">
-      <eParameters name="eClass" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EClass"/>
+      <eParameters name="eClass" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EClass"/>
     </eOperations>
     <eOperations name="withClassifierProvider" lowerBound="1" eType="#//EClassMetaclass">
       <eParameters name="classifierProvider" eType="#//ClassifierProvider"/>
@@ -67,7 +67,7 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EDataTypeClassifier" eSuperTypes="#//Classifier">
     <eOperations name="forEDataType" lowerBound="1" eType="#//EDataTypeClassifier">
-      <eParameters name="eDataType" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EDataType"/>
+      <eParameters name="eDataType" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EDataType"/>
     </eOperations>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="VitruviusDomain" eSuperTypes="#//Domain">
@@ -92,7 +92,7 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EFeatureAttribute" eSuperTypes="#//Attribute">
     <eOperations name="forEFeature" lowerBound="1" eType="#//EFeatureAttribute">
-      <eParameters name="eFeature" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EStructuralFeature"/>
+      <eParameters name="eFeature" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EStructuralFeature"/>
     </eOperations>
     <eOperations name="withClassifierProvider" lowerBound="1" eType="#//EFeatureAttribute">
       <eParameters name="classifierProvider" eType="#//ClassifierProvider"/>

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/model/LanguageElements.genmodel
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/model/LanguageElements.genmodel
@@ -3,6 +3,7 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/tools.vitruv.dsls.commonalities/src-gen" modelName="LanguageElements"
     rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container" importerID="org.eclipse.emf.importer.ecore"
     containmentProxies="true" complianceLevel="8.0" copyrightFields="false" language=""
+    usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore"
     classNamePattern="" operationReflection="true" importOrganizing="true">
   <foreignModel>LanguageElements.ecore</foreignModel>
   <genPackages prefix="LanguageElements" basePackage="tools.vitruv.dsls.commonalities.language"

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/matching/ParticipationMatchingReactionsBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/generator/reactions/matching/ParticipationMatchingReactionsBuilder.xtend
@@ -34,6 +34,7 @@ import static extension tools.vitruv.dsls.commonalities.generator.reactions.util
 import static extension tools.vitruv.dsls.commonalities.generator.reactions.util.ReactionsHelper.*
 import static extension tools.vitruv.dsls.commonalities.generator.reactions.util.XbaseHelper.*
 import static extension tools.vitruv.dsls.commonalities.language.extensions.CommonalitiesLanguageModelExtensions.*
+import tools.vitruv.extensions.dslruntime.commonalities.resources.ResourcesPackage
 
 /**
  * Generates the reactions and routines that match participations in given
@@ -312,8 +313,11 @@ class ParticipationMatchingReactionsBuilder extends ReactionsGenerationHelper {
 		return reaction.call [
 			match [
 				vall(INTERMEDIATE).retrieve(commonality.changeClass).correspondingTo.oldValue
+				vall(RESOURCE_BRIDGE).retrieve(ResourcesPackage.eINSTANCE.intermediateResourceBridge).correspondingTo.oldValue
 			]
 			action [
+				// Remove correspondence between the resource bridge and the just removed element
+				removeCorrespondenceBetween [extension typeProvider|typeProvider.oldValue].and(RESOURCE_BRIDGE).taggedWithAnything
 				delete(INTERMEDIATE)
 				// Note: The deletion of the intermediate will also remove it
 				// from any parent intermediate container (if there is one).

--- a/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/scoping/OperatorScopeProvider.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.commonalities/src/tools/vitruv/dsls/commonalities/scoping/OperatorScopeProvider.xtend
@@ -16,11 +16,11 @@ final class OperatorScopeProvider extends ImportedNamespaceAwareLocalScopeProvid
 	// Going forward, there should be no distinction between different operator types, and hence the
 	// need to differentiate should disappear.
 	// Thus: either remove different operator types or filter the scope by this class.
-	var Class<?> operatorBaseType
+	// var Class<?> operatorBaseType
 	var List<String> translatedImports
 	
 	private new(Class<?> operatorBaseType, List<String> defaultImports) {
-		this.operatorBaseType = operatorBaseType
+		// this.operatorBaseType = operatorBaseType
 		this.translatedImports = defaultImports.mapFixed [
 			CommonalitiesOperatorConventions.toOperatorTypeQualifiedName(it)
 		]

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
@@ -391,6 +391,12 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 			this.builder = builder
 			this.taggable = taggable
 		}
+		
+		def void taggedWithAnything() {
+			taggable.tag = LanguageFactory.eINSTANCE.createTagCodeBlock => [
+				code = XbaseFactory.eINSTANCE.createXNullLiteral
+			]
+		}
 
 		def void taggedWith(String tag) {
 			taggable.tag = LanguageFactory.eINSTANCE.createTagCodeBlock => [

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
@@ -129,14 +129,18 @@ class ReactionClassGenerator extends ClassGenerator {
 				«changeSequenceRepresentation.generatePropertiesAssignmentCode()»
 								
 				«IF hasPreconditionBlock»
-					getLogger().trace("Passed change matching of Reaction " + this.getClass().getName());
+					if (getLogger().isTraceEnabled()) {
+						getLogger().trace("Passed change matching of Reaction " + this.getClass().getName());
+					}
 					if (!«userDefinedPreconditionMethod.simpleName»(«
 						FOR argument : accessibleElementList.generateArgumentsForAccesibleElements SEPARATOR ", "»«argument»«ENDFOR»)) {
 						«resetChangesMethod.simpleName»();
 						return;
 					}
 				«ENDIF»
-				getLogger().trace("Passed complete precondition check of Reaction " + this.getClass().getName());
+				if (getLogger().isTraceEnabled()) {
+					getLogger().trace("Passed complete precondition check of Reaction " + this.getClass().getName());
+				}
 								
 				«userExecutionClassGenerator.qualifiedClassName» userExecution = new «userExecutionClassGenerator.qualifiedClassName»(this.executionState, this);
 				userExecution.«callRoutineMethod.simpleName»(«

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
@@ -319,9 +319,9 @@ class RoutineClassGenerator extends ClassGenerator {
 			body = '''
 				if (getLogger().isTraceEnabled()) {
 					getLogger().trace("Called routine «routineClassNameGenerator.simpleName» with input:");
-				«FOR inputParameter : inputParameters»
-					getLogger().trace("   «inputParameter.name»: " + this.«inputParameter.name»);
-				«ENDFOR»
+					«FOR inputParameter : inputParameters»
+						getLogger().trace("   «inputParameter.name»: " + this.«inputParameter.name»);
+					«ENDFOR»
 				}
 				
 				«FOR matcherStatement : matcherStatements»

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
@@ -313,10 +313,12 @@ class RoutineClassGenerator extends ClassGenerator {
 			visibility = JvmVisibility.PROTECTED;
 			exceptions += typeRef(IOException);
 			body = '''
-				getLogger().trace("Called routine «routineClassNameGenerator.simpleName» with input:");
+				if (getLogger().isTraceEnabled()) {
+					getLogger().trace("Called routine «routineClassNameGenerator.simpleName» with input:");
 				«FOR inputParameter : inputParameters»
 					getLogger().trace("   «inputParameter.name»: " + this.«inputParameter.name»);
 				«ENDFOR»
+				}
 				
 				«FOR matcherStatement : matcherStatements»
 					«matcherStatementsMap.get(matcherStatement)»

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
@@ -40,6 +40,7 @@ import tools.vitruv.dsls.common.ClassNameGenerator
 import tools.vitruv.dsls.reactions.language.toplevelelements.NamedJavaElementReference
 import tools.vitruv.dsls.common.elements.NamedMetaclassReference
 import static extension tools.vitruv.dsls.reactions.codegen.helper.ReactionsElementsCompletionChecker.isReferenceable
+import java.util.stream.Stream
 
 class RoutineClassGenerator extends ClassGenerator {
 	static val MISSING_NAME = "/* Name missing */"
@@ -235,6 +236,9 @@ class RoutineClassGenerator extends ClassGenerator {
 		val getElementMethod = generateMethodGetElement(deleteElement.element, currentlyAccessibleElements, typeRef(EObject));
 		val getElementMethodCall = getElementMethod?.userExecutionMethodCallString;
 		return '''
+			«Stream».of(new «Object»[] {«FOR accessibleElement : currentlyAccessibleElements SEPARATOR  ', '»«accessibleElement.name»«IF accessibleElement.optional».orElse(null)«ENDIF»«ENDFOR»})
+				.filter(it -> it instanceof «EObject»).map(it -> (EObject) it).forEach(accessibleElement ->
+					removeCorrespondenceBetween(«getElementMethodCall», accessibleElement, null));		
 			deleteObject(«getElementMethodCall»);
 		'''
 	}

--- a/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/AccessibleElement.xtend
+++ b/bundles/dsls/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/helper/AccessibleElement.xtend
@@ -5,6 +5,7 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypeReferenceBuilder
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import org.eclipse.xtext.common.types.JvmUnknownTypeReference
+import java.util.Optional
 
 class AccessibleElement {
 	static val UNKNOWN_TYPEREF_NAME = "unknown"
@@ -26,6 +27,10 @@ class AccessibleElement {
 	
 	new(String name, Class<?> type) {
 		this(name, type.name)
+	}
+	
+	def boolean isOptional() {
+		return Optional.name.equals(fullyQualifiedTypeName)
 	}
 	
 	def generateTypeRef(@Extension JvmTypeReferenceBuilder typeReferenceBuilder) {

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/effects/ReactionElementsHandlerImpl.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/effects/ReactionElementsHandlerImpl.xtend
@@ -24,7 +24,6 @@ class ReactionElementsHandlerImpl implements ReactionElementsHandler {
 		if (element === null) {
 			return;
 		}
-		ReactionsCorrespondenceHelper.removeCorrespondencesOfObject(correspondenceModel, element);
 		if (logger.debugEnabled) {
 			logger.debug("Removing object " + element + " from container " + element.eContainer());
 		}

--- a/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/effects/ReactionElementsHandlerImpl.xtend
+++ b/bundles/extensions/dslsruntime/tools.vitruv.extensions.dslsruntime.reactions/src/tools/vitruv/extensions/dslsruntime/reactions/effects/ReactionElementsHandlerImpl.xtend
@@ -25,7 +25,9 @@ class ReactionElementsHandlerImpl implements ReactionElementsHandler {
 			return;
 		}
 		ReactionsCorrespondenceHelper.removeCorrespondencesOfObject(correspondenceModel, element);
-		logger.debug("Removing object " + element + " from container " + element.eContainer());
+		if (logger.debugEnabled) {
+			logger.debug("Removing object " + element + " from container " + element.eContainer());
+		}
 		EcoreUtil.remove(element);
 	}
 	

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ChangePropagator.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ChangePropagator.xtend
@@ -19,7 +19,6 @@ import tools.vitruv.framework.userinteraction.InternalUserInteractor
 import tools.vitruv.framework.userinteraction.UserInteractionFactory
 import tools.vitruv.framework.userinteraction.UserInteractionListener
 
-import static com.google.common.base.Preconditions.checkNotNull
 import static com.google.common.base.Preconditions.checkState
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
@@ -156,7 +155,8 @@ package class ChangePropagator {
 			// Find created objects without resource
 			for (createdObjectWithoutResource : createdObjects.filter[eResource === null]) {
 				checkState(!resourceRepository.correspondenceModel.hasCorrespondences(List.of(createdObjectWithoutResource)),
-					"This object is part of a correspondence but not in any resource: %s", createdObjectWithoutResource)
+					"The object %s is part of a correspondence to %s but not in any resource", createdObjectWithoutResource,
+					resourceRepository.correspondenceModel.getCorrespondingEObjects(#[createdObjectWithoutResource]))
 				logger.warn("Object was created but has no correspondence and is thus lost: " 
 					+ createdObjectWithoutResource)
 			}


### PR DESCRIPTION
This PR provides some fixes and improvements to the handling of correspondences.

1. Reactions implicitly delete correspondences for objects that are deleted using the language statement `delete`. This was fine when using Reactions in a two-model-setting, because then only the single transformations between the two models and their correspondences were present. Since we combine transformations to networks, this does, however, not work properly anymore. The functionality also removes correspondences to completely different domains, thus correspondences relevant for completely different transformations. As an example, removing a PCM repository leads to the removal of corresponding UML packages, which also removes the correspondences between UML and Java packages, such that the Java packages cannot be removed properly by the UML to Java transformations anymore. In consequence, this PR proposes a fix that only applies the correspondence removal to elements that are accessible within the routine that deleted an object. While someone might find that selection confusing, it is, in my opinion, a reasonable scope, as a routine should access the elements relevant for the specific consistency rule it handles.
2. When saving correspondences, dangling references were removed, such that several correspondences were empty afterwards. This PR implements the proposal in #425. On correspondences save, it removes all correspondences whose related elements have been removed from the models. If there are correspondences of which only some elements have been removed from the models, an exception is thrown, as this indicates an unintended state. In consequence, no correspondence with one side being empty should occur anymore and obsolete correspondences (with all their elements being removed) should be removed automatically.

In addition, this PR provides some improvement for logging and error messages.

Fixes #425.