### PR TITLE
refactor p2 dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 target/
 *.log
 .mvn/wrapper/*.jar
+.flattened-pom.xml
+dependency-reduced-pom.xml
 
 # Eclipse
 META-INF

--- a/p2wrappers/activextendannotations/pom.xml
+++ b/p2wrappers/activextendannotations/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.framework.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.framework.p2wrappers.activextendannotations</artifactId>
+
+  <name>p2 Dependency Wrapper Active Xtend Annotations</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.xannotations.version>1.6.0</repo.xannotations.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>xannotations</id>
+      <name>XAnnotations</name>
+      <layout>p2</layout>
+      <url>https://kit-sdq.github.io/updatesite/release/xannotations/${repo.xannotations.version}</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>xannotations</groupId>
+      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
+      <version>1.6.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/emfcompare/pom.xml
+++ b/p2wrappers/emfcompare/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.framework.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.framework.p2wrappers.emfcompare</artifactId>
+
+  <name>p2 Dependency Wrapper EMF Compare</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.emf-compare.version>3.3</repo.emf-compare.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>emf-compare</id>
+      <name>EMF Compare</name>
+      <layout>p2</layout>
+      <url>https://download.eclipse.org/modeling/emf/compare/updates/releases/${repo.emf-compare.version}</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>emf-compare</groupId>
+      <artifactId>org.eclipse.emf.compare</artifactId>
+      <version>3.5.3.202212280858</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/emfutils/pom.xml
+++ b/p2wrappers/emfutils/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.framework.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.framework.p2wrappers.emfutils</artifactId>
+
+  <name>p2 Dependency Wrapper EMF Utils</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sdq-commons</id>
+      <name>SDQ Commons</name>
+      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>sdq-commons</groupId>
+      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
+      <version>2.3.0.202304271319</version>
+      <exclusions>
+        <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/javautils/pom.xml
+++ b/p2wrappers/javautils/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.framework.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.framework.p2wrappers.javautils</artifactId>
+
+  <name>p2 Dependency Wrapper Java Utils</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sdq-commons</id>
+      <name>SDQ Commons</name>
+      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>sdq-commons</groupId>
+      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <version>2.3.0.202304271319</version>
+      <exclusions>
+        <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/pom.xml
+++ b/p2wrappers/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.framework</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.framework.p2wrappers</artifactId>
+  <packaging>pom</packaging>
+
+  <name>p2 Dependency Wrappers</name>
+  <description />
+
+  <modules>
+    <module>activextendannotations</module>
+    <module>emfcompare</module>
+    <module>emfutils</module>
+    <module>javautils</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- allow Eclipse updatesites as repositories -->
+        <plugin>
+          <groupId>org.openntf.maven</groupId>
+          <artifactId>p2-layout-resolver</artifactId>
+          <version>1.9.0</version>
+          <extensions>true</extensions>
+        </plugin>
+        <!-- generate empty javadoc JARs for deployment -->
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.4.2</version>
+          <executions>
+            <execution>
+              <id>javadoc-jar</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <configuration>
+                <classifier>javadoc</classifier>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <pluginRepositories>
+    <!-- required for the p2-layout-resolver plugin -->
+    <pluginRepository>
+      <id>artifactory.openntf.org</id>
+      <name>artifactory.openntf.org</name>
+      <url>https://artifactory.openntf.org/openntf</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
   </modules>
 
   <properties>
+    <vitruv-change.version>3.1.0</vitruv-change.version>
     <!-- Additional Repositories -->
     <repo.emf-compare.version>3.3</repo.emf-compare.version>
     <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
@@ -102,52 +103,52 @@
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.atomic</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.correspondence</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.composite</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.interaction</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.interaction.model</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.propagation</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.core</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.integration</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.metamodels</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.utils</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
 
       <!-- External dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>parent</artifactId>
-    <version>3.0.6</version>
+    <version>3.0.7</version>
   </parent>
 
   <!-- Project Information -->

--- a/pom.xml
+++ b/pom.xml
@@ -41,60 +41,16 @@
     <module>remote</module>
     <module>testutils</module>
     <module>applications</module>
+    <module>p2wrappers</module>
   </modules>
 
   <properties>
     <vitruv-change.version>3.1.0</vitruv-change.version>
-    <!-- Additional Repositories -->
-    <repo.emf-compare.version>3.3</repo.emf-compare.version>
-    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
-    <repo.xannotations.version>1.6.0</repo.xannotations.version>
     <!-- SonarQube configuration -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>vitruv-tools</sonar.organization>
     <sonar.projectKey>vitruv-tools_Vitruv</sonar.projectKey>
   </properties>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.openntf.maven</groupId>
-        <artifactId>p2-layout-resolver</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
-  <repositories>
-    <!-- Maven Central should have priority -->
-    <repository>
-      <id>central</id>
-      <name>Maven Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
-    <!-- for p2 dependencies, `groupId` specifies the repository -->
-    <repository>
-      <id>emf-compare</id>
-      <name>EMF Compare</name>
-      <layout>p2</layout>
-      <url>https://download.eclipse.org/modeling/emf/compare/updates/releases/${repo.emf-compare.version}</url>
-    </repository>
-    <repository>
-      <id>sdq-commons</id>
-      <name>SDQ Commons</name>
-      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
-      <layout>p2</layout>
-    </repository>
-    <repository>
-      <id>xannotations</id>
-      <name>XAnnotations</name>
-      <layout>p2</layout>
-      <url>https://kit-sdq.github.io/updatesite/release/xannotations/${repo.xannotations.version}</url>
-    </repository>
-  </repositories>
 
   <!-- Dependency Management -->
   <dependencyManagement>
@@ -172,11 +128,6 @@
         <artifactId>micrometer-core</artifactId>
         <version>1.14.3</version>
       </dependency>
-      <dependency>
-        <groupId>emf-compare</groupId>
-        <artifactId>org.eclipse.emf.compare</artifactId>
-        <version>3.5.3.202212280858</version>
-      </dependency>
  <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-core</artifactId>
@@ -252,35 +203,6 @@
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-launcher</artifactId>
         <version>1.11.4</version>
-      </dependency>
-      <dependency>
-        <groupId>sdq-commons</groupId>
-        <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-        <version>2.3.0.202304271319</version>
-        <exclusions>
-          <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>sdq-commons</groupId>
-        <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
-        <version>2.3.0.202304271319</version>
-        <exclusions>
-          <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>xannotations</groupId>
-        <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-        <version>1.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -61,10 +61,6 @@
       <artifactId>org.eclipse.emf.ecore</artifactId>
     </dependency>
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -101,6 +97,13 @@
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <!-- p2 compile dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/testutils/deprecated/pom.xml
+++ b/testutils/deprecated/pom.xml
@@ -78,12 +78,15 @@
       <artifactId>org.eclipse.emf.ecore</artifactId>
     </dependency>
     <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
+    </dependency>
+
+    <!-- p2 dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/testutils/integration/pom.xml
+++ b/testutils/integration/pom.xml
@@ -94,12 +94,15 @@
       <artifactId>hamcrest</artifactId>
     </dependency>
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
+    </dependency>
+
+    <!-- p2 dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/views/pom.xml
+++ b/views/pom.xml
@@ -54,18 +54,6 @@
 
     <!-- external compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>emf-compare</groupId>
-      <artifactId>org.eclipse.emf.compare</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.emf</groupId>
       <artifactId>org.eclipse.emf.ecore</artifactId>
     </dependency>
@@ -113,11 +101,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -128,5 +111,29 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- p2 compile dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.emfcompare</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- p2 test dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/vsum/pom.xml
+++ b/vsum/pom.xml
@@ -75,7 +75,7 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- external dependencies -->
+    <!-- external compile dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -96,11 +96,6 @@
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-core</artifactId>
 </dependency>
-
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
@@ -110,11 +105,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -137,9 +127,25 @@
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- p2 test dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.framework.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
re-package p2 dependencies in wrapper JARs to make them available for users without having to support p2 repositories themselves

depends on the next release of https://github.com/vitruv-tools/Maven-Build-Parent