### PR TITLE
Enable repeated responses to the same types of user interactions in tests

### DIFF
--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestUserInteraction.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestUserInteraction.xtend
@@ -121,17 +121,28 @@ class TestUserInteraction {
 		onMultipleChoiceMultiSelection [true]
 	}
 
+	/**
+	 * Validates that all interactions, to which responses have been defined, have occurred. Otherwise, 
+	 * an {@link AssertionError} is thrown. Responses that have been defined for all occurrences of the 
+	 * same interaction by calling an {@code always} method of the builder will not be considered. 
+	 */
 	def assertAllInteractionsOccurred() {
-		val interactionsLeft = confirmations.size + notificationReactions.size + textInputs.size +
-			multipleChoices.size + multipleChoiceMultipleSelections.size
+		val nonRepeatedConfirmations = confirmations.filter[!repeatedly]
+		val nonRepeatedNotifications = notificationReactions.filter[!repeatedly]
+		val nonRepeatedTextInputs = textInputs.filter[!repeatedly]
+		val nonRepeatedMultipleChoices = multipleChoices.filter[!repeatedly]
+		val nonRepeatedMultipleChoiceMultipleSelections = multipleChoiceMultipleSelections.filter[!repeatedly]
+		val interactionsLeft = nonRepeatedConfirmations.size + nonRepeatedNotifications.size +
+			nonRepeatedTextInputs.size + nonRepeatedMultipleChoices.size +
+			nonRepeatedMultipleChoiceMultipleSelections.size
 		if (interactionsLeft > 0) {
 			val resultMessage = new StringBuilder()
 			resultMessage.joinSemantic(List.<Pair<String, Collection<?>>>of(
-				"confirmation" -> confirmations,
-				"notification" -> notificationReactions,
-				"text input" -> textInputs,
-				"single selection" -> multipleChoices,
-				"multi selection" -> multipleChoiceMultipleSelections
+				"confirmation" -> nonRepeatedConfirmations.toList,
+				"notification" -> nonRepeatedNotifications.toList,
+				"text input" -> nonRepeatedTextInputs.toList,
+				"single selection" -> nonRepeatedMultipleChoices.toList,
+				"multi selection" -> nonRepeatedMultipleChoiceMultipleSelections.toList
 			).filter[!value.isEmpty].toList, 'and') [
 				resultMessage.append(value.size).append(' ').append(plural(value, key))
 			].append(' ').append(if(interactionsLeft === 1) 'was' else 'were').append(' expected but did not occur!')

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestUserInteraction.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestUserInteraction.xtend
@@ -15,11 +15,18 @@ import java.util.ArrayList
 import java.util.Set
 
 class TestUserInteraction {
-	val List<Pair<(ConfirmationInteractionDescription)=>boolean, Boolean>> confirmations = new LinkedList
-	val List<Pair<(NotificationInteractionDescription)=>boolean, Void>> notificationReactions = new LinkedList
-	val List<Pair<(TextInputInteractionDescription)=>boolean, String>> textInputs = new LinkedList
-	val List<Pair<(MultipleChoiceInteractionDescription)=>boolean, (MultipleChoiceInteractionDescription)=>int>> multipleChoices = new LinkedList
-	val List<Pair<(MultipleChoiceMultipleSelectionInteractionDescription)=>boolean, (MultipleChoiceMultipleSelectionInteractionDescription)=>int[]>> multipleChoiceMultipleSelections = new LinkedList
+	val List<Response<ConfirmationInteractionDescription, Boolean>> confirmations = new LinkedList
+	val List<Response<NotificationInteractionDescription, Void>> notificationReactions = new LinkedList
+	val List<Response<TextInputInteractionDescription, String>> textInputs = new LinkedList
+	val List<Response<MultipleChoiceInteractionDescription, (MultipleChoiceInteractionDescription)=>int>> multipleChoices = new LinkedList
+	val List<Response<MultipleChoiceMultipleSelectionInteractionDescription, (MultipleChoiceMultipleSelectionInteractionDescription)=>int[]>> multipleChoiceMultipleSelections = new LinkedList
+
+	@FinalFieldsConstructor
+	static class Response<Description, Result> {
+		val (Description)=>boolean matcher
+		val Result response
+		val boolean repeatedly
+	}
 
 	def void addNextConfirmationInput(boolean nextConfirmation) {
 		onNextConfirmation.respondWith(nextConfirmation)
@@ -36,32 +43,32 @@ class TestUserInteraction {
 	def void addNextMultiSelection(int[] nextSelection) {
 		onNextMultipleChoiceMultiSelection.respondWithChoicesAt(nextSelection)
 	}
-	
+
 	/**
 	 * Configure a response to a confirmation interaction. The next confirmation that matches the
 	 * provided {@code condition} will be responded to with the result that is configured on the returned builder.
 	 * Once the result has been provided, it will not be used again. If the {@code condition} matches an interaction
 	 * that already has a programmed response, the response programmed on the returned builder will take precedence.
-	 */	
+	 */
 	def onConfirmation((ConfirmationInteractionDescription)=>boolean condition) {
 		new SimpleResponseBuilder(this, confirmations, condition)
 	}
-	
+
 	/**
 	 * Configures the response to the next confirmation interaction.
 	 */
 	def onNextConfirmation() {
 		onConfirmation [true]
 	}
-	
+
 	/**
 	 * Acknowledges once (i.e. does not raise an error for) a notification passing the provided {@code check}.
 	 */
 	def acknowledgeNotification((NotificationInteractionDescription)=>boolean check) {
-		notificationReactions += check -> null
+		notificationReactions += new Response(check, null, false)
 		return this
 	}
-	
+
 	/**
 	 * Configures a response to a text input interaction. The next text input interaction that matches the
 	 * provided {@code condition} will be responded to with the result that is configured on the returned builder.
@@ -71,14 +78,14 @@ class TestUserInteraction {
 	def onTextInput((TextInputInteractionDescription)=>boolean condition) {
 		new SimpleResponseBuilder(this, textInputs, condition)
 	}
-	
+
 	/**
 	 * Configures the response to the next text input interaction.
 	 */
 	def onNextTextInput() {
 		onTextInput [true]
 	}
-	
+
 	/**
 	 * Configures a response to a multiple choice interaction. The next multiple choice interaction that matches the
 	 * provided {@code condition} will be responded to with the result that is configured on the returned builder.
@@ -88,14 +95,14 @@ class TestUserInteraction {
 	def onMultipleChoiceSingleSelection((MultipleChoiceInteractionDescription)=>boolean condition) {
 		new MultipleChoiceResponseBuilder(this, condition)
 	}
-	
+
 	/**
 	 * Configures the response to the next multiple choice interaction.
 	 */
 	def onNextMultipleChoiceSingleSelection() {
 		onMultipleChoiceSingleSelection [true]
 	}
-	
+
 	/**
 	 * Configures a response to a multiple choice interaction with multiple possible selections. The next such 
 	 * interaction that matches the provided {@code condition} will be responded to with the result that is configured 
@@ -106,17 +113,17 @@ class TestUserInteraction {
 	def onMultipleChoiceMultiSelection((MultipleChoiceMultipleSelectionInteractionDescription)=>boolean condition) {
 		new MultipleChoiceMultipleSelectionResponseBuilder(this, condition)
 	}
-	
+
 	/**
 	 * Configures the response to the next multiple choice interaction with multiple possible selections.
 	 */
 	def onNextMultipleChoiceMultiSelection() {
 		onMultipleChoiceMultiSelection [true]
 	}
-	
+
 	def assertAllInteractionsOccurred() {
-		val interactionsLeft = confirmations.size + notificationReactions.size + textInputs.size 
-			+ multipleChoices.size + multipleChoiceMultipleSelections.size
+		val interactionsLeft = confirmations.size + notificationReactions.size + textInputs.size +
+			multipleChoices.size + multipleChoiceMultipleSelections.size
 		if (interactionsLeft > 0) {
 			val resultMessage = new StringBuilder()
 			resultMessage.joinSemantic(List.<Pair<String, Collection<?>>>of(
@@ -125,17 +132,14 @@ class TestUserInteraction {
 				"text input" -> textInputs,
 				"single selection" -> multipleChoices,
 				"multi selection" -> multipleChoiceMultipleSelections
-			) .filter [!value.isEmpty].toList, 'and') [
+			).filter[!value.isEmpty].toList, 'and') [
 				resultMessage.append(value.size).append(' ').append(plural(value, key))
-			]
-			.append(' ')
-			.append(if (interactionsLeft === 1) 'was' else 'were')
-			.append(' expected but did not occur!')
-			
+			].append(' ').append(if(interactionsLeft === 1) 'was' else 'were').append(' expected but did not occur!')
+
 			throw new AssertionError(resultMessage.toString())
-		} 
+		}
 	}
-	
+
 	/**
 	 * Removes all responses that have been programmed.
 	 */
@@ -146,48 +150,62 @@ class TestUserInteraction {
 		multipleChoices.clear()
 		multipleChoiceMultipleSelections.clear()
 	}
-	
+
 	def listSize(StringBuilder result, Collection<?> list, String type) {
 		if (!list.isEmpty) {
 			result.append(list.size).append(' ').append(plural(list, type))
-		} else null
-	} 
-	
+		} else
+			null
+	}
+
 	@FinalFieldsConstructor
 	static class SimpleResponseBuilder<Description, Result> {
 		val TestUserInteraction owner
-		val List<Pair<(Description)=>boolean, Result>> targetQueue
+		val List<Response<Description, Result>> targetQueue
 		val (Description)=>boolean condition
-		
+		var boolean repeatedly = false
+
+		def SimpleResponseBuilder<Description, Result> always() {
+			this.repeatedly = true
+			return this
+		}
+
 		/**
 		 * Responds the interaction with the provided {@code result} if the condition this builder was created for holds.
 		 */
 		def TestUserInteraction respondWith(Result result) {
-			targetQueue += condition -> result
+			targetQueue += new Response(condition, result, repeatedly)
 			return owner
 		}
 	}
-	
+
 	@FinalFieldsConstructor
 	static class MultipleChoiceResponseBuilder {
 		val TestUserInteraction owner
 		val (MultipleChoiceInteractionDescription)=>boolean condition
-		
+		var boolean repeatedly = false
+
+		def MultipleChoiceResponseBuilder always() {
+			this.repeatedly = true
+			return this
+		}
+
 		def TestUserInteraction respondWith(String result) {
 			respondWithChoiceMatching [it == result]
 		}
-		
+
 		def TestUserInteraction respondWithChoiceAt(int resultIndex) {
-			owner.multipleChoices.add(condition -> [resultIndex])
+			owner.multipleChoices.add(new Response(condition, [resultIndex], repeatedly))
 			return owner
 		}
-		
+
 		def TestUserInteraction respondWithChoiceMatching((String)=>boolean selector) {
-			owner.multipleChoices.add(condition -> [assertedIndexBy(selector)])
+			owner.multipleChoices.add(new Response(condition, [assertedIndexBy(selector)], repeatedly))
 			return owner
 		}
-		
-		def private static int assertedIndexBy(MultipleChoiceInteractionDescription interaction, (String)=>boolean selector) {
+
+		def private static int assertedIndexBy(MultipleChoiceInteractionDescription interaction,
+			(String)=>boolean selector) {
 			for (var i = 0, val choiceIt = interaction.choices.iterator; choiceIt.hasNext; i += 1) {
 				if (selector.apply(choiceIt.next)) {
 					return i
@@ -196,116 +214,127 @@ class TestUserInteraction {
 			throw new AssertionError('''«interaction.type» without an acceptable choice:«lineSeparator»«interaction»''')
 		}
 	}
-	
+
 	@FinalFieldsConstructor
 	static class MultipleChoiceMultipleSelectionResponseBuilder {
 		val TestUserInteraction owner
 		val (MultipleChoiceMultipleSelectionInteractionDescription)=>boolean condition
-		
+		var boolean repeatedly = false
+
+		def MultipleChoiceMultipleSelectionResponseBuilder always() {
+			this.repeatedly = true
+			return this
+		}
+
 		def TestUserInteraction respondWith(String... results) {
 			respondWith(Set.of(results))
 		}
-		
+
 		def TestUserInteraction respondWith(Set<String> results) {
 			respondWithChoicesMatching [results.contains(it)]
 		}
-		
+
 		def TestUserInteraction respondWithChoicesAt(int... resultIndeces) {
-			owner.multipleChoiceMultipleSelections.add(condition -> [resultIndeces])
+			owner.multipleChoiceMultipleSelections.add(new Response(condition, [resultIndeces], repeatedly))
 			return owner
 		}
-		
+
 		def TestUserInteraction respondWithChoicesMatching((String)=>boolean selector) {
-			owner.multipleChoiceMultipleSelections.add(condition -> [assertedIndecesBy(selector)])
+			owner.multipleChoiceMultipleSelections.add(
+				new Response(condition, [assertedIndecesBy(selector)], repeatedly))
 			return owner
 		}
-		
-		def private static int[] assertedIndecesBy(MultipleChoiceMultipleSelectionInteractionDescription interaction, (String)=>boolean selector) {
+
+		def private static int[] assertedIndecesBy(MultipleChoiceMultipleSelectionInteractionDescription interaction,
+			(String)=>boolean selector) {
 			val result = new ArrayList<Integer>
 			for (var i = 0, val choiceIt = interaction.getChoices.iterator; choiceIt.hasNext; i += 1) {
 				if (selector.apply(choiceIt.next)) {
 					result += i
 				}
 			}
-			if (result.isEmpty) {
-				throw new AssertionError('''«interaction.type» without any acceptable choice:«lineSeparator»«interaction»''')
-			}
 			return result
 		}
 	}
-	
+
 	@FinalFieldsConstructor
-	@Accessors 
+	@Accessors
 	static abstract class InteractionDescription {
 		val WindowModality windowModality
 		val String title
 		val String message
 		val String positiveDecisionText
+
 		def abstract String getType()
-		
+
 		override toString() {
 			'''«title»: «message»'''
 		}
-	}	
-	
+	}
+
 	@FinalFieldsConstructor
 	@Accessors
 	static class ConfirmationInteractionDescription extends InteractionDescription {
 		val String negativeDecisionText
 		val String cancelDecisionText
-		
+
 		override getType() {
 			"confirmation interaction"
 		}
 	}
-	
+
 	@FinalFieldsConstructor
 	@Accessors
 	static class TextInputInteractionDescription extends InteractionDescription {
 		val String cancelDecisionText
 		val InputValidator inputValidator
-		
+
 		override getType() {
 			"text input interaction"
 		}
 	}
-	
+
 	@FinalFieldsConstructor
 	@Accessors
 	static class NotificationInteractionDescription extends InteractionDescription {
 		val NotificationType notificationType
-		
+
 		override toString() {
 			'''«notificationType» «super.toString()»'''
 		}
-		
+
 		override getType() {
 			"notification interaction"
 		}
 	}
-	
+
 	@FinalFieldsConstructor
 	@Accessors
 	static class MultipleChoiceInteractionDescription extends InteractionDescription {
 		val String cancelDecisionText
 		val Iterable<String> choices
-		
+
 		override toString() {
-			super.toString() + choices.join('') ['''«lineSeparator»  • «it»''']
+			super.toString() + choices.join('')['''«lineSeparator»  • «it»''']
 		}
-		
+
 		override getType() {
 			"multiple choice interaction"
 		}
 	}
-	
+
 	static class MultipleChoiceMultipleSelectionInteractionDescription extends MultipleChoiceInteractionDescription {
-		new(WindowModality windowModality, String title, String message, String positiveDecisionText, 
-			String cancelDecisionText, Iterable<String> choices
+		new(
+			WindowModality windowModality,
+			String title,
+			String message,
+			String positiveDecisionText,
+			String cancelDecisionText,
+			Iterable<String> choices
 		) {
 			super(windowModality, title, message, positiveDecisionText, cancelDecisionText, choices)
 		}
-		
+
 		override getType() {
 			"multiple choice interaction with multiple selections"
 		}
@@ -314,52 +343,58 @@ class TestUserInteraction {
 	@FinalFieldsConstructor
 	static class ResultProvider implements InteractionResultProvider {
 		val TestUserInteraction source
-		
-		override getConfirmationInteractionResult(WindowModality windowModality, String title, String message, String positiveDecisionText, String negativeDecisionText, String cancelDecisionText) {
+
+		override getConfirmationInteractionResult(WindowModality windowModality, String title, String message,
+			String positiveDecisionText, String negativeDecisionText, String cancelDecisionText) {
 			source.confirmations.requireMatchingInteraction(
 				new ConfirmationInteractionDescription(windowModality, title, message, positiveDecisionText,
 					negativeDecisionText, cancelDecisionText)
 			)
 		}
-		
-		override getNotificationInteractionResult(WindowModality windowModality, String title, String message, String positiveDecisionText, NotificationType notificationType) {
+
+		override getNotificationInteractionResult(WindowModality windowModality, String title, String message,
+			String positiveDecisionText, NotificationType notificationType) {
 			source.notificationReactions.requireMatchingInteraction(
-				new NotificationInteractionDescription(windowModality, title, message, 
-					positiveDecisionText, notificationType)
+				new NotificationInteractionDescription(windowModality, title, message, positiveDecisionText,
+					notificationType)
 			)
 		}
-		
-		override getTextInputInteractionResult(WindowModality windowModality, String title, String message, String positiveDecisionText, String cancelDecisionText, InputValidator inputValidator) {
+
+		override getTextInputInteractionResult(WindowModality windowModality, String title, String message,
+			String positiveDecisionText, String cancelDecisionText, InputValidator inputValidator) {
 			source.textInputs.requireMatchingInteraction(
 				new TextInputInteractionDescription(windowModality, title, message, positiveDecisionText,
 					cancelDecisionText, inputValidator)
 			)
 		}
-		
-		override getMultipleChoiceSingleSelectionInteractionResult(WindowModality windowModality, String title, 
+
+		override getMultipleChoiceSingleSelectionInteractionResult(WindowModality windowModality, String title,
 			String message, String positiveDecisionText, String cancelDecisionText, Iterable<String> choices) {
 			val interaction = new MultipleChoiceInteractionDescription(windowModality, title, message,
-					 positiveDecisionText, cancelDecisionText, choices)
+				positiveDecisionText, cancelDecisionText, choices)
 			val resultProvider = source.multipleChoices.requireMatchingInteraction(interaction)
 			return resultProvider.apply(interaction)
 		}
-		
-		override getMultipleChoiceMultipleSelectionInteractionResult(WindowModality windowModality, String title, String message, String positiveDecisionText, String cancelDecisionText, Iterable<String> choices) {
+
+		override getMultipleChoiceMultipleSelectionInteractionResult(WindowModality windowModality, String title,
+			String message, String positiveDecisionText, String cancelDecisionText, Iterable<String> choices) {
 			val interaction = new MultipleChoiceMultipleSelectionInteractionDescription(windowModality, title, message,
-			 	positiveDecisionText, cancelDecisionText, choices)
+				positiveDecisionText, cancelDecisionText, choices)
 			val resultProvider = source.multipleChoiceMultipleSelections.requireMatchingInteraction(interaction)
 			return resultProvider.apply(interaction)
 		}
-		
+
 		private static def <Description extends InteractionDescription, Result> requireMatchingInteraction(
-			Iterable<Pair<(Description)=>boolean, Result>> options,
+			Iterable<Response<Description, Result>> options,
 			Description interaction
 		) {
 			for (val optionsIt = options.iterator(); optionsIt.hasNext;) {
 				val option = optionsIt.next()
-				if (option.key.apply(interaction)) {
-					optionsIt.remove()
-					return option.value
+				if (option.matcher.apply(interaction)) {
+					if (!option.repeatedly) {
+						optionsIt.remove()
+					}
+					return option.response
 				}
 			}
 			throw new AssertionError('''An unexpected «interaction.type» occurred:«lineSeparator»«interaction»''')

--- a/tests/tools.vitruv.testutils.tests/src/tools/vitruv/testutils/TestUserInteractionTest.java
+++ b/tests/tools.vitruv.testutils.tests/src/tools/vitruv/testutils/TestUserInteractionTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,18 @@ import static java.util.Collections.emptyList;
 public class TestUserInteractionTest {
 	private static String DIALOG_TITLE = "test";
 
+	private TestUserInteraction testInteraction;
+
+	@BeforeEach
+	public void setupInteraction() {
+		testInteraction = new TestUserInteraction();
+	}
+
+	@AfterEach
+	public void assertAllInteractionOccurred() {
+		testInteraction.assertAllInteractionsOccurred();
+	}
+
 	@Nested
 	@DisplayName("text input")
 	class TextInput {
@@ -25,7 +39,6 @@ public class TestUserInteractionTest {
 		@DisplayName("required and provided a single time")
 		public void provideAndRequireSingleTime() {
 			String responseText = "response";
-			TestUserInteraction testInteraction = new TestUserInteraction();
 			testInteraction.onTextInput((description) -> description.getTitle().equals(DIALOG_TITLE))
 					.respondWith(responseText);
 			UserInteractor userInteractor = generateInteractor(testInteraction);
@@ -37,7 +50,6 @@ public class TestUserInteractionTest {
 		@DisplayName("required and provided multiple times")
 		public void provideAndRequireMultipleTimes() {
 			String responseText = "response";
-			TestUserInteraction testInteraction = new TestUserInteraction();
 			testInteraction.onTextInput((description) -> description.getTitle().equals(DIALOG_TITLE)).always()
 					.respondWith(responseText);
 			UserInteractor userInteractor = generateInteractor(testInteraction);
@@ -50,7 +62,6 @@ public class TestUserInteractionTest {
 		@DisplayName("required multiple but provided a single time")
 		public void provideSingleButRequireMultipleTimes() {
 			String responseText = "response";
-			TestUserInteraction testInteraction = new TestUserInteraction();
 			testInteraction.onTextInput((description) -> description.getTitle().equals(DIALOG_TITLE))
 					.respondWith(responseText);
 			UserInteractor userInteractor = generateInteractor(testInteraction);
@@ -66,7 +77,6 @@ public class TestUserInteractionTest {
 		@Test
 		@DisplayName("required and provided a single time")
 		public void provideAndRequireSingleTime() {
-			TestUserInteraction testInteraction = new TestUserInteraction();
 			testInteraction.onConfirmation((description) -> description.getTitle().equals(DIALOG_TITLE))
 					.respondWith(true);
 			UserInteractor userInteractor = generateInteractor(testInteraction);
@@ -77,7 +87,6 @@ public class TestUserInteractionTest {
 		@Test
 		@DisplayName("required and provided multiple times")
 		public void provideAndRequireMultipleTimes() {
-			TestUserInteraction testInteraction = new TestUserInteraction();
 			testInteraction.onConfirmation((description) -> description.getTitle().equals(DIALOG_TITLE)).always()
 					.respondWith(true);
 			UserInteractor userInteractor = generateInteractor(testInteraction);
@@ -89,7 +98,6 @@ public class TestUserInteractionTest {
 		@Test
 		@DisplayName("required multiple but provided a single time")
 		public void provideSingleButRequireMultipleTimes() {
-			TestUserInteraction testInteraction = new TestUserInteraction();
 			testInteraction.onConfirmation((description) -> description.getTitle().equals(DIALOG_TITLE))
 					.respondWith(true);
 			UserInteractor userInteractor = generateInteractor(testInteraction);
@@ -110,7 +118,6 @@ public class TestUserInteractionTest {
 			public void provideAndRequireSingleTime() {
 				String response = "selectedItem";
 				List<String> choices = List.of("dummy", response);
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWith(response);
@@ -124,7 +131,6 @@ public class TestUserInteractionTest {
 			public void provideAndRequireMultipleTimes() {
 				String response = "selectedItem";
 				List<String> choices = List.of("dummy", response);
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.always().respondWith(response);
@@ -140,7 +146,6 @@ public class TestUserInteractionTest {
 			public void provideSingleButRequireMultipleTimes() {
 				String response = "selectedItem";
 				List<String> choices = List.of("dummy", response);
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWith(response);
@@ -160,7 +165,6 @@ public class TestUserInteractionTest {
 			public void provideAndRequireSingleTime() {
 				int selectedIndex = 1;
 				List<String> choices = List.of("firstDummy", "secondDummy");
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWithChoiceAt(selectedIndex);
@@ -174,7 +178,6 @@ public class TestUserInteractionTest {
 			public void provideAndRequireMultipleTimes() {
 				int selectedIndex = 1;
 				List<String> choices = List.of("firstDummy", "secondDummy");
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.always().respondWithChoiceAt(selectedIndex);
@@ -190,7 +193,6 @@ public class TestUserInteractionTest {
 			public void provideSingleButRequireMultipleTimes() {
 				int selectedIndex = 1;
 				List<String> choices = List.of("firstDummy", "secondDummy");
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWithChoiceAt(selectedIndex);
@@ -213,7 +215,6 @@ public class TestUserInteractionTest {
 			@DisplayName("required and provided a single time")
 			public void provideAndRequireSingleTime() {
 				List<String> choices = List.of("firstDummy", "secondDummy");
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWith(emptySet());
@@ -226,7 +227,6 @@ public class TestUserInteractionTest {
 			@DisplayName("required and provided multiple times")
 			public void provideAndRequireMultipleTimes() {
 				List<String> choices = List.of("firstDummy", "secondDummy");
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.always().respondWith(new String[] {});
@@ -241,7 +241,6 @@ public class TestUserInteractionTest {
 			@DisplayName("required multiple but provided a single time")
 			public void provideSingleButRequireMultipleTimes() {
 				List<String> choices = List.of("firstDummy", "secondDummy");
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWith(new String[] {});
@@ -261,7 +260,6 @@ public class TestUserInteractionTest {
 			public void provideAndRequireSingleTime() {
 				int response = 0;
 				List<String> choices = List.of("firstDummy", "secondDummy");
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWithChoicesAt(new int[] { response });
@@ -275,7 +273,6 @@ public class TestUserInteractionTest {
 			public void provideAndRequireMultipleTimes() {
 				int response = 0;
 				List<String> choices = List.of("firstDummy", "secondDummy");
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.always().respondWithChoicesAt(new int[] { response });
@@ -291,7 +288,6 @@ public class TestUserInteractionTest {
 			public void provideSingleButRequireMultipleTimes() {
 				int response = 0;
 				List<String> choices = List.of("firstDummy", "secondDummy");
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWithChoicesAt(new int[] { response });
@@ -311,7 +307,6 @@ public class TestUserInteractionTest {
 			public void provideAndRequireSingleTime() {
 				String response = "selectedItem";
 				List<String> choices = List.of("firstDummy", response);
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWith(new String[] { response });
@@ -325,7 +320,6 @@ public class TestUserInteractionTest {
 			public void provideAndRequireMultipleTimes() {
 				String response = "selectedItem";
 				List<String> choices = List.of("dummy", response);
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.always().respondWith(new String[] { response });
@@ -341,7 +335,6 @@ public class TestUserInteractionTest {
 			public void provideSingleButRequireMultipleTimes() {
 				String response = "selectedItem";
 				List<String> choices = List.of("dummy", response);
-				TestUserInteraction testInteraction = new TestUserInteraction();
 				testInteraction
 						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
 						.respondWith(new String[] { response });

--- a/tests/tools.vitruv.testutils.tests/src/tools/vitruv/testutils/TestUserInteractionTest.java
+++ b/tests/tools.vitruv.testutils.tests/src/tools/vitruv/testutils/TestUserInteractionTest.java
@@ -1,0 +1,361 @@
+package tools.vitruv.testutils;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import tools.vitruv.framework.userinteraction.UserInteractionFactory;
+import tools.vitruv.framework.userinteraction.UserInteractor;
+import tools.vitruv.testutils.TestUserInteraction.ResultProvider;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.emptyList;
+
+public class TestUserInteractionTest {
+	private static String DIALOG_TITLE = "test";
+
+	@Nested
+	@DisplayName("text input")
+	class TextInput {
+		@Test
+		@DisplayName("required and provided a single time")
+		public void provideAndRequireSingleTime() {
+			String responseText = "response";
+			TestUserInteraction testInteraction = new TestUserInteraction();
+			testInteraction.onTextInput((description) -> description.getTitle().equals(DIALOG_TITLE))
+					.respondWith(responseText);
+			UserInteractor userInteractor = generateInteractor(testInteraction);
+			assertThat(userInteractor.getTextInputDialogBuilder().message(DIALOG_TITLE).title(DIALOG_TITLE)
+					.startInteraction(), equalTo(responseText));
+		}
+
+		@Test
+		@DisplayName("required and provided multiple times")
+		public void provideAndRequireMultipleTimes() {
+			String responseText = "response";
+			TestUserInteraction testInteraction = new TestUserInteraction();
+			testInteraction.onTextInput((description) -> description.getTitle().equals(DIALOG_TITLE)).always()
+					.respondWith(responseText);
+			UserInteractor userInteractor = generateInteractor(testInteraction);
+			userInteractor.getTextInputDialogBuilder().message(DIALOG_TITLE).title(DIALOG_TITLE).startInteraction();
+			assertThat(userInteractor.getTextInputDialogBuilder().message(DIALOG_TITLE).title(DIALOG_TITLE)
+					.startInteraction(), equalTo(responseText));
+		}
+
+		@Test
+		@DisplayName("required multiple but provided a single time")
+		public void provideSingleButRequireMultipleTimes() {
+			String responseText = "response";
+			TestUserInteraction testInteraction = new TestUserInteraction();
+			testInteraction.onTextInput((description) -> description.getTitle().equals(DIALOG_TITLE))
+					.respondWith(responseText);
+			UserInteractor userInteractor = generateInteractor(testInteraction);
+			userInteractor.getTextInputDialogBuilder().message(DIALOG_TITLE).title(DIALOG_TITLE).startInteraction();
+			assertThrows(AssertionError.class, () -> userInteractor.getTextInputDialogBuilder().message(DIALOG_TITLE)
+					.title(DIALOG_TITLE).startInteraction());
+		}
+	}
+
+	@Nested
+	@DisplayName("confirmation")
+	class Confirmation {
+		@Test
+		@DisplayName("required and provided a single time")
+		public void provideAndRequireSingleTime() {
+			TestUserInteraction testInteraction = new TestUserInteraction();
+			testInteraction.onConfirmation((description) -> description.getTitle().equals(DIALOG_TITLE))
+					.respondWith(true);
+			UserInteractor userInteractor = generateInteractor(testInteraction);
+			assertThat(userInteractor.getConfirmationDialogBuilder().message(DIALOG_TITLE).title(DIALOG_TITLE)
+					.startInteraction(), equalTo(true));
+		}
+
+		@Test
+		@DisplayName("required and provided multiple times")
+		public void provideAndRequireMultipleTimes() {
+			TestUserInteraction testInteraction = new TestUserInteraction();
+			testInteraction.onConfirmation((description) -> description.getTitle().equals(DIALOG_TITLE)).always()
+					.respondWith(true);
+			UserInteractor userInteractor = generateInteractor(testInteraction);
+			userInteractor.getConfirmationDialogBuilder().message(DIALOG_TITLE).title(DIALOG_TITLE).startInteraction();
+			assertThat(userInteractor.getConfirmationDialogBuilder().message(DIALOG_TITLE).title(DIALOG_TITLE)
+					.startInteraction(), equalTo(true));
+		}
+
+		@Test
+		@DisplayName("required multiple but provided a single time")
+		public void provideSingleButRequireMultipleTimes() {
+			TestUserInteraction testInteraction = new TestUserInteraction();
+			testInteraction.onConfirmation((description) -> description.getTitle().equals(DIALOG_TITLE))
+					.respondWith(true);
+			UserInteractor userInteractor = generateInteractor(testInteraction);
+			userInteractor.getConfirmationDialogBuilder().message(DIALOG_TITLE).title(DIALOG_TITLE).startInteraction();
+			assertThrows(AssertionError.class, () -> userInteractor.getConfirmationDialogBuilder().message(DIALOG_TITLE)
+					.title(DIALOG_TITLE).startInteraction());
+		}
+	}
+
+	@Nested
+	@DisplayName("single selection")
+	class SingleSelection {
+		@Nested
+		@DisplayName("matched by string")
+		class MatchedByString {
+			@Test
+			@DisplayName("required and provided a single time")
+			public void provideAndRequireSingleTime() {
+				String response = "selectedItem";
+				List<String> choices = List.of("dummy", response);
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWith(response);
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				assertThat(userInteractor.getSingleSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(choices.indexOf(response)));
+			}
+
+			@Test
+			@DisplayName("required and provided multiple times")
+			public void provideAndRequireMultipleTimes() {
+				String response = "selectedItem";
+				List<String> choices = List.of("dummy", response);
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.always().respondWith(response);
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getSingleSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThat(userInteractor.getSingleSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(choices.indexOf(response)));
+			}
+
+			@Test
+			@DisplayName("required multiple but provided a single time")
+			public void provideSingleButRequireMultipleTimes() {
+				String response = "selectedItem";
+				List<String> choices = List.of("dummy", response);
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWith(response);
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getSingleSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThrows(AssertionError.class, () -> userInteractor.getSingleSelectionDialogBuilder()
+						.message(DIALOG_TITLE).choices(choices).title(DIALOG_TITLE).startInteraction());
+			}
+		}
+
+		@Nested
+		@DisplayName("matched by index")
+		class MatchedByIndex {
+			@Test
+			@DisplayName("required and provided a single time")
+			public void provideAndRequireSingleTime() {
+				int selectedIndex = 1;
+				List<String> choices = List.of("firstDummy", "secondDummy");
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWithChoiceAt(selectedIndex);
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				assertThat(userInteractor.getSingleSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(selectedIndex));
+			}
+
+			@Test
+			@DisplayName("required and provided multiple times")
+			public void provideAndRequireMultipleTimes() {
+				int selectedIndex = 1;
+				List<String> choices = List.of("firstDummy", "secondDummy");
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.always().respondWithChoiceAt(selectedIndex);
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getSingleSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThat(userInteractor.getSingleSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(selectedIndex));
+			}
+
+			@Test
+			@DisplayName("required multiple but provided a single time")
+			public void provideSingleButRequireMultipleTimes() {
+				int selectedIndex = 1;
+				List<String> choices = List.of("firstDummy", "secondDummy");
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceSingleSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWithChoiceAt(selectedIndex);
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getSingleSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThrows(AssertionError.class, () -> userInteractor.getSingleSelectionDialogBuilder()
+						.message(DIALOG_TITLE).choices(choices).title(DIALOG_TITLE).startInteraction());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("multiple selection")
+	class MultipleSelection {
+		@Nested
+		@DisplayName("with no element selected")
+		class NoIndexSelected {
+			@Test
+			@DisplayName("required and provided a single time")
+			public void provideAndRequireSingleTime() {
+				List<String> choices = List.of("firstDummy", "secondDummy");
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWith(emptySet());
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				assertThat(userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(emptyList()));
+			}
+
+			@Test
+			@DisplayName("required and provided multiple times")
+			public void provideAndRequireMultipleTimes() {
+				List<String> choices = List.of("firstDummy", "secondDummy");
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.always().respondWith(new String[] {});
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThat(userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(emptyList()));
+			}
+
+			@Test
+			@DisplayName("required multiple but provided a single time")
+			public void provideSingleButRequireMultipleTimes() {
+				List<String> choices = List.of("firstDummy", "secondDummy");
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWith(new String[] {});
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThrows(AssertionError.class, () -> userInteractor.getMultiSelectionDialogBuilder()
+						.message(DIALOG_TITLE).choices(choices).title(DIALOG_TITLE).startInteraction());
+			}
+		}
+
+		@Nested
+		@DisplayName("with index selected")
+		class IndexSelected {
+			@Test
+			@DisplayName("required and provided a single time")
+			public void provideAndRequireSingleTime() {
+				int response = 0;
+				List<String> choices = List.of("firstDummy", "secondDummy");
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWithChoicesAt(new int[] { response });
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				assertThat(userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(List.of(response)));
+			}
+
+			@Test
+			@DisplayName("required and provided multiple times")
+			public void provideAndRequireMultipleTimes() {
+				int response = 0;
+				List<String> choices = List.of("firstDummy", "secondDummy");
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.always().respondWithChoicesAt(new int[] { response });
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThat(userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(List.of(response)));
+			}
+
+			@Test
+			@DisplayName("required multiple but provided a single time")
+			public void provideSingleButRequireMultipleTimes() {
+				int response = 0;
+				List<String> choices = List.of("firstDummy", "secondDummy");
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWithChoicesAt(new int[] { response });
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThrows(AssertionError.class, () -> userInteractor.getMultiSelectionDialogBuilder()
+						.message(DIALOG_TITLE).choices(choices).title(DIALOG_TITLE).startInteraction());
+			}
+		}
+
+		@Nested
+		@DisplayName("with string selected")
+		class StringSelected {
+			@Test
+			@DisplayName("required and provided a single time")
+			public void provideAndRequireSingleTime() {
+				String response = "selectedItem";
+				List<String> choices = List.of("firstDummy", response);
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWith(new String[] { response });
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				assertThat(userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(List.of(choices.indexOf(response))));
+			}
+
+			@Test
+			@DisplayName("required and provided multiple times")
+			public void provideAndRequireMultipleTimes() {
+				String response = "selectedItem";
+				List<String> choices = List.of("dummy", response);
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.always().respondWith(new String[] { response });
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThat(userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction(), equalTo(List.of(choices.indexOf(response))));
+			}
+
+			@Test
+			@DisplayName("required multiple but provided a single time")
+			public void provideSingleButRequireMultipleTimes() {
+				String response = "selectedItem";
+				List<String> choices = List.of("dummy", response);
+				TestUserInteraction testInteraction = new TestUserInteraction();
+				testInteraction
+						.onMultipleChoiceMultiSelection((description) -> description.getTitle().equals(DIALOG_TITLE))
+						.respondWith(new String[] { response });
+				UserInteractor userInteractor = generateInteractor(testInteraction);
+				userInteractor.getMultiSelectionDialogBuilder().message(DIALOG_TITLE).choices(choices)
+						.title(DIALOG_TITLE).startInteraction();
+				assertThrows(AssertionError.class, () -> userInteractor.getMultiSelectionDialogBuilder()
+						.message(DIALOG_TITLE).choices(choices).title(DIALOG_TITLE).startInteraction());
+			}
+		}
+
+	}
+
+	private UserInteractor generateInteractor(TestUserInteraction testInteraction) {
+		return UserInteractionFactory.instance.createUserInteractor(new ResultProvider(testInteraction));
+	}
+}


### PR DESCRIPTION
This PR adds functionality for applying responses to user interactions in the `TestUserInteraction` repeatedly to define default behavior for specific kinds of interactions. To this end, the builders for reponses now provide an `always` operations, such that one can write commands like:

```onTextInput[title.equals("model name")].always.respondWith("mymodel")```

Validating the occurred interactions with `assertAllInteractionsOccurred` of the `TestUserInteractions` does only consider occurences for which the exact number was specified (i.e., for which no responses that `always` apply were defined).

Fixes #488.