### PR TITLE
Change propagation listener enhancement

### DIFF
--- a/bundles/tools.vitruv.framework.applications/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.framework.applications/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: tools.vitruv.change.propagation;visibility:=reexport,
  tools.vitruv.framework.domains;visibility:=reexport,
  com.google.guava,
+ org.apache.log4j,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,

--- a/bundles/tools.vitruv.framework.applications/src/tools/vitruv/framework/applications/VitruvApplicationsRegistry.xtend
+++ b/bundles/tools.vitruv.framework.applications/src/tools/vitruv/framework/applications/VitruvApplicationsRegistry.xtend
@@ -6,9 +6,11 @@ import java.util.HashSet
 import java.util.Collections
 import java.util.List
 import org.eclipse.core.runtime.Platform
+import org.apache.log4j.Logger
 
 class VitruvApplicationsRegistry {
 	public static String EXTENSION_POINT_ID = "tools.vitruv.framework.applications.application"
+	static Logger LOGGER = Logger.getLogger(VitruvApplicationsRegistry)
 	
 	@Accessors(PUBLIC_GETTER)
 	static VitruvApplicationsRegistry instance = new VitruvApplicationsRegistry
@@ -49,7 +51,12 @@ class VitruvApplicationsRegistry {
 		val List<VitruvApplication> applications = newArrayList();
 		if (Platform.running) {
 			Platform.getExtensionRegistry().getConfigurationElementsFor(EXTENSION_POINT_ID).map [
-				it.createExecutableExtension("class")
+				try {
+					it.createExecutableExtension("class")
+				} catch (Exception e) {
+					LOGGER.warn("Error when loading application for extension " + it)
+					null;
+				}
 			].filter(VitruvApplication).forEach[applications.add(it)];
 		}
 		return applications;

--- a/bundles/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/BasicView.xtend
+++ b/bundles/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/BasicView.xtend
@@ -9,7 +9,6 @@ import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.xtend.lib.annotations.Accessors
-import tools.vitruv.change.composite.propagation.ChangePropagationAbortCause
 import tools.vitruv.change.composite.propagation.ChangePropagationListener
 import tools.vitruv.framework.views.ChangeableViewSource
 import tools.vitruv.framework.views.ViewSelection
@@ -21,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState
 
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories
 import tools.vitruv.change.composite.description.PropagatedChange
+import tools.vitruv.change.composite.description.VitruviusChange
 
 package class BasicView implements ModifiableView, ChangePropagationListener {
     @Accessors(PUBLIC_GETTER, PROTECTED_SETTER)
@@ -85,15 +85,11 @@ package class BasicView implements ModifiableView, ChangePropagationListener {
         return closed
     }
 
-    override abortedChangePropagation(ChangePropagationAbortCause cause) {
-        // do nothing
-    }
-
     override finishedChangePropagation(Iterable<PropagatedChange> propagatedChanges) {
         modelChanged = true
     }
 
-    override startedChangePropagation() {
+    override startedChangePropagation(VitruviusChange changeToPropagate) {
         // do nothing
     }
 

--- a/bundles/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/BasicView.xtend
+++ b/bundles/tools.vitruv.framework.views/src/tools/vitruv/framework/views/impl/BasicView.xtend
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument
 import static com.google.common.base.Preconditions.checkState
 
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.ecore.resource.ResourceSetUtil.withGlobalFactories
+import tools.vitruv.change.composite.description.PropagatedChange
 
 package class BasicView implements ModifiableView, ChangePropagationListener {
     @Accessors(PUBLIC_GETTER, PROTECTED_SETTER)
@@ -88,7 +89,7 @@ package class BasicView implements ModifiableView, ChangePropagationListener {
         // do nothing
     }
 
-    override finishedChangePropagation() {
+    override finishedChangePropagation(Iterable<PropagatedChange> propagatedChanges) {
         modelChanged = true
     }
 

--- a/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/VirtualModelImpl.xtend
+++ b/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/VirtualModelImpl.xtend
@@ -86,7 +86,7 @@ class VirtualModelImpl implements InternalVirtualModel {
 			''')
 		}
 
-		finishChangePropagation(unresolvedChange)
+		finishChangePropagation(unresolvedChange, result)
 		informPropagatedChangeListeners(result)
 		LOGGER.info("Finished change propagation")
 		return result
@@ -97,9 +97,9 @@ class VirtualModelImpl implements InternalVirtualModel {
 		changePropagationListeners.forEach[startedChangePropagation]
 	}
 
-	private def void finishChangePropagation(VitruviusChange change) {
-		changePropagationListeners.forEach[finishedChangePropagation]
-		if(LOGGER.isDebugEnabled) LOGGER.debug('''Finished synchronizing change: «change»''')
+	private def void finishChangePropagation(VitruviusChange inputChange, Iterable<PropagatedChange> generatedChanges) {
+		changePropagationListeners.forEach[finishedChangePropagation(generatedChanges)]
+		if(LOGGER.isDebugEnabled) LOGGER.debug('''Finished synchronizing change: «inputChange»''')
 	}
 
 	override Path getFolder() {

--- a/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/VirtualModelImpl.xtend
+++ b/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/VirtualModelImpl.xtend
@@ -94,7 +94,7 @@ class VirtualModelImpl implements InternalVirtualModel {
 
 	private def void startChangePropagation(VitruviusChange change) {
 		if(LOGGER.isDebugEnabled) LOGGER.debug('''Started synchronizing change: «change»''')
-		changePropagationListeners.forEach[startedChangePropagation]
+		changePropagationListeners.forEach[startedChangePropagation(change)]
 	}
 
 	private def void finishChangePropagation(VitruviusChange inputChange, Iterable<PropagatedChange> generatedChanges) {


### PR DESCRIPTION
This is preparatory work for removing the `PropagatedChangeListener` by integrating the required functionality into the `ChangePropagationListener` interface.

The PR also makes the applications registry tolerate if applications are not configures correctly (i.e., provide faulty `plugin.xml`s) instead of throwing exceptions.