### PR TITLE
Reference latest kit-sdq updatesites

### DIFF
--- a/releng/tools.vitruv.parent/pom.xml
+++ b/releng/tools.vitruv.parent/pom.xml
@@ -16,17 +16,17 @@
 		<repository>
 			<id>Demo Metamodels</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/latest/</url>
 		</repository>
 		<repository>
 			<id>SDQ Commons</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/commons/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/commons/latest/</url>
 		</repository>
 		<repository>
 			<id>XAnnotations</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/xannotations/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/xannotations/latest/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Replaces the references to the composite kit-sdq updatesites with references of the latest versions. This avoid accidental resolution of artifacts from old versions and improves build times as not all versions of the updatesites have to be resolved.