### PR TITLE
Improve default state-based change resolution strategy

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
@@ -40,6 +40,10 @@ import tools.vitruv.framework.change.echange.EChange
  * that all objects that have been removed from their containment reference without being added to a new containment
  * reference while changes were being recorded have been deleted, resulting in an appropriate delete change.
  * The recorder considers resources being loaded as existing and does thus not produce changes for it.
+ *
+ * Does not record changes of the <code>xmi:id</code> tag in an 
+ * {@link org.eclipse.emf.ecore.xmi.XMLResource XMLResource} if it is not stored in the element 
+ * but directly in the <code>Resource</code>.
  */
 class ChangeRecorder implements AutoCloseable {
 	// invariant: if the recording adapter is installed on a notifier, it is also installed on all children

--- a/bundles/framework/tools.vitruv.framework.views/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.views/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Require-Bundle: org.apache.log4j,
  tools.vitruv.framework.domains,
  tools.vitruv.framework.change,
  org.eclipse.emf.compare,
- org.eclipse.emf.compare.rcp,
  org.eclipse.emf.ecore.xmi,
  org.eclipse.xtend.lib,
  edu.kit.ipd.sdq.activextendannotations

--- a/bundles/framework/tools.vitruv.framework.views/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.views/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Require-Bundle: org.apache.log4j,
  tools.vitruv.framework.domains,
  tools.vitruv.framework.change,
  org.eclipse.emf.compare,
+ org.eclipse.emf.compare.rcp,
  org.eclipse.xtend.lib,
  edu.kit.ipd.sdq.activextendannotations
 Export-Package: tools.vitruv.framework.views,

--- a/bundles/framework/tools.vitruv.framework.views/META-INF/MANIFEST.MF
+++ b/bundles/framework/tools.vitruv.framework.views/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Require-Bundle: org.apache.log4j,
  tools.vitruv.framework.change,
  org.eclipse.emf.compare,
  org.eclipse.emf.compare.rcp,
+ org.eclipse.emf.ecore.xmi,
  org.eclipse.xtend.lib,
  edu.kit.ipd.sdq.activextendannotations
 Export-Package: tools.vitruv.framework.views,

--- a/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
+++ b/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
@@ -55,7 +55,7 @@ class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResol
         newState.checkNoProxies("new state")
         oldState.checkNoProxies("old state")
         val monitoredResourceSet = new ResourceSetImpl()
-        val currentStateCopy = ResourceCopier.copyResource(oldState, monitoredResourceSet, true)
+        val currentStateCopy = ResourceCopier.copyViewResource(oldState, monitoredResourceSet)
         return currentStateCopy.record [
             if (oldState.URI != newState.URI) {
                 currentStateCopy.URI = newState.URI
@@ -82,7 +82,7 @@ class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResol
         oldState.checkNoProxies("old state")
         // Setup resolver and copy state:
         val monitoredResourceSet = new ResourceSetImpl()
-        val currentStateCopy = ResourceCopier.copyResource(oldState, monitoredResourceSet, true)
+        val currentStateCopy = ResourceCopier.copyViewResource(oldState, monitoredResourceSet)
         return currentStateCopy.record [
             currentStateCopy.contents.clear()
         ]

--- a/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
+++ b/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
@@ -25,12 +25,21 @@ import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resou
  * @author Timur Saglam
  */
 class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResolutionStrategy {
-    val UseIdentifiers useIdentifiers
+    /** The identifier matching behavior used by this strategy */
+    public val UseIdentifiers useIdentifiers
 
+    /**
+     * Creates a new instance with the default identifier matching behavior 
+     * which is match by identifier when available.
+     */
     new() {
         this(UseIdentifiers.WHEN_AVAILABLE)
     }
 
+    /**
+     * Creates a new instance with the provided identifier matching behavior.
+     * @param useIdentifiers The identifier matching behavior to use.
+     */
     new(UseIdentifiers useIdentifiers) {
         this.useIdentifiers = useIdentifiers
     }

--- a/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
+++ b/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
@@ -10,10 +10,10 @@ import org.eclipse.emf.compare.rcp.EMFCompareRCPPlugin
 import org.eclipse.emf.compare.scope.DefaultComparisonScope
 import org.eclipse.emf.compare.utils.UseIdentifiers
 import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.util.EcoreUtil
 import tools.vitruv.framework.change.recording.ChangeRecorder
+import tools.vitruv.framework.views.util.ResourceCopier
 
 import static com.google.common.base.Preconditions.checkArgument
 
@@ -46,7 +46,7 @@ class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResol
         newState.checkNoProxies("new state")
         oldState.checkNoProxies("old state")
         val monitoredResourceSet = new ResourceSetImpl()
-        val currentStateCopy = oldState.copyInto(monitoredResourceSet)
+        val currentStateCopy = ResourceCopier.copyResource(oldState, monitoredResourceSet, true)
         return currentStateCopy.record [
             if (oldState.URI != newState.URI) {
                 currentStateCopy.URI = newState.URI
@@ -73,7 +73,7 @@ class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResol
         oldState.checkNoProxies("old state")
         // Setup resolver and copy state:
         val monitoredResourceSet = new ResourceSetImpl()
-        val currentStateCopy = oldState.copyInto(monitoredResourceSet)
+        val currentStateCopy = ResourceCopier.copyResource(oldState, monitoredResourceSet, true)
         return currentStateCopy.record [
             currentStateCopy.contents.clear()
         ]
@@ -104,18 +104,5 @@ class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResol
         val mergerRegistry = IMerger.RegistryImpl.createStandaloneInstance()
         val merger = new BatchMerger(mergerRegistry)
         merger.copyAllLeftToRight(changes, new BasicMonitor)
-    }
-
-    /**
-     * Creates a new resource set, creates a resource and copies the content of the orignal resource.
-     */
-    private def Resource copyInto(Resource resource, ResourceSet resourceSet) {
-        val uri = resource.URI
-        val copy = resourceSet.resourceFactoryRegistry.getFactory(uri).createResource(uri)
-        val elementsCopy = EcoreUtil.copyAll(resource.contents)
-        elementsCopy.forEach[eAdapters.clear]
-        copy.contents.addAll(elementsCopy)
-        resourceSet.resources += copy
-        return copy
     }
 }

--- a/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
+++ b/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
@@ -3,15 +3,20 @@ package tools.vitruv.framework.views.changederivation
 import org.eclipse.emf.common.notify.Notifier
 import org.eclipse.emf.common.util.BasicMonitor
 import org.eclipse.emf.compare.EMFCompare
+import org.eclipse.emf.compare.match.impl.MatchEngineFactoryImpl
 import org.eclipse.emf.compare.merge.BatchMerger
 import org.eclipse.emf.compare.merge.IMerger
+import org.eclipse.emf.compare.rcp.EMFCompareRCPPlugin
 import org.eclipse.emf.compare.scope.DefaultComparisonScope
+import org.eclipse.emf.compare.utils.UseIdentifiers
 import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.util.EcoreUtil
 import tools.vitruv.framework.change.recording.ChangeRecorder
-import org.eclipse.emf.ecore.resource.ResourceSet
+
 import static com.google.common.base.Preconditions.checkArgument
+
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceUtil.getReferencedProxies
 
 /**
@@ -20,82 +25,97 @@ import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resou
  * @author Timur Saglam
  */
 class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResolutionStrategy {
-	private def checkNoProxies(Resource resource, String stateNotice) {
-		val proxies = resource.referencedProxies
-		checkArgument(proxies.empty, "%s '%s' should not contain proxies, but contains the following: %s", stateNotice,
-			resource.URI, String.join(", ", proxies.map[toString]))
-	}
+    val UseIdentifiers useIdentifiers
 
-	override getChangeSequenceBetween(Resource newState, Resource oldState) {
-		checkArgument(oldState !== null && newState !== null, "old state or new state must not be null!")
-		newState.checkNoProxies("new state")
-		oldState.checkNoProxies("old state")
-		val monitoredResourceSet = new ResourceSetImpl()
-		val currentStateCopy = oldState.copyInto(monitoredResourceSet)
-		return currentStateCopy.record [
-			if (oldState.URI != newState.URI) {
-				currentStateCopy.URI = newState.URI
-			}
-			compareStatesAndReplayChanges(newState, currentStateCopy)
-		]
-	}
+    new() {
+        this(UseIdentifiers.WHEN_AVAILABLE)
+    }
 
-	override getChangeSequenceForCreated(Resource newState) {
-		checkArgument(newState !== null, "new state must not be null!")
-		newState.checkNoProxies("new state")
-		// It is possible that root elements are automatically generated during resource creation (e.g., Java packages).
-		// Thus, we create the resource and then monitor the re-insertion of the elements
-		val monitoredResourceSet = new ResourceSetImpl()
-		val newResource = monitoredResourceSet.createResource(newState.URI)
-		newResource.contents.clear()
-		return newResource.record [
-			newResource.contents += EcoreUtil.copyAll(newState.contents)
-		]
-	}
+    new(UseIdentifiers useIdentifiers) {
+        this.useIdentifiers = useIdentifiers
+    }
 
-	override getChangeSequenceForDeleted(Resource oldState) {
-		checkArgument(oldState !== null, "old state must not be null!")
-		oldState.checkNoProxies("old state")
-		// Setup resolver and copy state:
-		val monitoredResourceSet = new ResourceSetImpl()
-		val currentStateCopy = oldState.copyInto(monitoredResourceSet)
-		return currentStateCopy.record [
-			currentStateCopy.contents.clear()
-		]
-	}
+    private def checkNoProxies(Resource resource, String stateNotice) {
+        val proxies = resource.referencedProxies
+        checkArgument(proxies.empty, "%s '%s' should not contain proxies, but contains the following: %s", stateNotice,
+            resource.URI, String.join(", ", proxies.map[toString]))
+    }
 
-	private def <T extends Notifier> record(Resource resource, ()=>void function) {
-		try (val changeRecorder = new ChangeRecorder(resource.resourceSet)) {
-			changeRecorder.beginRecording
-			changeRecorder.addToRecording(resource)
-			function.apply()
-			return changeRecorder.endRecording
-		}
-	}
+    override getChangeSequenceBetween(Resource newState, Resource oldState) {
+        checkArgument(oldState !== null && newState !== null, "old state or new state must not be null!")
+        newState.checkNoProxies("new state")
+        oldState.checkNoProxies("old state")
+        val monitoredResourceSet = new ResourceSetImpl()
+        val currentStateCopy = oldState.copyInto(monitoredResourceSet)
+        return currentStateCopy.record [
+            if (oldState.URI != newState.URI) {
+                currentStateCopy.URI = newState.URI
+            }
+            compareStatesAndReplayChanges(newState, currentStateCopy)
+        ]
+    }
 
-	/**
-	 * Compares states using EMFCompare and replays the changes to the current state.
-	 */
-	private def compareStatesAndReplayChanges(Notifier newState, Notifier currentState) {
-		val scope = new DefaultComparisonScope(newState, currentState, null)
-		val comparison = EMFCompare.builder.build.compare(scope)
-		val changes = comparison.differences
-		// Replay the EMF compare differences
-		val mergerRegistry = IMerger.RegistryImpl.createStandaloneInstance()
-		val merger = new BatchMerger(mergerRegistry)
-		merger.copyAllLeftToRight(changes, new BasicMonitor)
-	}
+    override getChangeSequenceForCreated(Resource newState) {
+        checkArgument(newState !== null, "new state must not be null!")
+        newState.checkNoProxies("new state")
+        // It is possible that root elements are automatically generated during resource creation (e.g., Java packages).
+        // Thus, we create the resource and then monitor the re-insertion of the elements
+        val monitoredResourceSet = new ResourceSetImpl()
+        val newResource = monitoredResourceSet.createResource(newState.URI)
+        newResource.contents.clear()
+        return newResource.record [
+            newResource.contents += EcoreUtil.copyAll(newState.contents)
+        ]
+    }
 
-	/**
-	 * Creates a new resource set, creates a resource and copies the content of the orignal resource.
-	 */
-	private def Resource copyInto(Resource resource, ResourceSet resourceSet) {
-		val uri = resource.URI
-		val copy = resourceSet.resourceFactoryRegistry.getFactory(uri).createResource(uri)
-		val elementsCopy = EcoreUtil.copyAll(resource.contents)
-		elementsCopy.forEach[eAdapters.clear]
-		copy.contents.addAll(elementsCopy)
-		resourceSet.resources += copy
-		return copy
-	}
+    override getChangeSequenceForDeleted(Resource oldState) {
+        checkArgument(oldState !== null, "old state must not be null!")
+        oldState.checkNoProxies("old state")
+        // Setup resolver and copy state:
+        val monitoredResourceSet = new ResourceSetImpl()
+        val currentStateCopy = oldState.copyInto(monitoredResourceSet)
+        return currentStateCopy.record [
+            currentStateCopy.contents.clear()
+        ]
+    }
+
+    private def <T extends Notifier> record(Resource resource, ()=>void function) {
+        try (val changeRecorder = new ChangeRecorder(resource.resourceSet)) {
+            changeRecorder.beginRecording
+            changeRecorder.addToRecording(resource)
+            function.apply()
+            return changeRecorder.endRecording
+        }
+    }
+
+    /**
+     * Compares states using EMFCompare and replays the changes to the current state.
+     */
+    private def compareStatesAndReplayChanges(Notifier newState, Notifier currentState) {
+        val matchEngineRegistry = EMFCompareRCPPlugin.getDefault.getMatchEngineFactoryRegistry
+        val matchEngineFactory = new MatchEngineFactoryImpl(useIdentifiers)
+        matchEngineFactory.ranking = 20 // default engine ranking is 10, must be higher to override.
+        matchEngineRegistry.add(matchEngineFactory)
+
+        val scope = new DefaultComparisonScope(newState, currentState, null)
+        val comparison = EMFCompare.builder.setMatchEngineFactoryRegistry(matchEngineRegistry).build.compare(scope)
+        val changes = comparison.differences
+        // Replay the EMF compare differences
+        val mergerRegistry = IMerger.RegistryImpl.createStandaloneInstance()
+        val merger = new BatchMerger(mergerRegistry)
+        merger.copyAllLeftToRight(changes, new BasicMonitor)
+    }
+
+    /**
+     * Creates a new resource set, creates a resource and copies the content of the orignal resource.
+     */
+    private def Resource copyInto(Resource resource, ResourceSet resourceSet) {
+        val uri = resource.URI
+        val copy = resourceSet.resourceFactoryRegistry.getFactory(uri).createResource(uri)
+        val elementsCopy = EcoreUtil.copyAll(resource.contents)
+        elementsCopy.forEach[eAdapters.clear]
+        copy.contents.addAll(elementsCopy)
+        resourceSet.resources += copy
+        return copy
+    }
 }

--- a/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/ChangeDerivingView.xtend
+++ b/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/ChangeDerivingView.xtend
@@ -48,7 +48,7 @@ class ChangeDerivingView implements ModifiableView, CommittableView {
 
     private def setupReferenceState() {
         originalStateViewResourceSet = new ResourceSetImpl
-        ResourceCopier.copyResources(view.viewResourceSet.resources, originalStateViewResourceSet)
+        ResourceCopier.copyResources(view.viewResourceSet.resources, originalStateViewResourceSet, true)
         originalStateResourceMapping = new HashMap
         view.viewResourceSet.resources.forEach[resource | originalStateResourceMapping.put(resource, originalStateViewResourceSet.resources.findFirst[URI === resource.URI])]
     }
@@ -58,7 +58,7 @@ class ChangeDerivingView implements ModifiableView, CommittableView {
         val propagatedChanges = new ArrayList()
         val allResources = new HashSet(originalStateResourceMapping.keySet)
         allResources.addAll(view.viewResourceSet.resources) // consider newly added resources
-        for (changedResource: allResources.filter[!URI.isPathmap]) {
+        for (changedResource : allResources.filter[!URI.isPathmap]) {
             val change = generateChange(changedResource, originalStateResourceMapping.get(changedResource))
             if (change.containsConcreteChange) {
                 propagatedChanges += viewSource.propagateChange(change)
@@ -78,11 +78,9 @@ class ChangeDerivingView implements ModifiableView, CommittableView {
     private def VitruviusChange generateChange(Resource newState, Resource referenceState) {
         if (referenceState === null) {
             return changeResolutionStrategy.getChangeSequenceForCreated(newState)
-        }
-        else if (newState === null) {
+        } else if (newState === null) {
             return changeResolutionStrategy.getChangeSequenceForDeleted(referenceState)
-        }
-        else {
+        } else {
             return changeResolutionStrategy.getChangeSequenceBetween(newState, referenceState)
         }
     }

--- a/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/ChangeDerivingView.xtend
+++ b/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/ChangeDerivingView.xtend
@@ -48,7 +48,7 @@ class ChangeDerivingView implements ModifiableView, CommittableView {
 
     private def setupReferenceState() {
         originalStateViewResourceSet = new ResourceSetImpl
-        ResourceCopier.copyResources(view.viewResourceSet.resources, originalStateViewResourceSet, true)
+        ResourceCopier.copyViewResources(view.viewResourceSet.resources, originalStateViewResourceSet)
         originalStateResourceMapping = new HashMap
         view.viewResourceSet.resources.forEach[resource | originalStateResourceMapping.put(resource, originalStateViewResourceSet.resources.findFirst[URI === resource.URI])]
     }

--- a/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/IdentityMappingViewType.xtend
+++ b/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/IdentityMappingViewType.xtend
@@ -43,7 +43,7 @@ class IdentityMappingViewType extends AbstractViewType<DirectViewElementSelector
 			val viewSources = view.viewSource.viewSourceModels
 			val selection = view.selection
 			val resourcesWithSelectedElements = viewSources.filter[contents.exists[selection.isViewObjectSelected(it)]]
-			ResourceCopier.copyResources(resourcesWithSelectedElements, viewResourceSet, false) [selection.isViewObjectSelected(it)]
+			ResourceCopier.copyViewSourceResources(resourcesWithSelectedElements, viewResourceSet) [selection.isViewObjectSelected(it)]
 		]
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/IdentityMappingViewType.xtend
+++ b/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/IdentityMappingViewType.xtend
@@ -43,7 +43,7 @@ class IdentityMappingViewType extends AbstractViewType<DirectViewElementSelector
 			val viewSources = view.viewSource.viewSourceModels
 			val selection = view.selection
 			val resourcesWithSelectedElements = viewSources.filter[contents.exists[selection.isViewObjectSelected(it)]]
-			ResourceCopier.copyResources(resourcesWithSelectedElements, viewResourceSet) [selection.isViewObjectSelected(it)]
+			ResourceCopier.copyResources(resourcesWithSelectedElements, viewResourceSet, false) [selection.isViewObjectSelected(it)]
 		]
 	}
 }

--- a/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/util/ResourceCopier.xtend
+++ b/bundles/framework/tools.vitruv.framework.views/src/tools/vitruv/framework/views/util/ResourceCopier.xtend
@@ -146,14 +146,19 @@ class ResourceCopier {
                 checkNotNull(copier.get(it), "corresponding object for %s is null", it)
             ]
             copiedResource.contents.addAll(mappedRootElements)
-            if (copyXmlIds) {
-                if (originalResource instanceof XMLResource && copiedResource instanceof XMLResource) {
-                    copyIds(originalResource as XMLResource, copiedResource as XMLResource, selectedRootElements,
-                        copier)
-                }
-            }
             newResourceSet.resources += copiedResource
             resourceMapping.put(originalResource, copiedResource)
+        }
+
+        if (copyXmlIds) {
+            for (entry: copier.entrySet) {
+                val sourceElement = entry.key
+                val targetElement = entry.value
+                if (sourceElement.eResource instanceof XMLResource && targetElement.eResource instanceof XMLResource) {
+                    val id = (sourceElement.eResource as XMLResource).getID(sourceElement)
+                    (targetElement.eResource as XMLResource).setID(targetElement, id)
+                }
+            }
         }
         return resourceMapping
     }
@@ -183,15 +188,5 @@ class ResourceCopier {
         }
         checkState(!sourceIterator.hasNext, "source uml resource has too many elements")
         checkState(!targetIterator.hasNext, "target uml resource has too many elements")
-    }
-
-    private static def void copyIds(XMLResource source, XMLResource target, Iterable<EObject> sourceElements,
-        Copier copier) {
-        sourceElements.forEach [ sourceElement |
-            val targetElement = copier.get(sourceElement)
-            checkNotNull(targetElement, "corresponding object for %s is null", sourceElement)
-            target.setID(targetElement, source.getID(sourceElement))
-            copyIds(source, target, sourceElement.eContents, copier)
-        ]
     }
 }

--- a/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestViewFactory.xtend
+++ b/bundles/testutils/tools.vitruv.testutils/src/tools/vitruv/testutils/TestViewFactory.xtend
@@ -3,13 +3,14 @@ package tools.vitruv.testutils
 import java.util.Collection
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import tools.vitruv.framework.views.CommittableView
-import tools.vitruv.framework.views.ViewProvider
 import tools.vitruv.framework.views.View
+import tools.vitruv.framework.views.ViewProvider
 import tools.vitruv.framework.views.ViewTypeFactory
+import tools.vitruv.framework.views.changederivation.StateBasedChangeResolutionStrategy
 
-import static org.hamcrest.MatcherAssert.assertThat
-import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.CoreMatchers.not
+import static org.hamcrest.MatcherAssert.assertThat
 
 @FinalFieldsConstructor
 class TestViewFactory {
@@ -34,10 +35,30 @@ class TestViewFactory {
      * Records the performed changes, commits the recorded changes, and closes the view afterwards.
      */
     def void changeViewRecordingChanges(View view, (CommittableView)=>void modelModification) {
-        val committableView = view.withChangeRecordingTrait
-        modelModification.apply(committableView)
-        committableView.commitChanges()
-        committableView.close()
+        changeView(view.withChangeRecordingTrait, modelModification)
+    }
+
+    /**
+     * Changes the given view according to the given modification function. 
+     * Derives the performed changes using the default strategy, commits the derived changes, and closes the view afterwards.
+     */
+    def void changeViewDerivingChanges(View view, (CommittableView)=>void modelModification) {
+        changeView(view.withChangeDerivingTrait, modelModification)
+    }
+
+    /**
+     * Changes the given view according to the given modification function. 
+     * Derives the performed changes using the provided strategy, commits the derived changes, and closes the view afterwards.
+     */
+    def void changeViewDerivingChanges(View view, StateBasedChangeResolutionStrategy strategy,
+        (CommittableView)=>void modelModification) {
+        changeView(view.withChangeDerivingTrait(strategy), modelModification)
+    }
+
+    private def void changeView(CommittableView view, (CommittableView)=>void modelModification) {
+        modelModification.apply(view)
+        view.commitChanges()
+        view.close()
     }
 
     /**

--- a/tests/framework/tools.vitruv.framework.views.tests/META-INF/MANIFEST.MF
+++ b/tests/framework/tools.vitruv.framework.views.tests/META-INF/MANIFEST.MF
@@ -14,6 +14,7 @@ Require-Bundle: org.apache.log4j,
  org.eclipse.xtend.lib,
  org.eclipse.uml2.uml,
  org.junit.jupiter.api,
+ org.junit.jupiter.params,
  org.hamcrest.core
 Bundle-ClassPath: ., lib/byte-buddy-1.12.4.jar, lib/mockito-core-4.2.0.jar, lib/objenesis-3.2.jar
 Bundle-ActivationPolicy: lazy

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
@@ -27,10 +27,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		getModelURI("Test.allElementTypes")
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@DisplayName("create new resource and calculate state-based difference")
 	@MethodSource("strategiesToTest")
-	def void createNewResource(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void createNewResource(StateBasedChangeResolutionStrategy strategyToTest) {
 		val modelResource = new ResourceSetImpl().createResource(testUri) => [
 			contents += aet.Root => [
 				id = "Root"
@@ -52,10 +52,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.resources.get(0), containsModelOf(modelResource))
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@DisplayName("delete existing resource and calculate state-based difference")
 	@MethodSource("strategiesToTest")
-	def void deleteResource(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void deleteResource(StateBasedChangeResolutionStrategy strategyToTest) {
 		val modelResource = new Capture<Resource>
 		resourceSet.record [
 			createResource(testUri) => [
@@ -79,10 +79,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertTrue(validationResourceSet.resources.get(0).contents.empty)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@DisplayName("replace root element and calculate state-based difference")
 	@MethodSource("strategiesToTest")
-	def void replaceRootElement(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void replaceRootElement(StateBasedChangeResolutionStrategy strategyToTest) {
 		val modelResource = new Capture<Resource>
 		resourceSet.record [
 			createResource(testUri) => [
@@ -110,10 +110,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@DisplayName("change a root element property and calculate state-based difference")
 	@MethodSource("strategiesToTest")
-	def void changeRootElementFeature(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void changeRootElementFeature(StateBasedChangeResolutionStrategy strategyToTest) {
 		val modelResource = new Capture<Resource>
 		val root = aet.Root
 		resourceSet.record [
@@ -141,10 +141,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
 	}
 	
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
     @DisplayName("change a root element's id and calculate state-based difference")
     @MethodSource("strategiesToTest")
-    def void changeRootElementId(DefaultStateBasedChangeResolutionStrategy strategyToTest, String name) {
+    def void changeRootElementId(DefaultStateBasedChangeResolutionStrategy strategyToTest) {
         val modelResource = new Capture<Resource>
         val root = aet.Root
         resourceSet.record [
@@ -188,10 +188,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
     }
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@DisplayName("change a non-root element property and calculate state-based difference")
 	@MethodSource("strategiesToTest")
-	def void changeNonRootElementFeature(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void changeNonRootElementFeature(StateBasedChangeResolutionStrategy strategyToTest) {
 		val modelResource = new Capture<Resource>
 		val root = aet.Root
 		val containedRoot = aet.Root
@@ -224,10 +224,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
 	}
 	
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
     @DisplayName("change a non-root element's id and calculate state-based difference")
     @MethodSource("strategiesToTest")
-    def void changeNonRootElementId(DefaultStateBasedChangeResolutionStrategy strategyToTest, String name) {
+    def void changeNonRootElementId(DefaultStateBasedChangeResolutionStrategy strategyToTest) {
         val modelResource = new Capture<Resource>
         val root = aet.Root
         val containedRoot = aet.Root
@@ -276,10 +276,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
     }
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@DisplayName("move a resource to new location and calculate state-based difference")
 	@MethodSource("strategiesToTest")
-	def void moveResource(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void moveResource(StateBasedChangeResolutionStrategy strategyToTest) {
 		val modelResource = new Capture<Resource>
 		val root = aet.Root
 		resourceSet.record [
@@ -313,10 +313,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.getResource(movedResourceUri, false), containsModelOf(-modelResource))
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@DisplayName("move a resource to new location changing root feature and calculate state-based difference")
 	@MethodSource("strategiesToTest")
-	def void moveResourceAndChangeRootFeature(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void moveResourceAndChangeRootFeature(StateBasedChangeResolutionStrategy strategyToTest) {
 		val modelResource = new Capture<Resource>
 		val root = aet.Root
 		resourceSet.record [
@@ -352,5 +352,4 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertEquals(2, validationResourceSet.resources.size)
 		assertThat(validationResourceSet.getResource(movedResourceUri, false), containsModelOf(-modelResource))
 	}
-
 }

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
@@ -14,6 +14,7 @@ import tools.vitruv.framework.change.echange.root.RemoveRootEObject
 import tools.vitruv.framework.util.Capture
 
 import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.CoreMatchers.instanceOf
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static tools.vitruv.testutils.matchers.ModelMatchers.containsModelOf
@@ -168,12 +169,12 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
             case WHEN_AVAILABLE: {
                 val Iterable<DeleteEObject<?>> deleteChanges = newArrayList(changes.EChanges.filter(DeleteEObject))
                 assertEquals(1, deleteChanges.size)
-                assertTrue(deleteChanges.head.affectedEObject instanceof Root)
+                assertThat(deleteChanges.head.affectedEObject, instanceOf(Root))
                 assertEquals("Root", (deleteChanges.head.affectedEObject as Root).id)
 
                 val Iterable<CreateEObject<?>> createChanges = newArrayList(changes.EChanges.filter(CreateEObject))
                 assertEquals(1, createChanges.size)
-                assertTrue(createChanges.head.affectedEObject instanceof Root)
+                assertThat(createChanges.head.affectedEObject, instanceOf(Root))
                 assertEquals("Root2", (createChanges.head.affectedEObject as Root).id)
             }
             case NEVER: {
@@ -256,12 +257,12 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
             case WHEN_AVAILABLE: {
                 val Iterable<DeleteEObject<?>> deleteChanges = newArrayList(changes.EChanges.filter(DeleteEObject))
                 assertEquals(1, deleteChanges.size)
-                assertTrue(deleteChanges.head.affectedEObject instanceof Root)
+                assertThat(deleteChanges.head.affectedEObject, instanceOf(Root))
                 assertEquals("ContainedRoot", (deleteChanges.head.affectedEObject as Root).id)
 
                 val Iterable<CreateEObject<?>> createChanges = newArrayList(changes.EChanges.filter(CreateEObject))
                 assertEquals(1, createChanges.size)
-                assertTrue(createChanges.head.affectedEObject instanceof Root)
+                assertThat(createChanges.head.affectedEObject, instanceOf(Root))
                 assertEquals("ContainedRoot2", (createChanges.head.affectedEObject as Root).id)
             }
             case NEVER: {

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
@@ -3,7 +3,8 @@ package tools.vitruv.framework.views.changederivation
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import tools.vitruv.framework.change.echange.eobject.CreateEObject
 import tools.vitruv.framework.change.echange.eobject.DeleteEObject
 import tools.vitruv.framework.change.echange.feature.attribute.ReplaceSingleValuedEAttribute
@@ -25,9 +26,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		getModelURI("Test.allElementTypes")
 	}
 
-	@Test
+	@ParameterizedTest(name = "{1}")
 	@DisplayName("create new resource and calculate state-based difference")
-	def void createNewResource() {
+	@MethodSource("strategiesToTest")
+	def void createNewResource(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		val modelResource = new ResourceSetImpl().createResource(testUri) => [
 			contents += aet.Root => [
 				id = "Root"
@@ -49,9 +51,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.resources.get(0), containsModelOf(modelResource))
 	}
 
-	@Test
+	@ParameterizedTest(name = "{1}")
 	@DisplayName("delete existing resource and calculate state-based difference")
-	def void deleteResource() {
+	@MethodSource("strategiesToTest")
+	def void deleteResource(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		val modelResource = new Capture<Resource>
 		resourceSet.record [
 			createResource(testUri) => [
@@ -75,9 +78,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertTrue(validationResourceSet.resources.get(0).contents.empty)
 	}
 
-	@Test
+	@ParameterizedTest(name = "{1}")
 	@DisplayName("replace root element and calculate state-based difference")
-	def void replaceRootElement() {
+	@MethodSource("strategiesToTest")
+	def void replaceRootElement(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		val modelResource = new Capture<Resource>
 		resourceSet.record [
 			createResource(testUri) => [
@@ -105,9 +109,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
 	}
 
-	@Test
+	@ParameterizedTest(name = "{1}")
 	@DisplayName("change a root element property and calculate state-based difference")
-	def void changeRootElementFeature() {
+	@MethodSource("strategiesToTest")
+	def void changeRootElementFeature(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		val modelResource = new Capture<Resource>
 		val root = aet.Root
 		resourceSet.record [
@@ -135,9 +140,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
 	}
 
-	@Test
+	@ParameterizedTest(name = "{1}")
 	@DisplayName("change a non-root element property and calculate state-based difference")
-	def void changeNonRootElementFeature() {
+	@MethodSource("strategiesToTest")
+	def void changeNonRootElementFeature(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		val modelResource = new Capture<Resource>
 		val root = aet.Root
 		val containedRoot = aet.Root
@@ -168,9 +174,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
 	}
 
-	@Test
+	@ParameterizedTest(name = "{1}")
 	@DisplayName("move a resource to new location and calculate state-based difference")
-	def void moveResource() {
+	@MethodSource("strategiesToTest")
+	def void moveResource(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		val modelResource = new Capture<Resource>
 		val root = aet.Root
 		resourceSet.record [
@@ -204,9 +211,10 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 		assertThat(validationResourceSet.getResource(movedResourceUri, false), containsModelOf(-modelResource))
 	}
 
-	@Test
+	@ParameterizedTest(name = "{1}")
 	@DisplayName("move a resource to new location changing root feature and calculate state-based difference")
-	def void moveResourceAndChangeRootFeature() {
+	@MethodSource("strategiesToTest")
+	def void moveResourceAndChangeRootFeature(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		val modelResource = new Capture<Resource>
 		val root = aet.Root
 		resourceSet.record [

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
@@ -166,12 +166,15 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         switch (strategyToTest.useIdentifiers) {
             case ONLY,
             case WHEN_AVAILABLE: {
-                assertEquals(1, changes.EChanges.filter(CreateEObject).map[affectedEObject].filter(Root).filter [
-                    id == "Root2"
-                ].size)
-                assertEquals(1, changes.EChanges.filter(DeleteEObject).map[affectedEObject].filter(Root).filter [
-                    id == "Root"
-                ].size)
+                val Iterable<DeleteEObject<?>> deleteChanges = newArrayList(changes.EChanges.filter(DeleteEObject))
+                assertEquals(1, deleteChanges.size)
+                assertTrue(deleteChanges.head.affectedEObject instanceof Root)
+                assertEquals("Root", (deleteChanges.head.affectedEObject as Root).id)
+
+                val Iterable<CreateEObject<?>> createChanges = newArrayList(changes.EChanges.filter(CreateEObject))
+                assertEquals(1, createChanges.size)
+                assertTrue(createChanges.head.affectedEObject instanceof Root)
+                assertEquals("Root2", (createChanges.head.affectedEObject as Root).id)
             }
             case NEVER: {
                 assertEquals(1, changes.EChanges.size)
@@ -251,12 +254,15 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         switch (strategyToTest.useIdentifiers) {
             case ONLY,
             case WHEN_AVAILABLE: {
-                assertEquals(1, changes.EChanges.filter(CreateEObject).map[affectedEObject].filter(Root).filter [
-                    id == "ContainedRoot2"
-                ].size)
-                assertEquals(1, changes.EChanges.filter(DeleteEObject).map[affectedEObject].filter(Root).filter [
-                    id == "ContainedRoot"
-                ].size)
+                val Iterable<DeleteEObject<?>> deleteChanges = newArrayList(changes.EChanges.filter(DeleteEObject))
+                assertEquals(1, deleteChanges.size)
+                assertTrue(deleteChanges.head.affectedEObject instanceof Root)
+                assertEquals("ContainedRoot", (deleteChanges.head.affectedEObject as Root).id)
+
+                val Iterable<CreateEObject<?>> createChanges = newArrayList(changes.EChanges.filter(CreateEObject))
+                assertEquals(1, createChanges.size)
+                assertTrue(createChanges.head.affectedEObject instanceof Root)
+                assertEquals("ContainedRoot2", (createChanges.head.affectedEObject as Root).id)
             }
             case NEVER: {
                 assertEquals(1, changes.EChanges.size)

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/EdgeCaseStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/EdgeCaseStateChangeTest.xtend
@@ -11,27 +11,27 @@ class EdgeCaseStateChangeTest extends StateChangePropagationTest {
 	/**
 	 * Tests the comparison of two states with no changes for the uml mockup model.
 	 */
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testNoUmlChange(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void testNoUmlChange(StateBasedChangeResolutionStrategy strategyToTest) {
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
 	/**
 	 * Tests the comparison of two states with no changes for the pcm mockup model.
 	 */
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testNoPcmChange(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void testNoPcmChange(StateBasedChangeResolutionStrategy strategyToTest) {
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
 	/**
 	 * Tests invalid input: null instead of state resources.
 	 */
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testNullResources(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void testNullResources(StateBasedChangeResolutionStrategy strategyToTest) {
 		val Resource nullResource = null
 		assertThrows(IllegalArgumentException)[strategyToTest.getChangeSequenceBetween(nullResource, nullResource)]
 	}

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/EdgeCaseStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/EdgeCaseStateChangeTest.xtend
@@ -1,7 +1,8 @@
 package tools.vitruv.framework.views.changederivation
 
 import org.eclipse.emf.ecore.resource.Resource
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 import static org.junit.jupiter.api.Assertions.assertThrows
 
@@ -10,24 +11,27 @@ class EdgeCaseStateChangeTest extends StateChangePropagationTest {
 	/**
 	 * Tests the comparison of two states with no changes for the uml mockup model.
 	 */
-	@Test
-	def void testNoUmlChange() {
-		compareChanges(umlModel, umlCheckpoint)
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testNoUmlChange(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
 	/**
 	 * Tests the comparison of two states with no changes for the pcm mockup model.
 	 */
-	@Test
-	def void testNoPcmChange() {
-		compareChanges(umlModel, umlCheckpoint)
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testNoPcmChange(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
 	/**
 	 * Tests invalid input: null instead of state resources.
 	 */
-	@Test
-	def void testNullResources() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testNullResources(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		val Resource nullResource = null
 		assertThrows(IllegalArgumentException)[strategyToTest.getChangeSequenceBetween(nullResource, nullResource)]
 	}

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/PcmStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/PcmStateChangeTest.xtend
@@ -6,30 +6,30 @@ import org.junit.jupiter.params.provider.MethodSource
 import static tools.vitruv.testutils.metamodels.PcmMockupCreators.pcm
 
 class PcmStateChangeTest extends StateChangePropagationTest {
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testAddComponent(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	def void testAddComponent(StateBasedChangeResolutionStrategy strategyToTest) {
 		pcmRoot.components += pcm.Component => [name = "NewlyAddedComponent"]
 		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testRenameComponent(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void testRenameComponent(StateBasedChangeResolutionStrategy strategyToTest) {
 		pcmRoot.components.get(0).name = "RenamedComponent"
 		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testDeleteComponent(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void testDeleteComponent(StateBasedChangeResolutionStrategy strategyToTest) {
 		pcmRoot.components.remove(0)
 		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testAddProvidedInterface(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	def void testAddProvidedInterface(StateBasedChangeResolutionStrategy strategyToTest) {
 		val newInterface = pcm.Interface => [name = "NewlyAddedInterface"]
 		pcmRoot.interfaces += pcm.Interface
 		newInterface.methods += pcm.Method => [name = "newMethod"]
@@ -37,9 +37,9 @@ class PcmStateChangeTest extends StateChangePropagationTest {
 		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testInterfaceWithMultipleMethods(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	def void testInterfaceWithMultipleMethods(StateBasedChangeResolutionStrategy strategyToTest) {
 		val newInterface = pcm.Interface => [
 			name = "NewlyAddedInterface"
 		]
@@ -51,9 +51,9 @@ class PcmStateChangeTest extends StateChangePropagationTest {
 		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testAddDifferentProvidedInterface(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	def void testAddDifferentProvidedInterface(StateBasedChangeResolutionStrategy strategyToTest) {
 		val firstInterface = pcm.Interface => [name = "NewlyAddedInterface"]
 		val secondInterface = pcm.Interface => [name = "NewlyAddedInterface2"]
 		pcmRoot.interfaces += #[firstInterface, secondInterface]
@@ -62,9 +62,9 @@ class PcmStateChangeTest extends StateChangePropagationTest {
 		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testAddMultipleInterfaces(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	def void testAddMultipleInterfaces(StateBasedChangeResolutionStrategy strategyToTest) {
 		pcmRoot.interfaces += (1 .. 3).map [ index |
 			pcm.Interface => [name = '''NewlyAddedInterface«index»''']
 		]

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/PcmStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/PcmStateChangeTest.xtend
@@ -1,39 +1,45 @@
 package tools.vitruv.framework.views.changederivation
 
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
 import static tools.vitruv.testutils.metamodels.PcmMockupCreators.pcm
 
 class PcmStateChangeTest extends StateChangePropagationTest {
-	@Test
-	def void testAddComponent() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testAddComponent(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		pcmRoot.components += pcm.Component => [name = "NewlyAddedComponent"]
-		compareChanges(pcmModel, pcmCheckpoint)
+		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testRenameComponent() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testRenameComponent(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		pcmRoot.components.get(0).name = "RenamedComponent"
-		compareChanges(pcmModel, pcmCheckpoint)
+		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testDeleteComponent() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testDeleteComponent(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		pcmRoot.components.remove(0)
-		compareChanges(pcmModel, pcmCheckpoint)
+		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testAddProvidedInterface() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testAddProvidedInterface(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		val newInterface = pcm.Interface => [name = "NewlyAddedInterface"]
 		pcmRoot.interfaces += pcm.Interface
 		newInterface.methods += pcm.Method => [name = "newMethod"]
 		pcmRoot.components.get(0).providedInterface = newInterface
-		compareChanges(pcmModel, pcmCheckpoint)
+		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testInterfaceWithMultipleMethods() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testInterfaceWithMultipleMethods(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		val newInterface = pcm.Interface => [
 			name = "NewlyAddedInterface"
 		]
@@ -42,26 +48,27 @@ class PcmStateChangeTest extends StateChangePropagationTest {
 			pcm.Method => [name = '''newMethod«index»''']
 		]
 		pcmRoot.components.get(0).providedInterface = newInterface
-		compareChanges(pcmModel, pcmCheckpoint)
+		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@Disabled("Example for a test case that will NOT pass since the state-based diff looses some information")
-	@Test
-	def void testAddDifferentProvidedInterface() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testAddDifferentProvidedInterface(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		val firstInterface = pcm.Interface => [name = "NewlyAddedInterface"]
 		val secondInterface = pcm.Interface => [name = "NewlyAddedInterface2"]
 		pcmRoot.interfaces += #[firstInterface, secondInterface]
 		pcmRoot.components.get(0).providedInterface = firstInterface
 		pcmRoot.components.get(0).providedInterface = secondInterface
-		compareChanges(pcmModel, pcmCheckpoint)
+		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testAddMultipleInterfaces() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testAddMultipleInterfaces(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		pcmRoot.interfaces += (1 .. 3).map [ index |
 			pcm.Interface => [name = '''NewlyAddedInterface«index»''']
 		]
 		pcmRoot.interfaces.forEach[methods += pcm.Method => [name = "newMethod"]]
-		compareChanges(pcmModel, pcmCheckpoint)
+		compareChanges(pcmModel, pcmCheckpoint, strategyToTest)
 	}
 }

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/StateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/StateChangePropagationTest.xtend
@@ -12,8 +12,8 @@ import org.eclipse.emf.ecore.util.EcoreUtil
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Named
 import org.junit.jupiter.api.^extension.ExtendWith
-import org.junit.jupiter.params.provider.Arguments
 import pcm_mockup.Repository
 import tools.vitruv.framework.change.description.VitruviusChange
 import tools.vitruv.framework.change.recording.ChangeRecorder
@@ -76,9 +76,9 @@ abstract class StateChangePropagationTest {
 	
 	static def strategiesToTest() {
 	    Stream.of(
-	        Arguments.of(new DefaultStateBasedChangeResolutionStrategy(UseIdentifiers.WHEN_AVAILABLE), "identifiers when available"),
-	        Arguments.of(new DefaultStateBasedChangeResolutionStrategy(UseIdentifiers.ONLY), "only identifiers"),
-	        Arguments.of(new DefaultStateBasedChangeResolutionStrategy(UseIdentifiers.NEVER), "never identifiers")
+	        Named.of("identifiers when available", new DefaultStateBasedChangeResolutionStrategy(UseIdentifiers.WHEN_AVAILABLE)),
+	        Named.of("only identifiers", new DefaultStateBasedChangeResolutionStrategy(UseIdentifiers.ONLY)),
+	        Named.of("never identifiers", new DefaultStateBasedChangeResolutionStrategy(UseIdentifiers.NEVER))
 	    )
 	}
 	

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/StateChangePropagationTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/StateChangePropagationTest.xtend
@@ -1,40 +1,40 @@
 package tools.vitruv.framework.views.changederivation
 
+import java.nio.file.Path
+import java.util.stream.Stream
 import org.eclipse.emf.common.notify.Notifier
 import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.compare.utils.UseIdentifiers
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
+import org.eclipse.emf.ecore.util.EcoreUtil
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.^extension.ExtendWith
+import org.junit.jupiter.params.provider.Arguments
 import pcm_mockup.Repository
 import tools.vitruv.framework.change.description.VitruviusChange
-import uml_mockup.UPackage
-import tools.vitruv.framework.views.changederivation.StateBasedChangeResolutionStrategy
-import tools.vitruv.framework.views.changederivation.DefaultStateBasedChangeResolutionStrategy
-import org.junit.jupiter.api.^extension.ExtendWith
+import tools.vitruv.framework.change.recording.ChangeRecorder
+import tools.vitruv.testutils.RegisterMetamodelsInStandalone
 import tools.vitruv.testutils.TestLogging
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.AfterEach
 import tools.vitruv.testutils.TestProject
-import java.nio.file.Path
+import tools.vitruv.testutils.TestProjectManager
+import uml_mockup.UPackage
 
 import static org.junit.jupiter.api.Assertions.*
 import static tools.vitruv.testutils.metamodels.PcmMockupCreators.pcm
 import static tools.vitruv.testutils.metamodels.UmlMockupCreators.uml
-import tools.vitruv.testutils.TestProjectManager
-import tools.vitruv.testutils.RegisterMetamodelsInStandalone
-import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories
-import tools.vitruv.framework.change.recording.ChangeRecorder
-import org.eclipse.emf.ecore.util.EcoreUtil
-import org.eclipse.xtend.lib.annotations.Accessors
+
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil.createFileURI
+import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories
 
 @ExtendWith(TestProjectManager, TestLogging, RegisterMetamodelsInStandalone)
 abstract class StateChangePropagationTest {
 	protected static final String PCM_FILE_EXT = "pcm_mockup"
 	protected static final String UML_FILE_EXT = "uml_mockup"
 	var Path testProjectFolder
-	@Accessors(PROTECTED_GETTER)
-	var StateBasedChangeResolutionStrategy strategyToTest
 	@Accessors(PROTECTED_GETTER)
 	var Resource umlCheckpoint
 	@Accessors(PROTECTED_GETTER)
@@ -59,7 +59,6 @@ abstract class StateChangePropagationTest {
 	def void setup(@TestProject Path testProjectFolder) {
 		this.testProjectFolder = testProjectFolder
 		// Setup:
-		strategyToTest = new DefaultStateBasedChangeResolutionStrategy()
 		resourceSet = new ResourceSetImpl().withGlobalFactories()
 		checkpointResourceSet = new ResourceSetImpl().withGlobalFactories()
 		changeRecorder = new ChangeRecorder(resourceSet)
@@ -75,6 +74,14 @@ abstract class StateChangePropagationTest {
 		pcmModel.startRecording
 	}
 	
+	static def strategiesToTest() {
+	    Stream.of(
+	        Arguments.of(new DefaultStateBasedChangeResolutionStrategy(UseIdentifiers.WHEN_AVAILABLE), "identifiers when available"),
+	        Arguments.of(new DefaultStateBasedChangeResolutionStrategy(UseIdentifiers.ONLY), "only identifiers"),
+	        Arguments.of(new DefaultStateBasedChangeResolutionStrategy(UseIdentifiers.NEVER), "never identifiers")
+	    )
+	}
+	
 	/**
 	 * Stops recording in case the test does not call getRecordedChanges() or getChangeFromComparisonWithCheckpoint().
 	 */
@@ -87,7 +94,7 @@ abstract class StateChangePropagationTest {
 	 * USE THIS METHOD TO COMPARE RESULTS!
 	 * Compares two changes: The recorded change sequence and the resolved changes by the state delta based strategy.
 	 */
-	protected def compareChanges(Resource model, Resource checkpoint) {
+	protected def compareChanges(Resource model, Resource checkpoint, StateBasedChangeResolutionStrategy strategyToTest) {
 		model.save(null)
 		val deltaBasedChange = resourceSet.endRecording
 		val stateBasedChange = strategyToTest.getChangeSequenceBetween(model, checkpoint)

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/UmlStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/UmlStateChangeTest.xtend
@@ -8,15 +8,15 @@ import org.junit.jupiter.params.provider.MethodSource
 import static tools.vitruv.testutils.metamodels.UmlMockupCreators.uml
 
 class UmlStateChangeTest extends StateChangePropagationTest {
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testRenameTypes(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	def void testRenameTypes(StateBasedChangeResolutionStrategy strategyToTest) {
 		umlRoot.classes.get(0) => [name = "RenamedClass"]
 		umlRoot.interfaces.get(0) => [name = "RenamedInterface"]
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{0}")
+	@ParameterizedTest()
 	@EnumSource(
 	    value = UseIdentifiers,
 	    //TODO: should be re-enabled when state comparison is used instead of change comparison
@@ -31,23 +31,23 @@ class UmlStateChangeTest extends StateChangePropagationTest {
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testNewMethod(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	def void testNewMethod(StateBasedChangeResolutionStrategy strategyToTest) {
 		umlRoot.interfaces.get(0) => [
 			methods += uml.Method => [name = "NewlyAddedMethod"]
 		]
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testNewClass(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	def void testNewClass(StateBasedChangeResolutionStrategy strategyToTest) {
 		umlRoot.classes += uml.Class => [name = "NewlyAddedClass"]
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{0}")
+	@ParameterizedTest()
     @EnumSource(
         value = UseIdentifiers,
         //TODO: should be re-enabled when state comparison is used instead of change comparison
@@ -61,16 +61,16 @@ class UmlStateChangeTest extends StateChangePropagationTest {
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testDeleteClass(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	def void testDeleteClass(StateBasedChangeResolutionStrategy strategyToTest) {
 		umlRoot.classes.remove(0)
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
+	@ParameterizedTest()
 	@MethodSource("strategiesToTest")
-	def void testNewInterface(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	def void testNewInterface(StateBasedChangeResolutionStrategy strategyToTest) {
 		umlRoot.interfaces += uml.Interface => [name = "NewlyAddedInterface"]
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/UmlStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/UmlStateChangeTest.xtend
@@ -1,6 +1,8 @@
 package tools.vitruv.framework.views.changederivation
 
+import org.eclipse.emf.compare.utils.UseIdentifiers
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.MethodSource
 
 import static tools.vitruv.testutils.metamodels.UmlMockupCreators.uml
@@ -14,9 +16,15 @@ class UmlStateChangeTest extends StateChangePropagationTest {
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
-	@MethodSource("strategiesToTest")
-	def void testNewAttributes(StateBasedChangeResolutionStrategy strategyToTest, String name) {
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(
+	    value = UseIdentifiers,
+	    //TODO: should be re-enabled when state comparison is used instead of change comparison
+	    names = #["ONLY"],
+	    mode = EnumSource.Mode.EXCLUDE
+	)
+	def void testNewAttributes(UseIdentifiers useIdentifiers) {
+	    val strategyToTest = new DefaultStateBasedChangeResolutionStrategy(useIdentifiers)
 		umlRoot.classes.get(0) => [
 			attributes += uml.Attribute => [attributeName = "NewlyAddedAttribute"]
 		]
@@ -39,9 +47,15 @@ class UmlStateChangeTest extends StateChangePropagationTest {
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@ParameterizedTest(name = "{1}")
-	@MethodSource("strategiesToTest")
-	def void testReplaceClass(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
+	@ParameterizedTest(name = "{0}")
+    @EnumSource(
+        value = UseIdentifiers,
+        //TODO: should be re-enabled when state comparison is used instead of change comparison
+        names = #["NEVER"],
+        mode = EnumSource.Mode.EXCLUDE
+    )
+	def void testReplaceClass(UseIdentifiers useIdentifiers) {
+	    val strategyToTest = new DefaultStateBasedChangeResolutionStrategy(useIdentifiers)
 		umlRoot.classes.remove(0)
 		umlRoot.classes += uml.Class => [name = "NewlyAddedClass"]
 		compareChanges(umlModel, umlCheckpoint, strategyToTest)

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/UmlStateChangeTest.xtend
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/changederivation/UmlStateChangeTest.xtend
@@ -1,54 +1,63 @@
 package tools.vitruv.framework.views.changederivation
 
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
 import static tools.vitruv.testutils.metamodels.UmlMockupCreators.uml
 
 class UmlStateChangeTest extends StateChangePropagationTest {
-	@Test
-	def void testRenameTypes() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testRenameTypes(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		umlRoot.classes.get(0) => [name = "RenamedClass"]
 		umlRoot.interfaces.get(0) => [name = "RenamedInterface"]
-		compareChanges(umlModel, umlCheckpoint)
+		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testNewAttributes() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testNewAttributes(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		umlRoot.classes.get(0) => [
 			attributes += uml.Attribute => [attributeName = "NewlyAddedAttribute"]
 		]
-		compareChanges(umlModel, umlCheckpoint)
+		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testNewMethod() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testNewMethod(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		umlRoot.interfaces.get(0) => [
 			methods += uml.Method => [name = "NewlyAddedMethod"]
 		]
-		compareChanges(umlModel, umlCheckpoint)
+		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testNewClass() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testNewClass(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		umlRoot.classes += uml.Class => [name = "NewlyAddedClass"]
-		compareChanges(umlModel, umlCheckpoint)
+		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testReplaceClass() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testReplaceClass(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		umlRoot.classes.remove(0)
 		umlRoot.classes += uml.Class => [name = "NewlyAddedClass"]
-		compareChanges(umlModel, umlCheckpoint)
+		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testDeleteClass() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testDeleteClass(StateBasedChangeResolutionStrategy strategyToTest, String name) {
 		umlRoot.classes.remove(0)
-		compareChanges(umlModel, umlCheckpoint)
+		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 
-	@Test
-	def void testNewInterface() {
+	@ParameterizedTest(name = "{1}")
+	@MethodSource("strategiesToTest")
+	def void testNewInterface(StateBasedChangeResolutionStrategy strategyToTest, String strategyName) {
 		umlRoot.interfaces += uml.Interface => [name = "NewlyAddedInterface"]
-		compareChanges(umlModel, umlCheckpoint)
+		compareChanges(umlModel, umlCheckpoint, strategyToTest)
 	}
 }

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/util/XmiIdEdgeCaseTest.java
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/util/XmiIdEdgeCaseTest.java
@@ -1,0 +1,119 @@
+package tools.vitruv.framework.views.util;
+
+import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil.createFileURI;
+import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static tools.vitruv.testutils.metamodels.UmlMockupCreators.uml;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.xmi.XMLResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import tools.vitruv.testutils.RegisterMetamodelsInStandalone;
+import tools.vitruv.testutils.TestLogging;
+import tools.vitruv.testutils.TestProject;
+import tools.vitruv.testutils.TestProjectManager;
+import uml_mockup.Identified;
+import uml_mockup.UClass;
+import uml_mockup.UPackage;
+
+@ExtendWith({ TestProjectManager.class, TestLogging.class, RegisterMetamodelsInStandalone.class })
+public class XmiIdEdgeCaseTest {
+	private ResourceSet resourceSet;
+	private Path testProjectFolder;
+	private XMLResource umlModel;
+	private Map<String, EObject> expectedIdMapping;
+
+	@BeforeEach
+	void setup(@TestProject Path testProjectFolder) {
+		this.testProjectFolder = testProjectFolder;
+		resourceSet = withGlobalFactories(new ResourceSetImpl());
+
+		this.umlModel = (XMLResource) resourceSet.createResource(getModelURI("my.uml_mockup"));
+		UPackage uPackage1 = uml.Package();
+		umlModel.getContents().add(uPackage1);
+		uPackage1.setName("Package1");
+		UClass uClass1 = uml.Class();
+		uPackage1.getClasses().add(uClass1);
+
+		UPackage uPackage2 = uml.Package();
+		umlModel.getContents().add(uPackage2);
+		uPackage2.setName("Package2");
+		UClass uClass2 = uml.Class();
+		uPackage2.getClasses().add(uClass2);
+
+		expectedIdMapping = Map.of( //
+				"package-1", uPackage1, //
+				"package-2", uPackage2, //
+				"class-1", uClass1, //
+				"class-2", uClass2 //
+		);
+		expectedIdMapping.forEach((id, obj) -> umlModel.setID(obj, id));
+	}
+
+	@Test
+	public void testSingleResourceCopy() {
+		ResourceSet copyResourceSet = new ResourceSetImpl();
+		XMLResource copiedModel = (XMLResource) ResourceCopier.copyViewResource(umlModel, copyResourceSet);
+		validateIds(copiedModel, expectedIdMapping);
+	}
+
+	@Test
+	public void testMultiResourceCopy() {
+		XMLResource umlModel2 = (XMLResource) resourceSet.createResource(getModelURI("my.uml_mockup"));
+		UPackage uPackage1 = uml.Package();
+		umlModel2.getContents().add(uPackage1);
+		uPackage1.setName("Package1");
+		UClass uClass1 = uml.Class();
+		uPackage1.getClasses().add(uClass1);
+
+		UPackage uPackage2 = uml.Package();
+		umlModel2.getContents().add(uPackage2);
+		uPackage2.setName("Package2");
+		UClass uClass2 = uml.Class();
+		uPackage2.getClasses().add(uClass2);
+
+		Map<String, EObject> expectedIdMapping2 = Map.of( //
+				"2-package-1", uPackage1, //
+				"2-package-2", uPackage2, //
+				"2-class-1", uClass1, //
+				"2-class-2", uClass2 //
+		);
+		expectedIdMapping2.forEach((id, obj) -> umlModel2.setID(obj, id));
+
+		ResourceSet copyResourceSet = new ResourceSetImpl();
+		Map<Resource, Resource> copiedModels = ResourceCopier.copyViewResources(List.of(umlModel, umlModel2),
+				copyResourceSet);
+		XMLResource copiedModel = (XMLResource) copiedModels.get(umlModel);
+		XMLResource copiedModel2 = (XMLResource) copiedModels.get(umlModel2);
+		assertNotNull(copiedModel, "copy for uml model is missing");
+		assertNotNull(copiedModel2, "copy for uml model 2 is missing");
+		validateIds(copiedModel, expectedIdMapping);
+		validateIds(copiedModel2, expectedIdMapping2);
+	}
+
+	private void validateIds(Resource copiedResource, Map<String, EObject> expectedIdMapping) {
+		expectedIdMapping.forEach((id, object) -> {
+			EObject copiedObject = copiedResource.getEObject(id);
+			assertNotNull(copiedObject, "could not find element with id " + id);
+			assertEquals(((Identified) object).getId(), ((Identified) copiedObject).getId());
+		});
+	}
+
+	protected URI getModelURI(String modelFileName) {
+		File file = testProjectFolder.resolve("model").resolve(modelFileName).toFile();
+		return createFileURI(file);
+	}
+}

--- a/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/util/XmiIdEdgeCaseTest.java
+++ b/tests/framework/tools.vitruv.framework.views.tests/src/tools/vitruv/framework/views/util/XmiIdEdgeCaseTest.java
@@ -72,7 +72,7 @@ public class XmiIdEdgeCaseTest {
 
 	@Test
 	public void testMultiResourceCopy() {
-		XMLResource umlModel2 = (XMLResource) resourceSet.createResource(getModelURI("my.uml_mockup"));
+		XMLResource umlModel2 = (XMLResource) resourceSet.createResource(getModelURI("my2.uml_mockup"));
 		UPackage uPackage1 = uml.Package();
 		umlModel2.getContents().add(uPackage1);
 		uPackage1.setName("Package1");


### PR DESCRIPTION
This PR adds the following improvements:

- Adds customization option to the default state-based change resolution strategy to enable / disable matching based on identifiers (defaults to _when available_)
- Fixed identifier-based comparison for resources with `xmi:id` tags (links to [Vitruv-Applications#184](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/issues/184)). Ids are only copied within the scope of the view and not when creating a view from the V-SUM. This is done as the ids there don't have any semantic as they are not detected by our change recorder.
- Adds a factory method for modifying views using a state-based view

### Details on `xmi:id`

As explained in [Vitruv-Applications#184](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/issues/184), the ids may not be stored in the `EObject`s but in the `Resource`. These ids are not copied when using the default `EcoreUtil` copy functionality. However, these ids are used by `EMFCompare` for identifier-based matching. This resulted in incorrect matching as the created resource copies did not contain the same ids as the original resources. This occurred in the change-deriving view when creating the reference state resource set as well as in the default state-based change derivation strategy when creating a resource copy to apply the derived differences to (to convert them to `EChange`s).