### PR TITLE
Fix memory leaks

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
@@ -130,6 +130,7 @@ class ChangeRecorder implements AutoCloseable {
 		resultChanges = null
 		val rootCopy = Set.copyOf(rootObjects)
 		rootObjects.clear()
+		existingObjects.clear()
 		rootCopy.forEach[recursively [removeAdapter()]]
 	}
 

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelBuilder.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelBuilder.xtend
@@ -143,7 +143,6 @@ class VirtualModelBuilder {
 		fileSystemLayout.prepare()
 		val vsum = new VirtualModelImpl(fileSystemLayout, userInteractor, domainRepository, changeSpecificationRepository)
 		vsum.loadExistingModels()
-		VirtualModelManager.instance.putVirtualModel(vsum)
 		return vsum
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelManager.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/VirtualModelManager.xtend
@@ -1,25 +1,22 @@
 package tools.vitruv.framework.vsum
 
-import java.util.Map
-import java.util.concurrent.ConcurrentHashMap
 import java.nio.file.Path
+import tools.vitruv.framework.vsum.internal.VirtualModelRegistry
 import tools.vitruv.framework.vsum.internal.InternalVirtualModel
 
 final class VirtualModelManager {
-	Map<Path, InternalVirtualModel> folderToVirtualModelMap;
-	
 	static val instance = new VirtualModelManager();
-	
+
 	private new() {
-		this.folderToVirtualModelMap = new ConcurrentHashMap();
 	}
-	
+
 	static def getInstance() {
 		return instance;
 	}
-	
-	def getVirtualModel(Path folder) {
-		folderToVirtualModelMap.computeIfAbsent(folder) [
+
+	def InternalVirtualModel getVirtualModel(Path folder) {
+		var virtualModel = VirtualModelRegistry.instance.getVirtualModel(folder)
+		if (virtualModel === null) {
 			// get the workspace root
 //			val root = ResourcesPlugin.getWorkspace().getRoot(); 
 //			// get the project handle 
@@ -27,11 +24,9 @@ final class VirtualModelManager {
 //			// open up this newly-created project in Eclipse 
 //			project.open(new NullProgressMonitor());
 //			// TODO HK: Extract VSUM from project
-			throw new UnsupportedOperationException();
-		]
+			throw new UnsupportedOperationException("Virtual models cannot be loaded yet");
+		}
+		return virtualModel
 	}
-	
-	def putVirtualModel(InternalVirtualModel model) {
-		folderToVirtualModelMap.put(model.folder, model);
-	}
+
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/VirtualModelImpl.xtend
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/VirtualModelImpl.xtend
@@ -42,6 +42,7 @@ class VirtualModelImpl implements InternalVirtualModel {
 			domainRepository,
 			userInteractor
 		)
+		VirtualModelRegistry.instance.registerVirtualModel(this)
 	}
 	
 	def loadExistingModels() {
@@ -199,6 +200,7 @@ class VirtualModelImpl implements InternalVirtualModel {
 
 	override void dispose() {
 		resourceRepository.close()
+		VirtualModelRegistry.instance.deregisterVirtualModel(this)
 	}
 
 }

--- a/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/VirtualModelRegistry.java
+++ b/bundles/framework/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/VirtualModelRegistry.java
@@ -1,0 +1,30 @@
+package tools.vitruv.framework.vsum.internal;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class VirtualModelRegistry {
+	private static VirtualModelRegistry instance = new VirtualModelRegistry();
+
+	private Map<Path, InternalVirtualModel> folderToVirtualModelMap = new ConcurrentHashMap<>();
+
+	private VirtualModelRegistry() {
+	}
+
+	public static VirtualModelRegistry getInstance() {
+		return instance;
+	}
+
+	public InternalVirtualModel getVirtualModel(Path folder) {
+		return folderToVirtualModelMap.get(folder);
+	}
+
+	public void registerVirtualModel(InternalVirtualModel model) {
+		folderToVirtualModelMap.put(model.getFolder(), model);
+	}
+
+	public void deregisterVirtualModel(InternalVirtualModel model) {
+		folderToVirtualModelMap.remove(model.getFolder());
+	}
+}


### PR DESCRIPTION
This PR fixes two memory leaks:
1. The `ChangeRecorder` kept a collection of existing elements after closing it. If the recorder is still referenced somewhere, these elements are kept in memory requiring large amounts of memory (as this affects _all_ elements monitored by the recorder before). Now closing the view also cleans this collections.
2. The `VirtualModel` was registered at a central registry but not removed on dispose. Thus, the model with all its contents remained in memory. Now the model deregisters itself on dispose.