### PR TITLE
Disable change recording for existing and pathmap resources (#484)

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
@@ -367,10 +367,15 @@ class ChangeRecorder implements AutoCloseable {
 		}
 
 		private def boolean isUnloadingResource(Notification notification) {
-			return if (notification.notifier instanceof Resource) {
-				!(notification.notifier as Resource).isLoaded
+			if (notification.notifier instanceof Resource) {
+				val resource = notification.notifier as Resource
+				val resourceSet = resource.resourceSet
+				// for an unload, resource must not be flagged loaded and there must still be a persistence at the URI
+				// (otherwise resource was deleted)
+				return !resource.isLoaded && resourceSet !== null &&
+					resourceSet.URIConverter.exists(resource.URI, emptyMap)
 			} else {
-				false
+				return false
 			}
 		}
 

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
@@ -331,8 +331,8 @@ class ChangeRecorder implements AutoCloseable {
 		}
 
 		private def Iterable<? extends EChange> extractRelevantChanges(Notification notification) {
-			val changes = if (notification.isLoadingResource || notification.isUnloadingResource) {
-					// If resource is being unloaded, do not process the changes from unloading 
+			val changes = if (notification.affectsLoadingResource || notification.affectsUnloadingResource) {
+					// If resource is being loaded or unloaded, do not process the changes 
 					emptyList
 				} else {
 					converter.convert(new NotificationInfo(notification))
@@ -361,16 +361,16 @@ class ChangeRecorder implements AutoCloseable {
 			]
 		}
 
-		private def boolean isLoadingResource(Notification notification) {
+		private def boolean affectsLoadingResource(Notification notification) {
 			val newEObject = if(notification.newValue instanceof EObject) notification.newValue as EObject else null
 			return newEObject?.eResource !== null && currentlyLoadingResources.contains(newEObject.eResource)
 		}
 
-		private def boolean isUnloadingResource(Notification notification) {
+		private def boolean affectsUnloadingResource(Notification notification) {
 			if (notification.notifier instanceof Resource) {
 				val resource = notification.notifier as Resource
 				val resourceSet = resource.resourceSet
-				// for an unload, resource must not be flagged loaded and there must still be a persistence at the URI
+				// for an unload, resource must not be flagged as loaded and there must still be a persistence at the URI
 				// (otherwise resource was deleted)
 				return !resource.isLoaded && resourceSet !== null &&
 					resourceSet.URIConverter.exists(resource.URI, emptyMap)

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/recording/ChangeRecorderTest.xtend
@@ -443,6 +443,24 @@ class ChangeRecorderTest {
 	}
 
 	@ParameterizedTest(name="while isRecording={0}")
+	@DisplayName("does not record unloading a resource")
+	@ValueSource(booleans=#[false, true])
+	def void doesntRecordUnloading(boolean isRecordingUnloadingResource) {
+		changeRecorder.addToRecording(resourceSet)
+		val resource = resourceSet.createResource(URI.createURI('test://test.aet')) => [
+			contents += aet.Root => [
+				nonRootObjectContainerHelper = aet.NonRootObjectContainerHelper => [
+					nonRootObjectsContainment += aet.NonRoot
+				]
+			]
+		]
+		recordIf(isRecordingUnloadingResource) [
+			resource.unload()
+		]
+		assertThat(changeRecorder.change, hasNoChanges)
+	}
+	
+	@ParameterizedTest(name="while isRecording={0}")
 	@DisplayName("removes an object unset from a containment reference from the recording")
 	@ValueSource(booleans=#[false, true])
 	def void removeAfterContainmentUnset(boolean isRecordingWhileRemovingObject) {


### PR DESCRIPTION
This PR introduces regression tests and a fix for #484.
The `NotificationRecorder` of a `ChangeRecorder` tracks whether contents are added to a resource by modification or because the resource is being loaded or unloaded and only generates changes in the former case. Before, changes were generated for resources being loaded or unloaded.

Complexity of the solution is increased because EMF does not provide a way proper way of tracking the load state of resources: The `loaded` flag is set to `true` as soon as loading is started, then notifications for adding the contents are emitted and only afterwards a notitification for setting the `loaded` flag is emitted. This makes it necessary to track the loading state of the resource in the recorder.
Vice versa, the `loaded` flag is set to `false` as soon as unloading is started and there is no simple way to distinguih between a resource being unloaded because of its deletion ad because of its removal from a resource set (which is completely different semantically). 

Fixes #484.