### PR TITLE
True Delta-Based Itereation 1

### DIFF
--- a/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ModelInstance.xtend
+++ b/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ModelInstance.xtend
@@ -1,65 +1,68 @@
 package tools.vitruv.framework.vsum.internal
 
 import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.Collections
+import java.util.List
+import java.util.Map
 import org.apache.log4j.Logger
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EObject
-import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
+import tools.vitruv.change.atomic.EChange
+import tools.vitruv.change.atomic.id.IdResolver
+import tools.vitruv.change.composite.description.VitruviusChangeFactory
+import tools.vitruv.framework.views.changederivation.DefaultStateBasedChangeResolutionStrategy
 
-import static com.google.common.base.Preconditions.checkArgument
-
-class ModelInstance {
+class ModelInstance extends ResourceImpl {
 	static val LOGGER = Logger.getLogger(ModelInstance)
-	@Accessors(PUBLIC_GETTER)
-	Resource resource
 
-	new(Resource resource) {
-		checkArgument(resource !== null, "cannot create a model instance for a null resource")
-		this.resource = resource
-		LOGGER.debug('''Create model instance for resource with URI: «URI»''')
-	}
-
-	def URI getURI() {
-		return resource.URI
+	new(URI uri) {
+		this.URI = uri
+		LOGGER.debug('''Create model instance for resource with URI: «uri»''')
 	}
 
 	def void addRoot(EObject root) {
-		resource.contents += root
-		resource.modified = true
-		LOGGER.debug('''Add root to resource: «resource»''')
+		this.contents += root
+		this.modified = true
+		LOGGER.debug('''Add root to model instance: «this»''')
 	}
-
-	def void markModified() {
-		resource.modified = true
-	}
-
+	
 	def boolean isEmpty() {
-		resource.contents.isEmpty
+		this.contents.isEmpty
 	}
-
-	def void save() {
-		if (!resource.modified) {
+	
+	private static def List<EChange> loadDeltas(URI modelUri) {
+        val resSet = new ResourceSetImpl();
+        val resource = resSet.getResource(modelUri, true);
+        return resource.getContents().map[it as EChange].toList
+	}
+	
+	override doLoad(InputStream inputStream, Map<?, ?> options) throws IOException {
+		val deltas = loadDeltas(this.URI)
+		VitruviusChangeFactory.getInstance().createTransactionalChange(deltas).resolveAndApply(IdResolver.create(this.resourceSet))
+	}
+	
+	override doSave(OutputStream outputStream, Map<?, ?> options) throws IOException {
+		if (!this.modified) {
 			return
 		}
-		LOGGER.debug('''Save resource: «resource»''')
-		try {
-			resource.save(null)
-			resource.modified = false
-		} catch (IOException e) {
-			LOGGER.error('''Model could not be saved: «URI»''', e)
-			throw new IllegalStateException('''Could not save URI «URI»''', e)
+		
+		val deltaChanges = new DefaultStateBasedChangeResolutionStrategy().getChangeSequenceForCreated(this).EChanges;
+		val resSet = new ResourceSetImpl();
+		val resource = resSet.createResource(this.URI);
+		resource.getContents().addAll(deltaChanges)
+		try (val out = outputStream){
+			resource.save(out, Collections.EMPTY_MAP)
 		}
+		
+		resource.modified = false
 	}
-
-	def void delete() {
-		LOGGER.debug('''Delete resource: «resource»''')
-		try {
-			resource.delete(null)
-		} catch (IOException e) {
-			LOGGER.error('''Deletion of resource «resource» did not work.''', e)
-			throw new IllegalStateException('''Could not delete URI «URI»''', e)
-		}
+	
+	override delete(Map<?, ?> options) throws IOException {
+		LOGGER.debug('''Delete model instance: «this»''')
+		super.delete(null)
 	}
-
 }

--- a/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ModelInstanceFactory.java
+++ b/bundles/tools.vitruv.framework.vsum/src/tools/vitruv/framework/vsum/internal/ModelInstanceFactory.java
@@ -1,0 +1,11 @@
+package tools.vitruv.framework.vsum.internal;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+
+public class ModelInstanceFactory implements Resource.Factory {
+	@Override
+	public Resource createResource(URI uri) {
+		return new ModelInstance(uri);
+	}
+}

--- a/bundles/tools.vitruv.testutils.vsum/src/tools/vitruv/testutils/DefaultVirtualModelBasedTestView.xtend
+++ b/bundles/tools.vitruv.testutils.vsum/src/tools/vitruv/testutils/DefaultVirtualModelBasedTestView.xtend
@@ -39,7 +39,7 @@ class DefaultVirtualModelBasedTestView implements VirtualModelBasedTestView, Non
 
 	private def NonTransactionalTestView generateTestView(Path testProjectPath, TestUserInteraction userInteraction) {
 		new ChangePublishingTestView(testProjectPath, userInteraction, this.uriMode, virtualModel,
-			virtualModel.uuidResolver)[virtualModel.getModelInstance(it)?.resource]
+			virtualModel.uuidResolver)[virtualModel.getModelInstance(it)]
 	}
 
 	override getVirtualModel() {

--- a/bundles/tools.vitruv.testutils.vsum/src/tools/vitruv/testutils/LegacyVitruvApplicationTest.xtend
+++ b/bundles/tools.vitruv.testutils.vsum/src/tools/vitruv/testutils/LegacyVitruvApplicationTest.xtend
@@ -52,7 +52,7 @@ abstract class LegacyVitruvApplicationTest extends VitruvApplicationTest impleme
 
 	private def dispatch EObject resolveInVirtualModel(EObject object) {
 		if (object.eResource !== null) {
-			internalVirtualModel.getModelInstance(object.eResource.URI).resource.getEObject(
+			internalVirtualModel.getModelInstance(object.eResource.URI).getEObject(
 				object.hierarchicUriFragment)
 		}
 	}

--- a/tests/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/vsum/VirtualModelTest.xtend
+++ b/tests/tools.vitruv.framework.vsum.tests/src/tools/vitruv/framework/vsum/VirtualModelTest.xtend
@@ -65,7 +65,7 @@ class VirtualModelTest {
 		val recordedChange = changeRecorder.endRecording(uuidResolver)
 		virtualModel.propagateChange(recordedChange)
 		val vsumModel = virtualModel.getModelInstance(createTestModelResourceUri(""))
-		assertThat(vsumModel.resource, containsModelOf(monitoredResource))
+		assertThat(vsumModel, containsModelOf(monitoredResource))
 	}
 
 	@Test
@@ -87,9 +87,9 @@ class VirtualModelTest {
 		val sorceModel = virtualModel.getModelInstance(createTestModelResourceUri(""))
 		val targetModel = virtualModel.getModelInstance(
 			RedundancyChangePropagationSpecification.getTargetResourceUri(createTestModelResourceUri("")))
-		assertThat(targetModel.resource, containsModelOf(monitoredResource))
+		assertThat(targetModel, containsModelOf(monitoredResource))
 		assertEquals(1,
-			virtualModel.correspondenceModel.getCorrespondingEObjects(sorceModel.resource.contents.get(0)).size)
+			virtualModel.correspondenceModel.getCorrespondingEObjects(sorceModel.contents.get(0)).size)
 	}
 
 	@Test
@@ -177,8 +177,7 @@ class VirtualModelTest {
 		]
 		val recordedChange = changeRecorder.endRecording(uuidResolver)
 		virtualModel.propagateChange(recordedChange)
-		val reloadedResource = new ResourceSetImpl().withGlobalFactories.getResource(createTestModelResourceUri(""),
-			true)
+		val reloadedResource = createAndLoadTestVirtualModelWithConsistencyPreservation(pathToVirtualModelProjectFolder).getModelInstance(createTestModelResourceUri(""))
 		assertThat(reloadedResource, containsModelOf(monitoredResource))
 	}
 
@@ -202,7 +201,7 @@ class VirtualModelTest {
 		val originalModel = virtualModel.getModelInstance(createTestModelResourceUri(""))
 		val reloadedVirtualModel = createAndLoadTestVirtualModel(pathToVirtualModelProjectFolder)
 		val reloadedModel = reloadedVirtualModel.getModelInstance(createTestModelResourceUri(""))
-		assertThat(reloadedModel.resource, containsModelOf(monitoredResource))
+		assertThat(reloadedModel, containsModelOf(monitoredResource))
 		assertNotEquals(originalModel, reloadedModel)
 		// Propagate another change to reloaded virtual model to ensure that everything is loaded correctly
 		changeRecorder.beginRecording
@@ -232,13 +231,13 @@ class VirtualModelTest {
 		val originalModel = virtualModel.getModelInstance(createTestModelResourceUri(""))
 		val reloadedVirtualModel = createAndLoadTestVirtualModel(pathToVirtualModelProjectFolder)
 		val reloadedModel = reloadedVirtualModel.getModelInstance(createTestModelResourceUri(""))
-		assertThat(reloadedModel.resource, containsModelOf(monitoredResource))
+		assertThat(reloadedModel, containsModelOf(monitoredResource))
 		assertNotEquals(originalModel, reloadedModel)
 		val reloadedTargetModel = reloadedVirtualModel.getModelInstance(
 			RedundancyChangePropagationSpecification.getTargetResourceUri(createTestModelResourceUri("")))
-		assertThat(reloadedTargetModel.resource, containsModelOf(monitoredResource))
+		assertThat(reloadedTargetModel, containsModelOf(monitoredResource))
 		assertEquals(1,
-			reloadedVirtualModel.correspondenceModel.getCorrespondingEObjects(reloadedModel.resource.contents.get(0)).
+			reloadedVirtualModel.correspondenceModel.getCorrespondingEObjects(reloadedModel.contents.get(0)).
 				size)
 	}
 


### PR DESCRIPTION
The goal of this PR is to save Vitruv Models in a delta-based representation. In iteration 1 we save the complete delta from start to current status of the model, without any concept of checkpoints or similar concepts.

**Open Tasks:**
- also save the correspondence model delta based
- investigate if it is possible to register own file extension (`.delta`) for delta-based models