### PR TITLE
Adding Tests for the Insertion of Multiple Elements into an EReference

### DIFF
--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -69,7 +69,7 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	}
 	
 	@Test
-	def void testMultipleAtOnceContainment() {		
+	def void testInsertMultipleAtOnceContainment() {		
 		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
 		val List<EChange> result = UPR.record [
 			multiValuedContainmentEReference.addAll(nonRootElements)
@@ -84,7 +84,7 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	}
 	
 	@Test
-	def void testMultipleAtOnceNonContainment() {
+	def void testInsertMultipleAtOnceNonContainment() {
 		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
 		nonContainmentHelperAddAllAsContainment(nonRootElements)
 		val List<EChange> result = UPR.record [
@@ -100,32 +100,32 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	}
 	
 	@Test
-	def void testInsertSingleEReferenceNonContainment() {
-		testInsertInNonContainmentEReference(0)
+	def void testInsertSingleNonContainment() {
+		insertAndAssertSingleNonContainment(0)
 	}
 
 	@Test
-	def void testInsertMultipleEReferenceNonContainment() {
-		testInsertInNonContainmentEReference(0)
-		testInsertInNonContainmentEReference(1)
-		testInsertInNonContainmentEReference(2)
-		testInsertInNonContainmentEReference(1)
+	def void testInsertMultipleIterativelyNonContainment() {
+		insertAndAssertSingleNonContainment(0)
+		insertAndAssertSingleNonContainment(1)
+		insertAndAssertSingleNonContainment(2)
+		insertAndAssertSingleNonContainment(1)
 	}
 
 	@Test
-	def void testInsertSingleEReferenceContainment() {
-		testInsertInContainmentEReference(0)
+	def void testInsertSingleContainment() {
+		insertAndAssertSingleContainment(0)
 	}
 
 	@Test
-	def void testInsertMultipleEReferenceContainment() {
-		testInsertInContainmentEReference(0)
-		testInsertInContainmentEReference(1)
-		testInsertInContainmentEReference(2)
-		testInsertInContainmentEReference(1)
+	def void testInsertMultipleIterativelyContainment() {
+		insertAndAssertSingleContainment(0)
+		insertAndAssertSingleContainment(1)
+		insertAndAssertSingleContainment(2)
+		insertAndAssertSingleContainment(1)
 	}
 
-	def private testInsertInContainmentEReference(int expectedIndex) {
+	def private insertAndAssertSingleContainment(int expectedIndex) {
 		// prepare
 		uniquePersistedRoot
 		
@@ -142,7 +142,7 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 			.assertEmpty
 	}
 
-	def private testInsertInNonContainmentEReference(int expectedIndex) {
+	def private insertAndAssertSingleNonContainment(int expectedIndex) {
 		// prepare
 		val nonRoot = aet.NonRoot
 		uniquePersistedRoot => [

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -18,7 +18,7 @@ import static extension tools.vitruv.framework.tests.change.util.CompoundEChange
 
 class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest { 
 
-	def private void assertCorrectInsertionNonContainment(List<EChange> actualChanges, Pair<NonRoot, Integer>... expectedInsertions) {
+	def private void assertCorrectInsertionNonContainment(List<EChange> actualChanges, List<Pair<NonRoot, Integer>> expectedInsertions) {
 		assertEquals(actualChanges.size, expectedInsertions.size)
 		var Iterable<? extends EChange> stepwiseConsumedResult = actualChanges
 		for (insertion : expectedInsertions) {
@@ -30,7 +30,7 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 		stepwiseConsumedResult.assertChangeCount(0)
 	}
 
-	def private void assertCorrectInsertionContainment(List<EChange> actualChanges, Pair<NonRoot, Integer>... expectedInsertions) {
+	def private void assertCorrectInsertionContainment(List<EChange> actualChanges, List<Pair<NonRoot, Integer>> expectedInsertions) {
 		assertEquals(actualChanges.size, expectedInsertions.size*3)
 		var Iterable<? extends EChange> stepwiseConsumedResult = actualChanges
 		for (insertion : expectedInsertions) {
@@ -53,12 +53,11 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	@ParameterizedTest
 	@ValueSource(ints = #[2,3,5,10])
 	def void testInsertMultipleAtOnceContainment(int count) {
-		val ArrayList<NonRoot> nonRootElements = new ArrayList<NonRoot>()
-		(0 ..< count).forEach[
-			val element = aet.NonRoot();
+		val Iterable<NonRoot> nonRootElements = (0 ..< count).map[
+			val element = aet.NonRoot()
 			element.id = it.toString()
-			nonRootElements.add(element)
-		]		
+			return element
+		]
 		val List<EChange> result = uniquePersistedRoot.record [
 			multiValuedContainmentEReference.addAll(nonRootElements)
 		]
@@ -69,9 +68,7 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	@ParameterizedTest
 	@ValueSource(ints = #[2,3,5,10])
 	def void testInsertMultipleAtOnceNonContainment(int count) {
-		val ArrayList<NonRoot> nonRootElements = new ArrayList<NonRoot>()
-		(0 ..< count).forEach[ nonRootElements.add(aet.NonRoot()) ]
-
+		val List<NonRoot> nonRootElements = (0 ..< count).map[ aet.NonRoot() ].toList()
 		nonContainmentHelperAddAllAsContainment(nonRootElements)
 		val List<EChange> result = uniquePersistedRoot.record [
 			multiValuedNonContainmentEReference.addAll(nonRootElements)

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -1,10 +1,11 @@
 package tools.vitruv.framework.tests.change.reference
 
 import allElementTypes.NonRoot
-import allElementTypes.Root
+import java.util.ArrayList
 import java.util.List
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import tools.vitruv.framework.change.echange.EChange
 import tools.vitruv.framework.tests.change.ChangeDescription2ChangeTransformationTest
 
@@ -14,20 +15,10 @@ import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
 
 import static extension tools.vitruv.framework.tests.change.util.AtomicEChangeAssertHelper.*
 import static extension tools.vitruv.framework.tests.change.util.CompoundEChangeAssertHelper.*
-import java.util.ArrayList
-import org.junit.jupiter.params.provider.ValueSource
-import org.junit.jupiter.params.ParameterizedTest
 
 class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest {
 
-	private static Root UPR;
-	
-	@BeforeEach
-	def void prepareComplexTest() {
-		UPR = getUniquePersistedRoot()
-	}
-	
-	private def Iterable<NonRoot> createNonRootElements(int count) {
+	def private ArrayList<NonRoot> createNonRootElements(int count) {
 		val ArrayList<NonRoot> nonRootElements = new ArrayList<NonRoot>()
 		(0 ..< count).forEach[
 			val element = aet.NonRoot();
@@ -37,71 +28,69 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 		return nonRootElements
 	} 
 
-	def void assertFiveNonRootsNonContainment(List<EChange> actualResult, Pair<NonRoot, Integer>... expectedInsertions) {
-		assertEquals(actualResult.size, expectedInsertions.size)
-		var Iterable<? extends EChange> stepwiseConsumedResult = actualResult
+	def private void assertCorrectInsertionNonContainment(List<EChange> actualChanges, Pair<NonRoot, Integer>... expectedInsertions) {
+		assertEquals(actualChanges.size, expectedInsertions.size)
+		var Iterable<? extends EChange> stepwiseConsumedResult = actualChanges
 		for (insertion : expectedInsertions) {
 			val nonRoot = insertion.key
 			val insertAtIndex = insertion.value
 			stepwiseConsumedResult = stepwiseConsumedResult
-				.assertInsertEReference(UPR, ROOT__MULTI_VALUED_NON_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false, false)
+				.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_NON_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false, false)
 		}
 		stepwiseConsumedResult.assertChangeCount(0)
 	}
 
-	def void assertFiveNonRootsContainment(List<EChange> actualResult, Pair<NonRoot, Integer>... expectedInsertions) {
-		assertEquals(actualResult.size, expectedInsertions.size*3)
-		var Iterable<? extends EChange> stepwiseConsumedResult = actualResult
+	def private void assertCorrectInsertionContainment(List<EChange> actualChanges, Pair<NonRoot, Integer>... expectedInsertions) {
+		assertEquals(actualChanges.size, expectedInsertions.size*3)
+		var Iterable<? extends EChange> stepwiseConsumedResult = actualChanges
 		for (insertion : expectedInsertions) {
 			val nonRoot = insertion.key
 			val insertAtIndex = insertion.value
 			stepwiseConsumedResult = stepwiseConsumedResult
-				.assertCreateAndInsertNonRoot(UPR, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false)
+				.assertCreateAndInsertNonRoot(uniquePersistedRoot, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false)
 				.assertReplaceSingleValuedEAttribute(nonRoot, IDENTIFIED__ID, null, nonRoot.id, false, false)
 		}
 		stepwiseConsumedResult.assertChangeCount(0)
 	}
-	
+
 	/** Elements which are to be inserted as NonContainment-EReferences have to be contained somewhere
 	 *  so they are containment-added to the unique persisted root to then be available for non containment insertion.
 	 */
-	def void nonContainmentHelperAddAllAsContainment(Iterable<NonRoot> nonRootElementsToBeContained) {
-		UPR.multiValuedContainmentEReference.addAll(nonRootElementsToBeContained)
+	def private void nonContainmentHelperAddAllAsContainment(Iterable<NonRoot> nonRootElementsToBeContained) {
+		uniquePersistedRoot.multiValuedContainmentEReference.addAll(nonRootElementsToBeContained)
 	}
-	
+
 	@ParameterizedTest
 	@ValueSource(ints = #[2,3,5,10])
-	def void testInsertMultipleAtOnceContainment(int count) {		
+	def void testInsertMultipleAtOnceContainment(int count) {
 		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
-		val List<EChange> result = UPR.record [
+		val List<EChange> result = uniquePersistedRoot.record [
 			multiValuedContainmentEReference.addAll(nonRootElements)
 		]
-		assertFiveNonRootsContainment(result, 
-			new Pair(nonRootElements.get(0), 0), 
-			new Pair(nonRootElements.get(1), 1), 
-			new Pair(nonRootElements.get(2), 2),
-			new Pair(nonRootElements.get(3), 3), 
-			new Pair(nonRootElements.get(4), 4)
-		)
+		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, #[0,1,2,3,4])
+		assertCorrectInsertionNonContainment(result, expectedInsertions)
 	}
-		
+
 	@ParameterizedTest
 	@ValueSource(ints = #[2,3,5,10])
-	def void testInsertMultipleAtOnceNonContainment(int count) {		
-		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)		
+	def void testInsertMultipleAtOnceNonContainment(int count) {
+		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
 		nonContainmentHelperAddAllAsContainment(nonRootElements)
-		val List<EChange> result = UPR.record [
+		val List<EChange> result = uniquePersistedRoot.record [
 			multiValuedNonContainmentEReference.addAll(nonRootElements)
 		]
-		assertFiveNonRootsNonContainment(result, 
-			new Pair(nonRootElements.get(0), 0), 
-			new Pair(nonRootElements.get(1), 1), 
-			new Pair(nonRootElements.get(2), 2),
-			new Pair(nonRootElements.get(3), 3), 
-			new Pair(nonRootElements.get(4), 4)
-		)
+		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, #[0,1,2,3,4])
+		assertCorrectInsertionNonContainment(result, expectedInsertions)
 	}
-	
+
+	def private ArrayList<Pair<NonRoot, Integer>> zipNonRootsWithExpectedInsertionIndeces(Iterable<NonRoot> nonRoots, List<Integer> integers) {
+		val ArrayList<Pair<NonRoot, Integer>> expectedInsertions = new ArrayList<Pair<NonRoot, Integer>>()
+		integers.forEach[ value, index |
+			expectedInsertions.add(new Pair(nonRoots.get(index), value))
+		]
+		return expectedInsertions
+	}
+
 	@Test
 	def void testInsertSingleNonContainment() {
 		insertAndAssertSingleNonContainment(0)
@@ -128,10 +117,10 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 		insertAndAssertSingleContainment(1)
 	}
 
-	def private insertAndAssertSingleContainment(int expectedIndex) {
+	def private void insertAndAssertSingleContainment(int expectedIndex) {
 		// prepare
 		uniquePersistedRoot
-		
+
 		// test
 		val nonRoot = aet.NonRoot
 		val result = uniquePersistedRoot.record [
@@ -145,16 +134,16 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 			.assertEmpty
 	}
 
-	def private insertAndAssertSingleNonContainment(int expectedIndex) {
+	def private void insertAndAssertSingleNonContainment(int expectedIndex) {
 		// prepare
 		val nonRoot = aet.NonRoot
 		uniquePersistedRoot => [
 			multiValuedContainmentEReference.add(expectedIndex, nonRoot)
 		]
 
-		// test			
+		// test
 		val result = uniquePersistedRoot.record [
-			multiValuedNonContainmentEReference.add(expectedIndex, nonRoot)			
+			multiValuedNonContainmentEReference.add(expectedIndex, nonRoot)
 		]
 
 		// assert

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -14,6 +14,7 @@ import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
 
 import static extension tools.vitruv.framework.tests.change.util.AtomicEChangeAssertHelper.*
 import static extension tools.vitruv.framework.tests.change.util.CompoundEChangeAssertHelper.*
+import java.util.ArrayList
 
 class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest {
 
@@ -25,11 +26,13 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	}
 	
 	private def Iterable<NonRoot> createNonRootElements(int count) {
-		return (0 ..< count).map [
+		val ArrayList<NonRoot> nonRootElements = new ArrayList<NonRoot>()
+		(0 ..< count).forEach[
 			val element = aet.NonRoot();
 			element.id = it.toString()
-			return element
+			nonRootElements.add(element)
 		]
+		return nonRootElements
 	} 
 
 	def void assertFiveNonRootsNonContainment(List<EChange> actualResult, Pair<NonRoot, Integer>... expectedInsertions) {
@@ -65,7 +68,7 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	 *  so they are containment-added to the unique persisted root to then be available for non containment insertion.
 	 */
 	def void nonContainmentHelperAddAllAsContainment(Iterable<NonRoot> nonRootElementsToBeContained) {
-		UPR => [ multiValuedContainmentEReference.addAll(nonRootElementsToBeContained) ]
+		UPR.multiValuedContainmentEReference.addAll(nonRootElementsToBeContained)
 	}
 	
 	@Test
@@ -82,10 +85,10 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 			new Pair(nonRootElements.get(4), 4)
 		)
 	}
-	
+		
 	@Test
-	def void testInsertMultipleAtOnceNonContainment() {
-		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
+	def void testInsertMultipleAtOnceNonContainment() {		
+		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)		
 		nonContainmentHelperAddAllAsContainment(nonRootElements)
 		val List<EChange> result = UPR.record [
 			multiValuedNonContainmentEReference.addAll(nonRootElements)

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -1,9 +1,7 @@
 package tools.vitruv.framework.tests.change.reference
 
-import allElementTypes.NonRoot
-import java.util.ArrayList
-import java.util.List
 import java.util.stream.Stream
+import java.util.stream.StreamSupport
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -15,9 +13,9 @@ import static allElementTypes.AllElementTypesPackage.Literals.*
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
 
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.mapFixed
 import static extension tools.vitruv.framework.tests.change.util.AtomicEChangeAssertHelper.*
 import static extension tools.vitruv.framework.tests.change.util.CompoundEChangeAssertHelper.*
-import java.util.stream.StreamSupport
 
 class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest { 
 
@@ -29,17 +27,17 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 		uniquePersistedRoot.record [ multiValuedContainmentEReference.addAll(preparationElements) ]
 
 	    //test
-	    val nonRootElements = (0 ..< count).map[
+	    val nonRootElements = (0 ..< count).mapFixed[
 			val element = aet.NonRoot()
 			element.id = it.toString()
 			return element
-		].toList
+		]
 		var Iterable<? extends EChange> actualChanges = uniquePersistedRoot.record [
 			multiValuedContainmentEReference.addAll(insertAt, nonRootElements)
 		]
 
 		//assert
-		val expectedInsertions = nonRootElements.indexed().map[new Pair(value, key + insertAt)]
+		val expectedInsertions = nonRootElements.indexed().mapFixed[new Pair(value, key + insertAt)]
 		assertEquals(actualChanges.size, expectedInsertions.size*3)		
 		for (insertion : expectedInsertions) {
 			val nonRoot = insertion.key
@@ -54,12 +52,12 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	@MethodSource("provideParametersInsertMultipleAtOnceAtIndex")
 	def void testInsertMultipleAtOnceNonContainment(int count, int insertAt) {
 		//prepare
-		val preparationElements = (0 ..< 10).map[ aet.NonRoot() ].toList
+		val preparationElements = (0 ..< 10).mapFixed[ aet.NonRoot() ]
 		uniquePersistedRoot.multiValuedContainmentEReference.addAll(preparationElements)
 		uniquePersistedRoot.record [ multiValuedNonContainmentEReference.addAll(preparationElements) ]
 
 		//test
-		val nonRootElements = (0 ..< count).map[ aet.NonRoot() ].toList
+		val nonRootElements = (0 ..< count).mapFixed[ aet.NonRoot() ]
 		uniquePersistedRoot.multiValuedContainmentEReference.addAll(nonRootElements)
 		var Iterable<? extends EChange> actualChanges = uniquePersistedRoot.record [
 			multiValuedNonContainmentEReference.addAll(insertAt, nonRootElements)

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -1,7 +1,7 @@
 package tools.vitruv.framework.tests.change.reference
 
 import java.util.stream.Stream
-import java.util.stream.StreamSupport
+import static java.util.stream.StreamSupport.stream
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -22,12 +22,12 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	@ParameterizedTest
 	@MethodSource("provideParametersInsertMultipleAtOnceAtIndex")
 	def void testInsertMultipleAtOnceContainment(int count, int insertAt) {
-		//prepare
-		val preparationElements = (0 ..< 10).map[ aet.NonRoot() ]
-		uniquePersistedRoot.record [ multiValuedContainmentEReference.addAll(preparationElements) ]
+		// prepare
+		val preparationElements = (0 ..< 10).map[aet.NonRoot()]
+		uniquePersistedRoot.record[multiValuedContainmentEReference.addAll(preparationElements)]
 
-	    //test
-	    val nonRootElements = (0 ..< count).mapFixed[
+		// test
+		val nonRootElements = (0 ..< count).mapFixed [
 			val element = aet.NonRoot()
 			element.id = it.toString()
 			return element
@@ -36,14 +36,14 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 			multiValuedContainmentEReference.addAll(insertAt, nonRootElements)
 		]
 
-		//assert
+		// assert
 		val expectedInsertions = nonRootElements.indexed().mapFixed[new Pair(value, key + insertAt)]
-		assertEquals(actualChanges.size, expectedInsertions.size*3)		
+		assertEquals(actualChanges.size, expectedInsertions.size * 3)
 		for (insertion : expectedInsertions) {
 			val nonRoot = insertion.key
 			val insertAtIndex = insertion.value
-			actualChanges = actualChanges
-				.assertCreateAndInsertNonRoot(uniquePersistedRoot, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false)
+			actualChanges = actualChanges //
+				.assertCreateAndInsertNonRoot(uniquePersistedRoot, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false) //
 				.assertReplaceSingleValuedEAttribute(nonRoot, IDENTIFIED__ID, null, nonRoot.id, false, false)
 		}
 	}
@@ -51,33 +51,33 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	@ParameterizedTest
 	@MethodSource("provideParametersInsertMultipleAtOnceAtIndex")
 	def void testInsertMultipleAtOnceNonContainment(int count, int insertAt) {
-		//prepare
-		val preparationElements = (0 ..< 10).mapFixed[ aet.NonRoot() ]
+		// prepare
+		val preparationElements = (0 ..< 10).mapFixed[aet.NonRoot()]
 		uniquePersistedRoot.multiValuedContainmentEReference.addAll(preparationElements)
-		uniquePersistedRoot.record [ multiValuedNonContainmentEReference.addAll(preparationElements) ]
+		uniquePersistedRoot.record[multiValuedNonContainmentEReference.addAll(preparationElements)]
 
-		//test
-		val nonRootElements = (0 ..< count).mapFixed[ aet.NonRoot() ]
+		// test
+		val nonRootElements = (0 ..< count).mapFixed[aet.NonRoot()]
 		uniquePersistedRoot.multiValuedContainmentEReference.addAll(nonRootElements)
 		var Iterable<? extends EChange> actualChanges = uniquePersistedRoot.record [
 			multiValuedNonContainmentEReference.addAll(insertAt, nonRootElements)
 		]
 
-		//assert
+		// assert
 		val expectedInsertions = nonRootElements.indexed().map[new Pair(value, key + insertAt)]
 		assertEquals(actualChanges.size, expectedInsertions.size)
 		for (insertion : expectedInsertions) {
 			val nonRoot = insertion.key
 			val insertAtIndex = insertion.value
-			actualChanges = actualChanges
+			actualChanges = actualChanges //
 				.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_NON_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false, false)
 		}
 	}
 
-	def private static Stream<Arguments> provideParametersInsertMultipleAtOnceAtIndex() {
-	    val counts = #[2,3,5,10]
-		val insertionIndexes = #[0, 5, 10]		
-		return StreamSupport.stream(insertionIndexes.map [ index | counts.map [ Arguments.of(it, index) ]].flatten.spliterator, false)		
+	def static Stream<Arguments> provideParametersInsertMultipleAtOnceAtIndex() {
+		val counts = #[2, 3, 5, 10]
+		val insertionIndexes = #[0, 5, 10]
+		return stream(insertionIndexes.map[index|counts.map[Arguments.of(it, index)]].flatten.spliterator, false)
 	}
 
 	@Test

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -16,17 +16,7 @@ import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
 import static extension tools.vitruv.framework.tests.change.util.AtomicEChangeAssertHelper.*
 import static extension tools.vitruv.framework.tests.change.util.CompoundEChangeAssertHelper.*
 
-class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest {
-
-	def private ArrayList<NonRoot> createNonRootElements(int count) {
-		val ArrayList<NonRoot> nonRootElements = new ArrayList<NonRoot>()
-		(0 ..< count).forEach[
-			val element = aet.NonRoot();
-			element.id = it.toString()
-			nonRootElements.add(element)
-		]
-		return nonRootElements
-	} 
+class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest { 
 
 	def private void assertCorrectInsertionNonContainment(List<EChange> actualChanges, Pair<NonRoot, Integer>... expectedInsertions) {
 		assertEquals(actualChanges.size, expectedInsertions.size)
@@ -63,23 +53,30 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	@ParameterizedTest
 	@ValueSource(ints = #[2,3,5,10])
 	def void testInsertMultipleAtOnceContainment(int count) {
-		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
+		val ArrayList<NonRoot> nonRootElements = new ArrayList<NonRoot>()
+		(0 ..< count).forEach[
+			val element = aet.NonRoot();
+			element.id = it.toString()
+			nonRootElements.add(element)
+		]		
 		val List<EChange> result = uniquePersistedRoot.record [
 			multiValuedContainmentEReference.addAll(nonRootElements)
 		]
-		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, #[0,1,2,3,4])
-		assertCorrectInsertionNonContainment(result, expectedInsertions)
+		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, (0 ..< count).toList)
+		assertCorrectInsertionContainment(result, expectedInsertions)
 	}
 
 	@ParameterizedTest
 	@ValueSource(ints = #[2,3,5,10])
 	def void testInsertMultipleAtOnceNonContainment(int count) {
-		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
+		val ArrayList<NonRoot> nonRootElements = new ArrayList<NonRoot>()
+		(0 ..< count).forEach[ nonRootElements.add(aet.NonRoot()) ]
+
 		nonContainmentHelperAddAllAsContainment(nonRootElements)
 		val List<EChange> result = uniquePersistedRoot.record [
 			multiValuedNonContainmentEReference.addAll(nonRootElements)
 		]
-		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, #[0,1,2,3,4])
+		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, (0 ..< count).toList)
 		assertCorrectInsertionNonContainment(result, expectedInsertions)
 	}
 

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -1,35 +1,122 @@
 package tools.vitruv.framework.tests.change.reference
 
+import allElementTypes.NonRoot
+import allElementTypes.Root
+import java.util.List
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import tools.vitruv.framework.change.echange.EChange
+import tools.vitruv.framework.tests.change.ChangeDescription2ChangeTransformationTest
+
 import static allElementTypes.AllElementTypesPackage.Literals.*
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
 
 import static extension tools.vitruv.framework.tests.change.util.AtomicEChangeAssertHelper.*
 import static extension tools.vitruv.framework.tests.change.util.CompoundEChangeAssertHelper.*
-import org.junit.jupiter.api.Test
-import static extension tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
-import tools.vitruv.framework.tests.change.ChangeDescription2ChangeTransformationTest
 
 class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest {
 
+	private static Root UPR;
+	private static final NonRoot NR1 = aet.NonRoot();
+	private static final NonRoot NR2 = aet.NonRoot();
+	private static final NonRoot NR3 = aet.NonRoot();
+	private static final NonRoot NR4 = aet.NonRoot();
+	private static final NonRoot NR5 = aet.NonRoot();
+	
+	@BeforeEach
+	def void prepareComplexTest() {
+		UPR = getUniquePersistedRoot()
+		NR1.id = 1.toString()
+		NR2.id = 2.toString()
+		NR3.id = 3.toString()
+		NR4.id = 4.toString()
+		NR5.id = 5.toString()
+	}
+
+	def void assertFiveNonRootsNonContainment(List<EChange> actualResult, Pair<NonRoot, Integer>... expectedInsertions) {
+		assertEquals(actualResult.size, expectedInsertions.size)
+		var Iterable<? extends EChange> stepwiseConsumedResult = actualResult
+		for (var int i = 0; i < expectedInsertions.size; i++) {
+			val Pair<NonRoot, Integer> insertion = expectedInsertions.get(i)
+			val nonRoot = insertion.key
+			val insertAtIndex = insertion.value
+			stepwiseConsumedResult = stepwiseConsumedResult
+				.assertChangeCount(expectedInsertions.size-i)
+				.assertInsertEReference(UPR, ROOT__MULTI_VALUED_NON_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false, false)
+		}
+		stepwiseConsumedResult.assertChangeCount(0)
+	}
+
+	def void assertFiveNonRootsContainment(List<EChange> actualResult, Pair<NonRoot, Integer>... expectedInsertions) {
+		assertEquals(actualResult.size, expectedInsertions.size*3)
+		var Iterable<? extends EChange> stepwiseConsumedResult = actualResult
+		for (var int i = 0; i < expectedInsertions.size; i++) {
+			val Pair<NonRoot, Integer> insertion = expectedInsertions.get(i)
+			val nonRoot = insertion.key
+			val insertAtIndex = insertion.value
+			stepwiseConsumedResult = stepwiseConsumedResult
+				.assertChangeCount((expectedInsertions.size-i)*3)
+				.assertCreateAndInsertNonRoot(UPR, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false)
+				.assertReplaceSingleValuedEAttribute(nonRoot, IDENTIFIED__ID, null, nonRoot.id, false, false)
+		}
+		stepwiseConsumedResult.assertChangeCount(0)
+	}
+	
+	/** Elements which are to be inserted as NonContainment-EReferences have to be contained somewhere
+	 *  so they are containment-added to the unique persisted root to then be available for non containment insertion.
+	 */
+	def void nonContainmentHelperAddAllAsContainment() {
+		UPR => [
+			multiValuedContainmentEReference.add(0, NR1)
+			multiValuedContainmentEReference.add(0, NR2)
+			multiValuedContainmentEReference.add(0, NR3)
+			multiValuedContainmentEReference.add(0, NR4)
+			multiValuedContainmentEReference.add(0, NR5)
+		]
+	}
+	
 	@Test
-	def void testInsertEReferenceNonContainment() {
-		testInsertInEReference(0)
+	def void testMultipleAtOnceContainment() {
+		val List<NonRoot> li = #[NR1, NR2, NR3, NR4, NR5]
+		val List<EChange> result = UPR.record [
+			multiValuedContainmentEReference.addAll(li)
+		]
+		assertFiveNonRootsContainment(result, new Pair(NR1, 0), new Pair(NR2, 1), new Pair(NR3, 2),
+			new Pair(NR4, 3), new Pair(NR5, 4))
+	}
+	
+	@Test
+	def void testMultipleAtOnceNonContainment() {
+		nonContainmentHelperAddAllAsContainment()
+		val List<NonRoot> li = #[NR1, NR2, NR3, NR4, NR5]
+		val List<EChange> result = UPR.record [
+			multiValuedNonContainmentEReference.addAll(li)
+		]
+		assertFiveNonRootsNonContainment(result, new Pair(NR1, 0), new Pair(NR2, 1), new Pair(NR3, 2),
+			new Pair(NR4, 3), new Pair(NR5, 4))
+	}
+	
+	@Test
+	def void testInsertSingleEReferenceNonContainment() {
+		testInsertInNonContainmentEReference(0)
 	}
 
 	@Test
-	def void testMultipleInsertEReferenceNonContainment() {
-		testInsertInEReference(0)
-		testInsertInEReference(1)
-		testInsertInEReference(2)
-		testInsertInEReference(1)
+	def void testInsertMultipleEReferenceNonContainment() {
+		testInsertInNonContainmentEReference(0)
+		testInsertInNonContainmentEReference(1)
+		testInsertInNonContainmentEReference(2)
+		testInsertInNonContainmentEReference(1)
 	}
 
 	@Test
-	def void testInsertEReferenceContainment() {
+	def void testInsertSingleEReferenceContainment() {
 		testInsertInContainmentEReference(0)
 	}
 
 	@Test
-	def void testMultipleInsertEReferenceContainment() {
+	def void testInsertMultipleEReferenceContainment() {
 		testInsertInContainmentEReference(0)
 		testInsertInContainmentEReference(1)
 		testInsertInContainmentEReference(2)
@@ -53,7 +140,7 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 			.assertEmpty
 	}
 
-	def private testInsertInEReference(int expectedIndex) {
+	def private testInsertInNonContainmentEReference(int expectedIndex) {
 		// prepare
 		val nonRoot = aet.NonRoot
 		uniquePersistedRoot => [

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -15,6 +15,8 @@ import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.*
 import static extension tools.vitruv.framework.tests.change.util.AtomicEChangeAssertHelper.*
 import static extension tools.vitruv.framework.tests.change.util.CompoundEChangeAssertHelper.*
 import java.util.ArrayList
+import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.params.ParameterizedTest
 
 class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest {
 
@@ -38,12 +40,10 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	def void assertFiveNonRootsNonContainment(List<EChange> actualResult, Pair<NonRoot, Integer>... expectedInsertions) {
 		assertEquals(actualResult.size, expectedInsertions.size)
 		var Iterable<? extends EChange> stepwiseConsumedResult = actualResult
-		for (var int i = 0; i < expectedInsertions.size; i++) {
-			val Pair<NonRoot, Integer> insertion = expectedInsertions.get(i)
+		for (insertion : expectedInsertions) {
 			val nonRoot = insertion.key
 			val insertAtIndex = insertion.value
 			stepwiseConsumedResult = stepwiseConsumedResult
-				.assertChangeCount(expectedInsertions.size-i)
 				.assertInsertEReference(UPR, ROOT__MULTI_VALUED_NON_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false, false)
 		}
 		stepwiseConsumedResult.assertChangeCount(0)
@@ -52,12 +52,10 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	def void assertFiveNonRootsContainment(List<EChange> actualResult, Pair<NonRoot, Integer>... expectedInsertions) {
 		assertEquals(actualResult.size, expectedInsertions.size*3)
 		var Iterable<? extends EChange> stepwiseConsumedResult = actualResult
-		for (var int i = 0; i < expectedInsertions.size; i++) {
-			val Pair<NonRoot, Integer> insertion = expectedInsertions.get(i)
+		for (insertion : expectedInsertions) {
 			val nonRoot = insertion.key
 			val insertAtIndex = insertion.value
 			stepwiseConsumedResult = stepwiseConsumedResult
-				.assertChangeCount((expectedInsertions.size-i)*3)
 				.assertCreateAndInsertNonRoot(UPR, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false)
 				.assertReplaceSingleValuedEAttribute(nonRoot, IDENTIFIED__ID, null, nonRoot.id, false, false)
 		}
@@ -71,8 +69,9 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 		UPR.multiValuedContainmentEReference.addAll(nonRootElementsToBeContained)
 	}
 	
-	@Test
-	def void testInsertMultipleAtOnceContainment() {		
+	@ParameterizedTest
+	@ValueSource(ints = #[2,3,5,10])
+	def void testInsertMultipleAtOnceContainment(int count) {		
 		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
 		val List<EChange> result = UPR.record [
 			multiValuedContainmentEReference.addAll(nonRootElements)
@@ -86,8 +85,9 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 		)
 	}
 		
-	@Test
-	def void testInsertMultipleAtOnceNonContainment() {		
+	@ParameterizedTest
+	@ValueSource(ints = #[2,3,5,10])
+	def void testInsertMultipleAtOnceNonContainment(int count) {		
 		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)		
 		nonContainmentHelperAddAllAsContainment(nonRootElements)
 		val List<EChange> result = UPR.record [

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -20,31 +20,6 @@ import static extension tools.vitruv.framework.tests.change.util.CompoundEChange
 
 class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest { 
 
-	def private void assertCorrectInsertionNonContainment(List<EChange> actualChanges, List<Pair<NonRoot, Integer>> expectedInsertions) {
-		assertEquals(actualChanges.size, expectedInsertions.size)
-		var Iterable<? extends EChange> stepwiseConsumedResult = actualChanges
-		for (insertion : expectedInsertions) {
-			val nonRoot = insertion.key
-			val insertAtIndex = insertion.value
-			stepwiseConsumedResult = stepwiseConsumedResult
-				.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_NON_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false, false)
-		}
-		stepwiseConsumedResult.assertChangeCount(0)
-	}
-
-	def private void assertCorrectInsertionContainment(List<EChange> actualChanges, List<Pair<NonRoot, Integer>> expectedInsertions) {
-		assertEquals(actualChanges.size, expectedInsertions.size*3)
-		var Iterable<? extends EChange> stepwiseConsumedResult = actualChanges
-		for (insertion : expectedInsertions) {
-			val nonRoot = insertion.key
-			val insertAtIndex = insertion.value
-			stepwiseConsumedResult = stepwiseConsumedResult
-				.assertCreateAndInsertNonRoot(uniquePersistedRoot, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false)
-				.assertReplaceSingleValuedEAttribute(nonRoot, IDENTIFIED__ID, null, nonRoot.id, false, false)
-		}
-		stepwiseConsumedResult.assertChangeCount(0)
-	}
-
 	@ParameterizedTest
 	@MethodSource("provideParametersInsertMultipleAtOnceAtIndex")
 	def void testInsertMultipleAtOnceContainment(int count, int insertAt) {
@@ -63,13 +38,22 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 			element.id = it.toString()
 			return element
 		].toList()
-		val List<EChange> result = uniquePersistedRoot.record [
+		val List<EChange> actualChanges = uniquePersistedRoot.record [
 			multiValuedContainmentEReference.addAll(insertAt, nonRootElements)
 		]
 
 		//assert
 		val expectedInsertions = nonRootElements.indexed().map[new Pair(value, key + insertAt)].toList
-		assertCorrectInsertionContainment(result, expectedInsertions)
+		assertEquals(actualChanges.size, expectedInsertions.size*3)
+		var Iterable<? extends EChange> stepwiseConsumedResult = actualChanges
+		for (insertion : expectedInsertions) {
+			val nonRoot = insertion.key
+			val insertAtIndex = insertion.value
+			stepwiseConsumedResult = stepwiseConsumedResult
+				.assertCreateAndInsertNonRoot(uniquePersistedRoot, ROOT__MULTI_VALUED_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false)
+				.assertReplaceSingleValuedEAttribute(nonRoot, IDENTIFIED__ID, null, nonRoot.id, false, false)
+		}
+		stepwiseConsumedResult.assertChangeCount(0)
 	}
 
 	@ParameterizedTest
@@ -83,13 +67,21 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 		//test
 		val List<NonRoot> nonRootElements = (0 ..< count).map[ aet.NonRoot() ].toList()
 		uniquePersistedRoot.multiValuedContainmentEReference.addAll(nonRootElements)
-		val List<EChange> result = uniquePersistedRoot.record [
+		val List<EChange> actualChanges = uniquePersistedRoot.record [
 			multiValuedNonContainmentEReference.addAll(insertAt, nonRootElements)
 		]
 
 		//assert
 		val expectedInsertions = nonRootElements.indexed().map[new Pair(value, key + insertAt)].toList
-		assertCorrectInsertionNonContainment(result, expectedInsertions)
+		assertEquals(actualChanges.size, expectedInsertions.size)
+		var Iterable<? extends EChange> stepwiseConsumedResult = actualChanges
+		for (insertion : expectedInsertions) {
+			val nonRoot = insertion.key
+			val insertAtIndex = insertion.value
+			stepwiseConsumedResult = stepwiseConsumedResult
+				.assertInsertEReference(uniquePersistedRoot, ROOT__MULTI_VALUED_NON_CONTAINMENT_EREFERENCE, nonRoot, insertAtIndex, false, false)
+		}
+		stepwiseConsumedResult.assertChangeCount(0)
 	}
 
 	def private static Stream<Arguments> provideParametersInsertMultipleAtOnceAtIndex() {

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -18,21 +18,19 @@ import static extension tools.vitruv.framework.tests.change.util.CompoundEChange
 class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTransformationTest {
 
 	private static Root UPR;
-	private static final NonRoot NR1 = aet.NonRoot();
-	private static final NonRoot NR2 = aet.NonRoot();
-	private static final NonRoot NR3 = aet.NonRoot();
-	private static final NonRoot NR4 = aet.NonRoot();
-	private static final NonRoot NR5 = aet.NonRoot();
 	
 	@BeforeEach
 	def void prepareComplexTest() {
 		UPR = getUniquePersistedRoot()
-		NR1.id = 1.toString()
-		NR2.id = 2.toString()
-		NR3.id = 3.toString()
-		NR4.id = 4.toString()
-		NR5.id = 5.toString()
 	}
+	
+	private def Iterable<NonRoot> createNonRootElements(int count) {
+		return (0 ..< count).map [
+			val element = aet.NonRoot();
+			element.id = it.toString()
+			return element
+		]
+	} 
 
 	def void assertFiveNonRootsNonContainment(List<EChange> actualResult, Pair<NonRoot, Integer>... expectedInsertions) {
 		assertEquals(actualResult.size, expectedInsertions.size)
@@ -66,35 +64,39 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	/** Elements which are to be inserted as NonContainment-EReferences have to be contained somewhere
 	 *  so they are containment-added to the unique persisted root to then be available for non containment insertion.
 	 */
-	def void nonContainmentHelperAddAllAsContainment() {
-		UPR => [
-			multiValuedContainmentEReference.add(0, NR1)
-			multiValuedContainmentEReference.add(0, NR2)
-			multiValuedContainmentEReference.add(0, NR3)
-			multiValuedContainmentEReference.add(0, NR4)
-			multiValuedContainmentEReference.add(0, NR5)
-		]
+	def void nonContainmentHelperAddAllAsContainment(Iterable<NonRoot> nonRootElementsToBeContained) {
+		UPR => [ multiValuedContainmentEReference.addAll(nonRootElementsToBeContained) ]
 	}
 	
 	@Test
-	def void testMultipleAtOnceContainment() {
-		val List<NonRoot> li = #[NR1, NR2, NR3, NR4, NR5]
+	def void testMultipleAtOnceContainment() {		
+		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
 		val List<EChange> result = UPR.record [
-			multiValuedContainmentEReference.addAll(li)
+			multiValuedContainmentEReference.addAll(nonRootElements)
 		]
-		assertFiveNonRootsContainment(result, new Pair(NR1, 0), new Pair(NR2, 1), new Pair(NR3, 2),
-			new Pair(NR4, 3), new Pair(NR5, 4))
+		assertFiveNonRootsContainment(result, 
+			new Pair(nonRootElements.get(0), 0), 
+			new Pair(nonRootElements.get(1), 1), 
+			new Pair(nonRootElements.get(2), 2),
+			new Pair(nonRootElements.get(3), 3), 
+			new Pair(nonRootElements.get(4), 4)
+		)
 	}
 	
 	@Test
 	def void testMultipleAtOnceNonContainment() {
-		nonContainmentHelperAddAllAsContainment()
-		val List<NonRoot> li = #[NR1, NR2, NR3, NR4, NR5]
+		val Iterable<NonRoot> nonRootElements = this.createNonRootElements(5)
+		nonContainmentHelperAddAllAsContainment(nonRootElements)
 		val List<EChange> result = UPR.record [
-			multiValuedNonContainmentEReference.addAll(li)
+			multiValuedNonContainmentEReference.addAll(nonRootElements)
 		]
-		assertFiveNonRootsNonContainment(result, new Pair(NR1, 0), new Pair(NR2, 1), new Pair(NR3, 2),
-			new Pair(NR4, 3), new Pair(NR5, 4))
+		assertFiveNonRootsNonContainment(result, 
+			new Pair(nonRootElements.get(0), 0), 
+			new Pair(nonRootElements.get(1), 1), 
+			new Pair(nonRootElements.get(2), 2),
+			new Pair(nonRootElements.get(3), 3), 
+			new Pair(nonRootElements.get(4), 4)
+		)
 	}
 	
 	@Test

--- a/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
+++ b/tests/framework/tools.vitruv.framework.change.tests/src/tools/vitruv/framework/tests/change/reference/ChangeDescription2InsertEReferenceTest.xtend
@@ -3,9 +3,11 @@ package tools.vitruv.framework.tests.change.reference
 import allElementTypes.NonRoot
 import java.util.ArrayList
 import java.util.List
+import java.util.stream.Stream
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import tools.vitruv.framework.change.echange.EChange
 import tools.vitruv.framework.tests.change.ChangeDescription2ChangeTransformationTest
 
@@ -48,35 +50,72 @@ class ChangeDescription2InsertEReferenceTest extends ChangeDescription2ChangeTra
 	 */
 	def private void nonContainmentHelperAddAllAsContainment(Iterable<NonRoot> nonRootElementsToBeContained) {
 		uniquePersistedRoot.multiValuedContainmentEReference.addAll(nonRootElementsToBeContained)
-	}
-
+	}	
+			
 	@ParameterizedTest
-	@ValueSource(ints = #[2,3,5,10])
-	def void testInsertMultipleAtOnceContainment(int count) {
-		val Iterable<NonRoot> nonRootElements = (0 ..< count).map[
+	@MethodSource("provideParametersInsertMultipleAtOnceAtIndex")
+	def void testInsertMultipleAtOnceAtIndexContainment(int count, int insertAt) {
+		//prepare
+		val ids = #['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+		val List<NonRoot> preparationElements = ids.map[ 
 			val element = aet.NonRoot()
 			element.id = it.toString()
 			return element
-		]
+		].toList()
+		uniquePersistedRoot.record [ multiValuedContainmentEReference.addAll(preparationElements) ]
+		
+	    //test
+	    val List<NonRoot> nonRootElements = (0 ..< count).map[
+			val element = aet.NonRoot()
+			element.id = it.toString()
+			return element
+		].toList()
 		val List<EChange> result = uniquePersistedRoot.record [
-			multiValuedContainmentEReference.addAll(nonRootElements)
+			multiValuedContainmentEReference.addAll(insertAt, nonRootElements)
 		]
-		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, (0 ..< count).toList)
+		
+		//assert
+		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, (insertAt ..< insertAt + count).toList())
 		assertCorrectInsertionContainment(result, expectedInsertions)
 	}
-
+	
 	@ParameterizedTest
-	@ValueSource(ints = #[2,3,5,10])
-	def void testInsertMultipleAtOnceNonContainment(int count) {
+	@MethodSource("provideParametersInsertMultipleAtOnceAtIndex")
+	def void testInsertMultipleAtOnceAtIndexNonContainment(int count, int insertAt) {
+		//prepare
+		val List<NonRoot> preparationElements = (0 ..< 10).map[ aet.NonRoot() ].toList()
+		nonContainmentHelperAddAllAsContainment(preparationElements)
+		uniquePersistedRoot.record [ multiValuedNonContainmentEReference.addAll(preparationElements) ]
+		
+		//test
 		val List<NonRoot> nonRootElements = (0 ..< count).map[ aet.NonRoot() ].toList()
 		nonContainmentHelperAddAllAsContainment(nonRootElements)
 		val List<EChange> result = uniquePersistedRoot.record [
-			multiValuedNonContainmentEReference.addAll(nonRootElements)
+			multiValuedNonContainmentEReference.addAll(insertAt, nonRootElements)
 		]
-		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, (0 ..< count).toList)
+		
+		//assert
+		val expectedInsertions = this.zipNonRootsWithExpectedInsertionIndeces(nonRootElements, (insertAt ..< insertAt + count).toList())
 		assertCorrectInsertionNonContainment(result, expectedInsertions)
+	}	
+	
+	def private static Stream<Arguments> provideParametersInsertMultipleAtOnceAtIndex() {
+	    return Stream.of(
+	            Arguments.of(2, 0),
+	            Arguments.of(3, 0),
+	            Arguments.of(5, 0),
+	            Arguments.of(10, 0),
+	            Arguments.of(2, 5),
+	            Arguments.of(3, 5),
+	            Arguments.of(5, 5),
+	            Arguments.of(10, 5),
+	            Arguments.of(2, 10),
+	            Arguments.of(3, 10),
+	            Arguments.of(5, 10),
+	            Arguments.of(10, 10)
+	    );
 	}
-
+	
 	def private ArrayList<Pair<NonRoot, Integer>> zipNonRootsWithExpectedInsertionIndeces(Iterable<NonRoot> nonRoots, List<Integer> integers) {
 		val ArrayList<Pair<NonRoot, Integer>> expectedInsertions = new ArrayList<Pair<NonRoot, Integer>>()
 		integers.forEach[ value, index |


### PR DESCRIPTION
Adds the missing tests mentioned in https://github.com/vitruv-tools/Vitruv/issues/507#