### PR TITLE
Fix Xtend error

### DIFF
--- a/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
+++ b/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
@@ -16,7 +16,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
@@ -102,7 +101,7 @@ class ResourceRepositoryImpl implements ModelRepository {
 
 	private void writeModelsFile() throws IOException {
 		Files.write(fileSystemLayout.getModelsNamesFilesPath(),
-				modelsResourceSet.getResources().stream().map(Resource::getURI).map(URI::toString).collect(Collectors.toList()));
+				modelsResourceSet.getResources().stream().map(Resource::getURI).map(URI::toString).toList());
 	}
 
 	private void readModelsFile() throws IOException {
@@ -208,7 +207,7 @@ class ResourceRepositoryImpl implements ModelRepository {
 		isRecording = false;
 		fileExtensionRecorderMapping.getRecorders().forEach(ChangeRecorder::endRecording);
 		return fileExtensionRecorderMapping.getRecorders().stream().map(ChangeRecorder::getChange)
-				.filter(TransactionalChange::containsConcreteChange).collect(Collectors.toList());
+				.filter(TransactionalChange::containsConcreteChange).toList();
 	}
 
 	@Override

--- a/bundles/tools.vitruv.testutils.vsum/.classpath
+++ b/bundles/tools.vitruv.testutils.vsum/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/tests/tools.vitruv.framework.views.tests/.classpath
+++ b/tests/tools.vitruv.framework.views.tests/.classpath
@@ -7,6 +7,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="lib" path="lib/mockito-core-4.2.0.jar"/>
 	<classpathentry kind="lib" path="lib/byte-buddy-1.12.4.jar"/>

--- a/tests/tools.vitruv.framework.vsum.tests/.classpath
+++ b/tests/tools.vitruv.framework.vsum.tests/.classpath
@@ -11,6 +11,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
This PR adds JUnit 5 to all test projects' classpaths, thus fixing the Xtend errors occurring with Xtend 2.29 and Eclipse 2022-12.

https://github.com/vitruv-tools/.github/issues/10

Also refactors stream operations to use the Java 16 `toList()` method.