### PR TITLE
Support change propagation mode customization in view-based tests

### DIFF
--- a/bundles/tools.vitruv.testutils.vsum/src/tools/vitruv/testutils/ViewBasedVitruvApplicationTest.xtend
+++ b/bundles/tools.vitruv.testutils.vsum/src/tools/vitruv/testutils/ViewBasedVitruvApplicationTest.xtend
@@ -30,10 +30,12 @@ abstract class ViewBasedVitruvApplicationTest {
 	def protected abstract Iterable<? extends ChangePropagationSpecification> getChangePropagationSpecifications()
 	
 	/**
-	 * Determines the {@link ChangePropagationMode} to be used in this test.
-	 * If <code>null</code> is returned, the default change propagation mode of the virtual model is used.
+	 * Determines the {@link ChangePropagationMode} to use in this test.
+	 * If <code>true</code> is returned, {@link ChangePropagationMode#TRANSITIVE_CYCLIC} is used.
+	 * If <code>false</code> is returned, {@link ChangePropagationMode#SINGLE_STEP} is used.
+	 * Defaults to <code>true</code>.
 	 */
-	abstract def protected ChangePropagationMode getChangePropagationMode()
+	def protected enableTransitiveCyclicChangePropagation() { true }
 
 	/**
 	 * Determines which {@link UriMode} should be used for this test.
@@ -44,15 +46,13 @@ abstract class ViewBasedVitruvApplicationTest {
 	def final package void prepareVirtualModel(TestInfo testInfo, @TestProject Path testProjectPath,
 		@TestProject(variant="vsum") Path vsumPath) {
 		val changePropagationSpecifications = this.changePropagationSpecifications
+		val changePropagationMode = enableTransitiveCyclicChangePropagation ? ChangePropagationMode.TRANSITIVE_CYCLIC : ChangePropagationMode.SINGLE_STEP
 		userInteraction = new TestUserInteraction
 		virtualModel = new VirtualModelBuilder() //
 		.withStorageFolder(vsumPath) //
 		.withUserInteractorForResultProvider(new TestUserInteraction.ResultProvider(userInteraction)) //
 		.withChangePropagationSpecifications(changePropagationSpecifications).buildAndInitialize()
-		val propagationMode = changePropagationMode
-		if (propagationMode !== null) {
-			virtualModel.changePropagationMode = propagationMode
-		}
+		virtualModel.changePropagationMode = changePropagationMode
 		this.testProjectPath = testProjectPath
 	}
 

--- a/bundles/tools.vitruv.testutils.vsum/src/tools/vitruv/testutils/ViewBasedVitruvApplicationTest.xtend
+++ b/bundles/tools.vitruv.testutils.vsum/src/tools/vitruv/testutils/ViewBasedVitruvApplicationTest.xtend
@@ -15,6 +15,7 @@ import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil.c
 import static org.eclipse.emf.common.util.URI.createPlatformResourceURI
 import org.eclipse.xtend.lib.annotations.Accessors
 import tools.vitruv.testutils.views.UriMode
+import tools.vitruv.change.propagation.ChangePropagationMode
 
 @ExtendWith(TestLogging, TestProjectManager)
 abstract class ViewBasedVitruvApplicationTest {
@@ -27,6 +28,12 @@ abstract class ViewBasedVitruvApplicationTest {
 	 * Determines the {@link ChangePropagationSpecification}s to be used in this test.
 	 */
 	def protected abstract Iterable<? extends ChangePropagationSpecification> getChangePropagationSpecifications()
+	
+	/**
+	 * Determines the {@link ChangePropagationMode} to be used in this test.
+	 * If <code>null</code> is returned, the default change propagation mode of the virtual model is used.
+	 */
+	abstract def protected ChangePropagationMode getChangePropagationMode()
 
 	/**
 	 * Determines which {@link UriMode} should be used for this test.
@@ -42,6 +49,10 @@ abstract class ViewBasedVitruvApplicationTest {
 		.withStorageFolder(vsumPath) //
 		.withUserInteractorForResultProvider(new TestUserInteraction.ResultProvider(userInteraction)) //
 		.withChangePropagationSpecifications(changePropagationSpecifications).buildAndInitialize()
+		val propagationMode = changePropagationMode
+		if (propagationMode !== null) {
+			virtualModel.changePropagationMode = propagationMode
+		}
 		this.testProjectPath = testProjectPath
 	}
 


### PR DESCRIPTION
Currently, in our UML <-> Java tests, we run uni- and bidirectional tests by calling `setupTransformationDirection` before each tests. By default, unidirectional tests are executed. Additionally, each test class has a subclass where the method is overridden to configure bidirectional tests.
In this implementation however is a mistake such that the bidirectional configuration happens only accidentally. More specifically, when overriding a method without again specifying the JUnit annotations (here `@BeforeEach`), the annotation is lost and thus the method is not executed. In the UML <-> Java test cases, this results in the `setupTransformationDirection` method not called and thus the default change propagation mode being used which is accidentally the `TRANSITIVE_CYCLIC` mode when want.

To prevent such accidental configurations, I added an endpoint which can be safely overridden without having to care for JUnit annotations.