### PR TITLE
Prepare Release 3.1.0

### DIFF
--- a/.github/prepare-release
+++ b/.github/prepare-release
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+if [ $# -lt 2 ];
+then
+    echo "usage: $0 <release-version> <new-snapshot-version>" >&2
+    echo "" >&2
+    echo "release-version     : Version of the next release, e.g., 3.1.0" >&2
+    echo "new-snapshot-version: Version of the upcoming nightly releases without the -SNAPSHOT suffix, e.g., 3.2.0" >&2
+    return 1
+fi
+
+git switch -C prepare-release/$1 || exit 1
+
+set_version_and_commit() {
+    ./mvnw versions:set -DnewVersion=$1 -DgenerateBackupPoms=false || return 1
+
+    git add pom.xml || return 1
+    git add "**/pom.xml" 2> /dev/null
+
+    git commit -m "$2" || return 1
+}
+
+set_version_and_commit "$1" "[Release] Version $1"
+set_version_and_commit "$2-SNAPSHOT" "[Release] Update version to $2-SNAPSHOT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+# workflow triggers
+on:
+  # manually
+  workflow_dispatch:
+  # releases
+  release:
+    types: [published]
+
+jobs:
+  verify:
+    name: Verify build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.2.2
+
+    - name: Setup Java and Maven cache
+      uses: actions/setup-java@v4.5.0
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        check-latest: true
+        cache: 'maven'
+
+    - name: Verify build
+      run: >
+        ./mvnw clean verify
+        --batch-mode
+        --update-snapshots
+        --no-transfer-progress
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [verify]
+    strategy:
+      fail-fast: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.2.2
+
+    - name: Setup Java and Maven cache
+      uses: actions/setup-java@v4.5.0
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        check-latest: true
+        cache: 'maven'
+        server-id: ossrh
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+    - name: Deploy to staging and release
+      run: >
+        ./mvnw clean deploy -P release
+        -DskipTests
+        --batch-mode
+        --update-snapshots
+        --no-transfer-progress
+      env:
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.applications</artifactId>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.applications</artifactId>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -30,14 +30,12 @@
   </build>
 
   <dependencies>
-    <!-- project dependencies -->
+    <!-- Vitruvius dependencies -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>tools.vitruv</groupId>
       <artifactId>tools.vitruv.change.propagation</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
-    <!-- project test depencies -->
     <!-- external dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -46,30 +44,22 @@
     <dependency>
       <groupId>org.eclipse.xtend</groupId>
       <artifactId>org.eclipse.xtend.lib</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.equinox.registry</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.core.runtime</artifactId>
-      <scope>compile</scope>
     </dependency>
-
-    <!-- external test dependencies -->
-
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <!-- Project Information -->
   <artifactId>tools.vitruv.framework</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Vitruv Framework</name>

--- a/pom.xml
+++ b/pom.xml
@@ -74,19 +74,6 @@
       </snapshots>
     </repository>
 
-    <!-- allow snapshots -->
-    <repository>
-      <id>ossrh-snapshots</id>
-      <name>OSSRH Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-
     <!-- for p2 dependencies, `groupId` specifies the repository -->
     <repository>
       <id>emf-compare</id>
@@ -115,32 +102,32 @@
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.correspondence</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.composite</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.interaction</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.propagation</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.core</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.integration</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0</version>
       </dependency>
 
       <!-- External dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
       <!-- Vitruvius dependencies -->
       <dependency>
         <groupId>tools.vitruv</groupId>
+        <artifactId>tools.vitruv.change.atomic</artifactId>
+        <version>3.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.correspondence</artifactId>
         <version>3.1.0</version>
       </dependency>
@@ -112,6 +117,11 @@
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.interaction</artifactId>
+        <version>3.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>tools.vitruv</groupId>
+        <artifactId>tools.vitruv.change.interaction.model</artifactId>
         <version>3.1.0</version>
       </dependency>
       <dependency>
@@ -129,8 +139,28 @@
         <artifactId>tools.vitruv.change.testutils.integration</artifactId>
         <version>3.1.0</version>
       </dependency>
+      <dependency>
+        <groupId>tools.vitruv</groupId>
+        <artifactId>tools.vitruv.change.testutils.metamodels</artifactId>
+        <version>3.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>tools.vitruv</groupId>
+        <artifactId>tools.vitruv.change.utils</artifactId>
+        <version>3.1.0</version>
+      </dependency>
 
       <!-- External dependencies -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.18.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.18.2</version>
+      </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
@@ -165,6 +195,11 @@
         <groupId>org.eclipse.emf</groupId>
         <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
         <version>2.38.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.emfcloud</groupId>
+        <artifactId>emfjson-jackson</artifactId>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
@@ -250,29 +285,6 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>5.14.2</version>
-        <scope>test</scope>
-      </dependency>
-
-      <!-- Dependencies Vitruv Remote -->
-      <dependency>
-        <groupId>org.eclipse.emfcloud</groupId>
-        <artifactId>emfjson-jackson</artifactId>
-        <version>2.2.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.18.2</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.18.2</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.18.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <!-- Project Information -->
   <artifactId>tools.vitruv.framework</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.0</version>
   <packaging>pom</packaging>
 
   <name>Vitruv Framework</name>

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.remote</artifactId>

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.remote</artifactId>

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -20,27 +20,6 @@
     <!-- project dependencies -->
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.utils</artifactId>
-      <version>${project.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.composite</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.interaction.model</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.atomic</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>tools.vitruv.framework.views</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -48,6 +27,24 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>tools.vitruv.framework.vsum</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <!-- Vitruvius dependencies -->
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.composite</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.interaction.model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.atomic</artifactId>
     </dependency>
 
     <!-- external dependencies -->

--- a/testutils/deprecated/pom.xml
+++ b/testutils/deprecated/pom.xml
@@ -33,31 +33,6 @@
     <!-- project dependencies -->
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.propagation</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.composite</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.correspondence</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.atomic</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.testutils.integration</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>tools.vitruv.framework.vsum</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -65,6 +40,28 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>tools.vitruv.framework.testutils.integration</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <!-- Vitruvius dependencies -->
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.propagation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.composite</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.correspondence</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.atomic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.testutils.integration</artifactId>
     </dependency>
 
     <!-- external dependencies -->

--- a/testutils/deprecated/pom.xml
+++ b/testutils/deprecated/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework.testutils</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.testutils.deprecated</artifactId>

--- a/testutils/deprecated/pom.xml
+++ b/testutils/deprecated/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework.testutils</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.testutils.deprecated</artifactId>

--- a/testutils/integration/pom.xml
+++ b/testutils/integration/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework.testutils</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.testutils.integration</artifactId>

--- a/testutils/integration/pom.xml
+++ b/testutils/integration/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework.testutils</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.testutils.integration</artifactId>

--- a/testutils/integration/pom.xml
+++ b/testutils/integration/pom.xml
@@ -33,36 +33,6 @@
     <!-- project dependencies -->
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.testutils.core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.testutils.integration</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.interaction</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.atomic</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.propagation</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.composite</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>tools.vitruv.framework.vsum</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -70,6 +40,32 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>tools.vitruv.framework.views</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <!-- Vitruvius dependencies -->
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.testutils.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.testutils.integration</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.interaction</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.atomic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.propagation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.composite</artifactId>
     </dependency>
 
     <!-- external dependencies -->

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.testutils</artifactId>

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.testutils</artifactId>

--- a/views/pom.xml
+++ b/views/pom.xml
@@ -30,29 +30,25 @@
   </build>
 
   <dependencies>
-    <!-- project dependencies -->
+    <!-- Vitruvius dependencies -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>tools.vitruv</groupId>
       <artifactId>tools.vitruv.change.composite</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>tools.vitruv</groupId>
       <artifactId>tools.vitruv.change.atomic</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
-    <!-- project test dependencies -->
+    <!-- Vitruvius test dependencies -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>tools.vitruv</groupId>
       <artifactId>tools.vitruv.change.testutils.core</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>tools.vitruv</groupId>
       <artifactId>tools.vitruv.change.testutils.metamodels</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -85,13 +81,12 @@
       <groupId>org.eclipse.emf</groupId>
       <artifactId>org.eclipse.emf.common</artifactId>
     </dependency>
-
-    <!-- external test dependencies -->
     <dependency>
       <groupId>org.eclipse.xtend</groupId>
       <artifactId>org.eclipse.xtend.lib</artifactId>
-      <scope>compile</scope>
     </dependency>
+
+    <!-- external test dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>

--- a/views/pom.xml
+++ b/views/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.views</artifactId>

--- a/views/pom.xml
+++ b/views/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.views</artifactId>

--- a/vsum/pom.xml
+++ b/vsum/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.vsum</artifactId>

--- a/vsum/pom.xml
+++ b/vsum/pom.xml
@@ -33,52 +33,45 @@
     <!-- project dependencies -->
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.utils</artifactId>
-      <version>${project.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.composite</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.propagation</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.correspondence</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.interaction</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>tools.vitruv.change.atomic</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>tools.vitruv.framework.views</artifactId>
       <version>${project.version}</version>
     </dependency>
 
-    <!-- project test depencies -->
+    <!-- Vitruvius dependencies -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.composite</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.propagation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.correspondence</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.interaction</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.vitruv</groupId>
+      <artifactId>tools.vitruv.change.atomic</artifactId>
+    </dependency>
+
+    <!-- Vitruvius test depencies -->
+    <dependency>
+      <groupId>tools.vitruv</groupId>
       <artifactId>tools.vitruv.change.testutils.metamodels</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>tools.vitruv</groupId>
       <artifactId>tools.vitruv.change.testutils.core</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/vsum/pom.xml
+++ b/vsum/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tools.vitruv.framework</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>tools.vitruv.framework.vsum</artifactId>


### PR DESCRIPTION
Notice the difference between project dependencies (other modules in the same project/repo), which only appear in the module POMs:
```
<dependency>
  <groupId>${project.groupId}</groupId>
  <artifactId>x.y.z</artifactId>
  <version>${project.version}</version>
</dependency>
```

and dependencies to module from other Vitruvius projects, which appear in the `dependencyManagement` section of the main POM with a version and in the module POMs without a version, but fixed `groupId`:
```
<!-- in the main POM: -->
<dependencyManagement>
  <dependency>
    <groupId>tools.vitruv</groupId>
    <artifactId>tools.vitruv.x.y.z</artifactId>
    <version>a.b.c</version>
  </dependency>
<dependencyManagement>

<!-- in the module POMs: -->
<dependencies>
  <dependency>
    <groupId>tools.vitruv</groupId>
    <artifactId>tools.vitruv.x.y.z</artifactId>
  </dependency>
<dependencies>
```