### PR TITLE
Upgrade to demo metamodels 1.5.0

### DIFF
--- a/releng/tools.vitruv.parent/pom.xml
+++ b/releng/tools.vitruv.parent/pom.xml
@@ -16,7 +16,7 @@
 		<repository>
 			<id>Demo Metamodels</id>
 			<layout>p2</layout>
-			<url>http://kit-sdq.github.io/updatesite/release/metamodels/demo/1.4.0/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/1.5.0/</url>
 		</repository>
 		<repository>
 			<id>SDQ Commons</id>


### PR DESCRIPTION
Upgrades to demo metamodels 1.5.0, in particular containing fixes for the insurance metamodel (missing usage of gender in clients).