### PR TITLE
Create .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto


### PR DESCRIPTION
Add `.gitattributes` files to the repo to enforce line ending normalization (see  #496).