### PR TITLE
Run CI validation on all major OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,14 +43,14 @@ jobs:
         env: 
           MAVEN_OPTS: -Djansi.force=true
       - name: Store Framework Artifact
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v3
         with:
           name: framework
           path: releng/tools.vitruv.updatesite/target/repository
           retention-days: 1
       - name: Publish Nightly Update Site
-        if: github.event_name != 'release' && github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools'
+        if: github.event_name != 'release' && github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools' && matrix.os == 'ubuntu-latest'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}
@@ -57,7 +61,7 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
       - name: Publish Release Update Site
-        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools'
+        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools' && matrix.os == 'ubuntu-latest'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}


### PR DESCRIPTION
This PR adds support to run the validation GitHub Actions on all major OS (Linux, Windows, macOS).
Releases are still built and released on Ubuntu only.

⚠️ Before merging this, the branch protection rules need to be adjusted to the modified jobs ⚠️

Follows https://github.com/vitruv-tools/Vitruv-Change/pull/24