### PR TITLE
Preparation for renaming all Vitruv default branches to `main`

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -25,7 +25,7 @@ jobs:
           repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
           ref: main
           fetch-depth: 0
-      - name: Checkout Matching Domains/Applications Branches
+      - name: Checkout Matching DSLs/Applications Branches
         run: |
           cd dsls
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           path: cbsapplications
           repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
-          ref: master
+          ref: main
           fetch-depth: 0
       - name: Checkout Matching Domains/Applications Branches
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   release:
     types: [created]
   pull_request:
@@ -39,7 +39,7 @@ jobs:
         env: 
           MAVEN_OPTS: -Djansi.force=true
       - name: Publish Nightly Update Site
-        if: github.ref == 'refs/heads/master' && github.repository_owner == 'vitruv-tools'
+        if: github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vitruv
 [![GitHub Action CI](https://github.com/vitruv-tools/Vitruv/workflows/CI/badge.svg)](https://github.com/vitruv-tools/Vitruv/actions?query=workflow%3ACI)
 [![Issues](https://img.shields.io/github/issues/vitruv-tools/Vitruv.svg)](https://github.com/vitruv-tools/Vitruv/issues)
-[![License](https://img.shields.io/github/license/vitruv-tools/Vitruv.svg)](https://raw.githubusercontent.com/vitruv-tools/Vitruv/master/LICENSE)
+[![License](https://img.shields.io/github/license/vitruv-tools/Vitruv.svg)](https://raw.githubusercontent.com/vitruv-tools/Vitruv/main/LICENSE)
 
 Vitruv is a framework for view-based software development. It assumes different models to be used for describing a software system,
 which are automatically kept consistent by the framework and its applications.


### PR DESCRIPTION
Adapts the GitHub actions to renaming the default branch to `main`.
Adapts the GitHub actions to renaming the Application-CBS repository's default branch to `main`.

⚠️ Depends on [Vitruv-Applications-CBS#211](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/pull/211)

Closes #499 

GitHub provides [built-in functionality](https://github.com/github/renaming#renaming-existing-branches) for renaming the branch. First the branch has to be renamed, then the PR should be merged.