### PR TITLE
Migrate to Eclipse 2022-12 and Java 17

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>2.7.4</version>
+    <version>3.0.0</version>
   </extension>
 </extensions>

--- a/bundles/tools.vitruv.framework.applications/.classpath
+++ b/bundles/tools.vitruv.framework.applications/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.framework.applications/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.framework.applications/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: vitruv.tools
 Bundle-SymbolicName: tools.vitruv.framework.applications;singleton:=true
 Automatic-Module-Name: tools.vitruv.framework.applications
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: tools.vitruv.change.propagation;visibility:=reexport,
  com.google.guava,
  org.apache.log4j,

--- a/bundles/tools.vitruv.framework.views/.classpath
+++ b/bundles/tools.vitruv.framework.views/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.framework.views/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.framework.views/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Framework Views
 Bundle-SymbolicName: tools.vitruv.framework.views;singleton:=true
 Automatic-Module-Name: tools.vitruv.framework.views
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.apache.log4j,
  tools.vitruv.change.composite,
  org.eclipse.emf.compare,

--- a/bundles/tools.vitruv.framework.vsum/.classpath
+++ b/bundles/tools.vitruv.framework.vsum/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.framework.vsum/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.framework.vsum/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Framework Virtual Single Underlying Model
 Bundle-SymbolicName: tools.vitruv.framework.vsum;singleton:=true
 Automatic-Module-Name: tools.vitruv.framework.vsum
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.apache.log4j,
  tools.vitruv.change.composite;visibility:=reexport,
  tools.vitruv.framework.views;visibility:=reexport,

--- a/bundles/tools.vitruv.testutils.vsum/.classpath
+++ b/bundles/tools.vitruv.testutils.vsum/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/bundles/tools.vitruv.testutils.vsum/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.testutils.vsum/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: tools.vitruv.testutils.vsum
 Bundle-Version: 3.0.1.qualifier
 Bundle-Vendor: tools.vitruv
 Automatic-Module-Name: tools.vitruv.testutils.vsum
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,

--- a/releng/tools.vitruv.parent/pom.xml
+++ b/releng/tools.vitruv.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1</version>
 	</parent>
 	<artifactId>framework-parent</artifactId>
 	<version>3.0.1-SNAPSHOT</version>
@@ -27,17 +27,17 @@
 		<repository>
 			<id>Demo Metamodels</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/latest/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/${sdq.demometamodels.version}</url>
 		</repository>
 		<repository>
 			<id>SDQ Commons</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/commons/latest/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/commons/${sdq.commons.version}</url>
 		</repository>
 		<repository>
 			<id>XAnnotations</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/xannotations/latest/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/xannotations/${sdq.xannotations.version}</url>
 		</repository>
 	</repositories>
 

--- a/releng/tools.vitruv.parent/pom.xml
+++ b/releng/tools.vitruv.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.0.2</version>
+		<version>2.1.0</version>
 	</parent>
 	<artifactId>framework-parent</artifactId>
 	<version>3.0.1-SNAPSHOT</version>

--- a/tests/tools.vitruv.framework.views.tests/.classpath
+++ b/tests/tools.vitruv.framework.views.tests/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/tests/tools.vitruv.framework.views.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.framework.views.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Framwork Views Tests
 Bundle-SymbolicName: tools.vitruv.framework.views.tests;singleton:=true
 Automatic-Module-Name: tools.vitruv.framework.views.tests
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Fragment-Host: tools.vitruv.framework.views
 Require-Bundle: org.apache.log4j,
  tools.vitruv.testutils.vsum,

--- a/tests/tools.vitruv.framework.vsum.tests/.classpath
+++ b/tests/tools.vitruv.framework.vsum.tests/.classpath
@@ -6,7 +6,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/tests/tools.vitruv.framework.vsum.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.framework.vsum.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Framwork Virtual Single Underlying Model Tests
 Bundle-SymbolicName: tools.vitruv.framework.vsum.tests;singleton:=true
 Automatic-Module-Name: tools.vitruv.framework.vsum.tests
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Fragment-Host: tools.vitruv.framework.vsum
 Require-Bundle: org.apache.log4j,
  tools.vitruv.testutils.vsum,


### PR DESCRIPTION
Updates dependencies to Eclipse 2022-12 and migrates to JavaSE-17.
Pins SDQ dependency versions to version specified in parent pom.