### PR TITLE
Minor framework cleanup

### DIFF
--- a/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/command/ApplyEChangeSwitch.xtend
+++ b/bundles/framework/tools.vitruv.framework.change.echange/src/tools/vitruv/framework/change/echange/command/ApplyEChangeSwitch.xtend
@@ -1,10 +1,11 @@
 package tools.vitruv.framework.change.echange.command
 
-import tools.vitruv.framework.change.echange.EChange
-import org.eclipse.emf.common.command.Command
 import edu.kit.ipd.sdq.activextendannotations.Utility
-import static com.google.common.base.Preconditions.checkState
+import org.eclipse.emf.common.command.Command
+import tools.vitruv.framework.change.echange.EChange
+
 import static com.google.common.base.Preconditions.checkArgument
+import static com.google.common.base.Preconditions.checkState
 
 /**
  * Utility class for applying an EChange.
@@ -33,12 +34,7 @@ class ApplyEChangeSwitch {
 
 		for (Command c : commands) {
 			checkState(c.canExecute, "cannot execute command generated for EChange: %s", change)
-			try {
-				c.execute()
-			} catch (UnsupportedOperationException e) {
-				// Some features are derived but not marked as such an cannot be modified,
-				// so catch that exception and move on
-			}
+			c.execute()
 		}
 	}
 

--- a/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
+++ b/bundles/framework/tools.vitruv.framework.change/src/tools/vitruv/framework/change/recording/ChangeRecorder.xtend
@@ -87,7 +87,6 @@ class ChangeRecorder implements AutoCloseable {
 
 	/**
 	 * Add the given elements and all its contained elements ({@link Resource}s, {@link EObject}s) to the recorder.
-	 * Register all existing elements at the {@link IdResolverAndRepository} with existing UUIDs.
 	 * 
 	 * @param notifier - the {@link Notifier} to add the recorder to
 	 * @throws IllegalStateException if the recorder is already disposed

--- a/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
+++ b/tests/dsls/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
@@ -75,13 +75,8 @@ class BidirectionalExecutionTests extends ReactionsExecutionTest {
 		assertThat(propagatedChanges.get(1).consequentialChanges.EChanges, is(emptyList))
 	}
 
-	/** Regression test for #175:
-	 *  Removing an object from its container for which the UUID is not cached in the local UUID resolver,
-	 *  the UUID resolution failed: Local and global resolution both failed, because the object
-	 *  has a changed URI (due to removal from container).
-	 */
 	@Test
-	def void testApplyRemoveInOtherModel() {
+	def void testApplyRemoveInTargetModel() {
 		val propagatedChanges = Root.from(TARGET_MODEL).propagate [
 			nonRootObjectContainerHelper.nonRootObjectsContainment.remove(0)
 		]
@@ -96,13 +91,8 @@ class BidirectionalExecutionTests extends ReactionsExecutionTest {
 		assertThat(propagatedChanges.get(1).consequentialChanges.EChanges, is(emptyList))
 	}
 
-	/** Regression test for #175:
-	 *  Removing a root object from a resource for which the UUID is not cached in the local UUID resolver,
-	 *  the UUID resolution failed: Local and global resolution both failed, because the object
-	 *  has a changed URI (due to removal from container).
-	 */
 	@Test
-	def void testApplyRemoveRootInOtherModel() {
+	def void testApplyRemoveRootInTargetModel() {
 		val propagatedChanges = resourceAt(TARGET_MODEL).propagate [delete(emptyMap)]
 
 		assertThat(propagatedChanges.size, is(2))


### PR DESCRIPTION
1) Removes some outdated documentation regarding UUIDs.
2) Removes exception hiding in `ApplyEChangeSwitch` as all test cases work without catching the referenced exception.