### PR TITLE
Migrate to Java 17 CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
       - name: Build and Verify
         run: >
           ./mvnw -B -U clean verify 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
       - name: Build DSLs
         uses: GabrielBB/xvfb-action@v1
         with:
@@ -91,8 +91,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
       - name: Build and Verify Case Studies
         uses: GabrielBB/xvfb-action@v1
         with:
@@ -141,8 +141,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
       - name: Build and Verify Tools Adapters
         uses: GabrielBB/xvfb-action@v1
         with: 


### PR DESCRIPTION
In preparation for migrating to Java 17, this PR already updates the CI to use Java 17 for building in source compatibility mode for Java 11 (as specified in [Maven Build Parent](https://github.com/vitruv-tools/Maven-Build-Parent)).

Additionally, the Java distribution is changed to the Eclipse distribution temurin.