### PR TITLE
Properly Remove Model Instances

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
@@ -140,6 +140,7 @@ class ChangeRecorder implements AutoCloseable {
 	 */
 	def TransactionalChange endRecording() {
 		checkNotDisposed()
+		checkState(isRecording, "This recorder is not recording")
 		isRecording = false
 		resultChanges = List.copyOf(resultChanges.postprocessRemovals().assignIds())
 		idResolver.endTransaction()

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.xtend
@@ -117,9 +117,12 @@ package class ResourceRepositoryImpl implements ModelRepository {
 
 	override void saveOrDeleteModels() {
 		if(logger.isDebugEnabled) logger.debug('''Saving all models of model repository for VSUM «fileSystemLayout»''')
-		for (modelInstance : modelInstances.values) {
+		val modelInstancesIterator = modelInstances.entrySet.iterator
+		while (modelInstancesIterator.hasNext()) {
+			val modelInstance = modelInstancesIterator.next().value
 			if (modelInstance.empty) {
 				modelInstance.delete()
+				modelInstancesIterator.remove()
 			} else {
 				modelInstance.save()
 			}

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
@@ -63,6 +63,14 @@ class ChangeRecorderTest {
 		changes.apply
 		if(condition) changeRecorder.endRecording()
 	}
+	
+	@Test
+	@DisplayName("does not allow end recording twice")
+	def void endRecordingTwice() {
+		changeRecorder.beginRecording()
+		changeRecorder.endRecording()
+		assertThrows(IllegalStateException) [changeRecorder.endRecording()]
+	}
 
 	@Test
 	@DisplayName("records direct changes to an object")

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
@@ -128,7 +128,6 @@ class ChangeRecorderTest {
 		record [
 			inner.id = 'test'
 		]
-		changeRecorder.endRecording()
 
 		assertThat(changeRecorder.change, hasEChanges(ReplaceSingleValuedEAttribute))
 	}


### PR DESCRIPTION
This PR fixes a bug that caused `ModelInstances` not to be removed from the `ResourceRepositoryImpl` although the contained resource was empty and deleted.
In consequence, this led to the situation that if a resource with the same URI was used again afterwards, the deleted resource of the still contained `ModelInstance` was returned. While most things worked even with that deleted resource, it was, in particular, not contained in a `ResourceSet` anymore, which leads to created correspondences being interpreted as faulty (after the changes in #470), as the referenced element is not contained in a resource set.
Anyway, not properly deleting the `ModelInstance` is a bug that is fixed by this PR and checked by a regression test.

In addition, this PR adds a check that for a `ChangeRecorder` the method `endRecording` may only be called once within a transaction, because otherwise postprocessing of changes is performed twice, which leads to bugs. No one did that before, so no failures occurred, but this may easily lead to bugs in the future (like it did when implementing the above mentioned regression test).