### PR TITLE
Use snapshot versions of Vitruvius dependencies

### DIFF
--- a/.github/prepare-release
+++ b/.github/prepare-release
@@ -9,13 +9,16 @@ then
     return 1
 fi
 
+vitruv_property_name="vitruv-change.version"
+
 git switch -C prepare-release/$1 || exit 1
 
 set_version_and_commit() {
     ./mvnw versions:set -DnewVersion=$1 -DgenerateBackupPoms=false || return 1
+    ./mvnw versions:set-property -Dproperty=$vitruv_property_name -DnewVersion=$1 -DgenerateBackupPoms=false || return 1
 
     git add pom.xml || return 1
-    git add "**/pom.xml" 2> /dev/null
+    git add "**/pom.xml" 2> /dev/null || return 1
 
     git commit -m "$2" || return 1
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   </modules>
 
   <properties>
-    <vitruv-change.version>3.1.2</vitruv-change.version>
+    <vitruv-change.version>3.2.0-SNAPSHOT</vitruv-change.version>
     <!-- SonarQube configuration -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>vitruv-tools</sonar.organization>
@@ -191,4 +191,18 @@
     </dependencies>
   </dependencyManagement>
 
+  <repositories>
+    <!-- allow snapshots -->
+    <repository>
+      <id>ossrh-snapshots</id>
+      <name>OSSRH Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+  </repositories>
 </project>

--- a/views/src/main/java/tools/vitruv/framework/views/impl/IdentityMappingViewType.java
+++ b/views/src/main/java/tools/vitruv/framework/views/impl/IdentityMappingViewType.java
@@ -21,6 +21,7 @@ import tools.vitruv.change.atomic.uuid.Uuid;
 import tools.vitruv.change.atomic.uuid.UuidResolver;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.description.VitruviusChangeResolver;
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory;
 import tools.vitruv.framework.views.ChangeableViewSource;
 import tools.vitruv.framework.views.View;
 import tools.vitruv.framework.views.ViewSelection;
@@ -68,9 +69,9 @@ public class IdentityMappingViewType extends AbstractViewType<DirectViewElementS
 	@Override
 	public void commitViewChanges(ModifiableView view, VitruviusChange<HierarchicalId> viewChange) {
 		ResourceSet viewSourceCopyResourceSet = withGlobalFactories(new ResourceSetImpl());
-		VitruviusChangeResolver<HierarchicalId> idChangeResolver = VitruviusChangeResolver.forHierarchicalIds(viewSourceCopyResourceSet);
+		VitruviusChangeResolver<HierarchicalId> idChangeResolver = VitruviusChangeResolverFactory.forHierarchicalIds(viewSourceCopyResourceSet);
 		UuidResolver viewSourceCopyUuidResolver = UuidResolver.create(viewSourceCopyResourceSet);
-		VitruviusChangeResolver<Uuid> uuidChangeResolver = VitruviusChangeResolver.forUuids(viewSourceCopyUuidResolver);
+		VitruviusChangeResolver<Uuid> uuidChangeResolver = VitruviusChangeResolverFactory.forUuids(viewSourceCopyUuidResolver);
 		Map<Resource, Resource> mapping = createViewResources(view, viewSourceCopyResourceSet);
 		view.getViewSource().getUuidResolver().resolveResources(mapping, viewSourceCopyUuidResolver);
 

--- a/views/src/main/xtend/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
+++ b/views/src/main/xtend/tools/vitruv/framework/views/changederivation/DefaultStateBasedChangeResolutionStrategy.xtend
@@ -12,7 +12,7 @@ import org.eclipse.emf.compare.utils.UseIdentifiers
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.util.EcoreUtil
-import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.composite.recording.ChangeRecorder
 
 import static com.google.common.base.Preconditions.checkArgument
@@ -94,7 +94,7 @@ class DefaultStateBasedChangeResolutionStrategy implements StateBasedChangeResol
             changeRecorder.addToRecording(resource)
             function.apply()
             val recordedChanges = changeRecorder.endRecording
-            val changeResolver = VitruviusChangeResolver.forHierarchicalIds(resource.resourceSet)
+            val changeResolver = VitruviusChangeResolverFactory.forHierarchicalIds(resource.resourceSet)
             return changeResolver.assignIds(recordedChanges)
         }
     }

--- a/views/src/main/xtend/tools/vitruv/framework/views/impl/ChangeRecordingView.xtend
+++ b/views/src/main/xtend/tools/vitruv/framework/views/impl/ChangeRecordingView.xtend
@@ -1,7 +1,7 @@
 package tools.vitruv.framework.views.impl
 
 import org.eclipse.xtend.lib.annotations.Delegate
-import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.composite.recording.ChangeRecorder
 import tools.vitruv.framework.views.CommittableView
 import tools.vitruv.framework.views.View
@@ -41,7 +41,7 @@ class ChangeRecordingView implements ModifiableView, CommittableView {
     override commitChanges() {
         view.checkNotClosed()
         val recordedChange = changeRecorder.endRecording()
-        val changeResolver = VitruviusChangeResolver.forHierarchicalIds(view.viewResourceSet)
+        val changeResolver = VitruviusChangeResolverFactory.forHierarchicalIds(view.viewResourceSet)
         val unresolvedChanges = changeResolver.assignIds(recordedChange)
         view.viewType.commitViewChanges(this, unresolvedChanges)
         view.viewChanged = false

--- a/views/src/test/java/tools/vitruv/framework/views/impl/ChangeDerivingViewTest.java
+++ b/views/src/test/java/tools/vitruv/framework/views/impl/ChangeDerivingViewTest.java
@@ -35,7 +35,7 @@ import tools.vitruv.change.atomic.root.InsertRootEObject;
 import tools.vitruv.change.atomic.root.RootFactory;
 import tools.vitruv.change.atomic.root.RootPackage;
 import tools.vitruv.change.composite.description.VitruviusChange;
-import tools.vitruv.change.composite.description.VitruviusChangeResolver;
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory;
 import tools.vitruv.framework.views.ChangeableViewSource;
 import tools.vitruv.framework.views.ModifiableViewSelection;
 import tools.vitruv.framework.views.changederivation.DefaultStateBasedChangeResolutionStrategy;
@@ -211,7 +211,7 @@ public class ChangeDerivingViewTest {
 				view.commitChanges();
 				verify(mockViewType).commitViewChanges(viewArgument.capture(), changeArgument.capture());
 				assertThat(viewArgument.getValue(), is(view));
-				VitruviusChange<EObject> change = VitruviusChangeResolver.forHierarchicalIds(root.eResource().getResourceSet()).resolveAndApply(changeArgument.getValue());
+				VitruviusChange<EObject> change = VitruviusChangeResolverFactory.forHierarchicalIds(root.eResource().getResourceSet()).resolveAndApply(changeArgument.getValue());
 				InsertRootEObject<EObject> expectedChange = RootFactory.eINSTANCE.createInsertRootEObject();
 				expectedChange.setNewValue(root);
 				expectedChange.setUri(testResourceUriString);

--- a/views/src/test/java/tools/vitruv/framework/views/impl/ChangeRecordingViewTest.java
+++ b/views/src/test/java/tools/vitruv/framework/views/impl/ChangeRecordingViewTest.java
@@ -45,7 +45,7 @@ import tools.vitruv.change.atomic.root.InsertRootEObject;
 import tools.vitruv.change.atomic.root.RootFactory;
 import tools.vitruv.change.atomic.root.RootPackage;
 import tools.vitruv.change.composite.description.VitruviusChange;
-import tools.vitruv.change.composite.description.VitruviusChangeResolver;
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory;
 import tools.vitruv.framework.views.ChangeableViewSource;
 import tools.vitruv.framework.views.ModifiableViewSelection;
 import tools.vitruv.change.testutils.RegisterMetamodelsInStandalone;
@@ -216,7 +216,7 @@ public class ChangeRecordingViewTest {
 
 				assertThat(viewArgument.getValue(), is(view));
 				ResourceSet resolveInResourceSet = new ResourceSetImpl();
-				VitruviusChange<EObject> resolvedChange = VitruviusChangeResolver
+				VitruviusChange<EObject> resolvedChange = VitruviusChangeResolverFactory
 						.forHierarchicalIds(resolveInResourceSet).resolveAndApply(changeArgument.getValue());
 				InsertRootEObject<EObject> expectedChange = RootFactory.eINSTANCE.createInsertRootEObject();
 				expectedChange.setNewValue(root);
@@ -300,7 +300,7 @@ public class ChangeRecordingViewTest {
 				view.commitChanges();
 				verify(mockViewType).commitViewChanges(viewArgument.capture(), changeArgument.capture());
 				assertThat(viewArgument.getValue(), is(view));
-				VitruviusChange<EObject> resolvedChange = VitruviusChangeResolver
+				VitruviusChange<EObject> resolvedChange = VitruviusChangeResolverFactory
 						.forHierarchicalIds(resolveInResourceSet).resolveAndApply(changeArgument.getValue());
 				List<EChange<EObject>> capturedEChanges = resolvedChange.getEChanges();
 				InsertRootEObject<EObject> expectedChange = RootFactory.eINSTANCE.createInsertRootEObject();
@@ -374,7 +374,7 @@ public class ChangeRecordingViewTest {
 			view.commitChanges();
 			verify(mockViewType).commitViewChanges(viewArgument.capture(), changeArgument.capture());
 
-			VitruviusChange<EObject> resolvedChange = VitruviusChangeResolver.forHierarchicalIds(resolveInResourceSet)
+			VitruviusChange<EObject> resolvedChange = VitruviusChangeResolverFactory.forHierarchicalIds(resolveInResourceSet)
 					.resolveAndApply(changeArgument.getValue());
 			List<EChange<EObject>> capturedEChanges = resolvedChange.getEChanges();
 			assertThat(capturedEChanges.size(), is(4)); // Create, Insert, ReplaceValue, Delete

--- a/views/src/test/java/tools/vitruv/framework/views/impl/IdentityMappingViewTypeTest.java
+++ b/views/src/test/java/tools/vitruv/framework/views/impl/IdentityMappingViewTypeTest.java
@@ -48,6 +48,7 @@ import tools.vitruv.change.atomic.uuid.UuidResolver;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.description.VitruviusChangeFactory;
 import tools.vitruv.change.composite.description.VitruviusChangeResolver;
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory;
 import tools.vitruv.change.composite.recording.ChangeRecorder;
 import tools.vitruv.framework.views.ChangeableViewSource;
 import tools.vitruv.framework.views.View;
@@ -456,7 +457,7 @@ public class IdentityMappingViewTypeTest {
 		}
 
 		private VitruviusChange<HierarchicalId> assignIds(VitruviusChange<EObject> change) {
-			VitruviusChangeResolver<HierarchicalId> idChangeResolver = VitruviusChangeResolver
+			VitruviusChangeResolver<HierarchicalId> idChangeResolver = VitruviusChangeResolverFactory
 					.forHierarchicalIds(viewResourceSet);
 			return idChangeResolver.assignIds(change);
 		}

--- a/views/src/test/xtend/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
+++ b/views/src/test/xtend/tools/vitruv/framework/views/changederivation/BasicStateChangePropagationTest.xtend
@@ -11,7 +11,7 @@ import tools.vitruv.change.atomic.eobject.DeleteEObject
 import tools.vitruv.change.atomic.feature.attribute.ReplaceSingleValuedEAttribute
 import tools.vitruv.change.atomic.root.InsertRootEObject
 import tools.vitruv.change.atomic.root.RemoveRootEObject
-import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.testutils.Capture
 
 import static org.hamcrest.CoreMatchers.instanceOf
@@ -47,7 +47,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
 
         // Create empty resource to apply generated changes to
         val validationResourceSet = new ResourceSetImpl()
-        VitruviusChangeResolver.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
+        VitruviusChangeResolverFactory.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
 
         modelResource.save(null)
         assertEquals(1, validationResourceSet.resources.size)
@@ -75,7 +75,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         // Load resource to apply generated changes to
         val validationResourceSet = new ResourceSetImpl()
         validationResourceSet.getResource(testUri, true)
-        VitruviusChangeResolver.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
+        VitruviusChangeResolverFactory.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
 
         assertEquals(1, validationResourceSet.resources.size)
         assertTrue(validationResourceSet.resources.get(0).contents.empty)
@@ -106,7 +106,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         val oldState = validationResourceSet.getResource(testUri, true)
         val changes = strategyToTest.getChangeSequenceBetween(-modelResource, oldState)
 
-        VitruviusChangeResolver.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
+        VitruviusChangeResolverFactory.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
 
         assertEquals(1, validationResourceSet.resources.size)
         assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
@@ -137,7 +137,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         assertEquals(1, changes.EChanges.size)
         assertEquals(1, changes.EChanges.filter(ReplaceSingleValuedEAttribute).size)
 
-        VitruviusChangeResolver.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
+        VitruviusChangeResolverFactory.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
 
         assertEquals(1, validationResourceSet.resources.size)
         assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
@@ -165,7 +165,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         val validationResourceSet = new ResourceSetImpl().withGlobalFactories()
         val oldState = validationResourceSet.getResource(testUri, true)
         val unresolvedChanges = strategyToTest.getChangeSequenceBetween(-modelResource, oldState)
-        val changes = VitruviusChangeResolver.forHierarchicalIds(validationResourceSet).resolveAndApply(unresolvedChanges)
+        val changes = VitruviusChangeResolverFactory.forHierarchicalIds(validationResourceSet).resolveAndApply(unresolvedChanges)
         switch (strategyToTest.useIdentifiers) {
             case ONLY,
             case WHEN_AVAILABLE: {
@@ -219,7 +219,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         assertEquals(1, changes.EChanges.size)
         assertEquals(1, changes.EChanges.filter(ReplaceSingleValuedEAttribute).size)
 
-        VitruviusChangeResolver.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
+        VitruviusChangeResolverFactory.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
 
         assertEquals(1, validationResourceSet.resources.size)
         assertThat(validationResourceSet.resources.get(0), containsModelOf(-modelResource))
@@ -252,7 +252,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         val validationResourceSet = new ResourceSetImpl().withGlobalFactories()
         val oldState = validationResourceSet.getResource(testUri, true)
         val unresolvedChanges = strategyToTest.getChangeSequenceBetween(-modelResource, oldState)
-        val changes = VitruviusChangeResolver.forHierarchicalIds(validationResourceSet).resolveAndApply(unresolvedChanges)
+        val changes = VitruviusChangeResolverFactory.forHierarchicalIds(validationResourceSet).resolveAndApply(unresolvedChanges)
         switch (strategyToTest.useIdentifiers) {
             case ONLY,
             case WHEN_AVAILABLE: {
@@ -306,7 +306,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         assertEquals(1, changes.EChanges.filter(RemoveRootEObject).size)
         assertEquals(1, changes.EChanges.filter(InsertRootEObject).size)
 
-        VitruviusChangeResolver.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
+        VitruviusChangeResolverFactory.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
 
         (-modelResource).save(null)
         assertEquals(2, validationResourceSet.resources.size)
@@ -346,7 +346,7 @@ class BasicStateChangePropagationTest extends StateChangePropagationTest {
         assertEquals(1, changes.EChanges.filter(InsertRootEObject).size)
         assertEquals(1, changes.EChanges.filter(ReplaceSingleValuedEAttribute).size)
 
-        VitruviusChangeResolver.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
+        VitruviusChangeResolverFactory.forHierarchicalIds(validationResourceSet).resolveAndApply(changes)
 
         (-modelResource).save(null)
         assertEquals(2, validationResourceSet.resources.size)

--- a/views/src/test/xtend/tools/vitruv/framework/views/changederivation/StateChangePropagationTest.xtend
+++ b/views/src/test/xtend/tools/vitruv/framework/views/changederivation/StateChangePropagationTest.xtend
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Named
 import org.junit.jupiter.api.^extension.ExtendWith
 import pcm_mockup.Repository
 import tools.vitruv.change.composite.description.VitruviusChange
-import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.composite.recording.ChangeRecorder
 import tools.vitruv.change.testutils.RegisterMetamodelsInStandalone
 import tools.vitruv.change.testutils.TestLogging
@@ -101,7 +101,7 @@ abstract class StateChangePropagationTest {
 		val deltaBasedChange = resourceSet.endRecording
 		val unresolvedStateBasedChange = strategyToTest.getChangeSequenceBetween(model, checkpoint)
 		assertNotNull(unresolvedStateBasedChange)
-		val stateBasedChange = VitruviusChangeResolver.forHierarchicalIds(checkpoint.resourceSet).resolveAndApply(unresolvedStateBasedChange)
+		val stateBasedChange = VitruviusChangeResolverFactory.forHierarchicalIds(checkpoint.resourceSet).resolveAndApply(unresolvedStateBasedChange)
 		val message = getTextualRepresentation(stateBasedChange, deltaBasedChange)
 		val stateBasedChangedObjects = stateBasedChange.affectedAndReferencedEObjects
 		val deltaBasedChangedObjects = deltaBasedChange.affectedAndReferencedEObjects

--- a/vsum/src/main/java/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
+++ b/vsum/src/main/java/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
@@ -28,6 +28,7 @@ import tools.vitruv.change.atomic.uuid.UuidResolver;
 import tools.vitruv.change.composite.description.TransactionalChange;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.description.VitruviusChangeResolver;
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory;
 import tools.vitruv.change.composite.recording.ChangeRecorder;
 import tools.vitruv.change.correspondence.Correspondence;
 import tools.vitruv.change.correspondence.model.PersistableCorrespondenceModel;
@@ -44,7 +45,7 @@ class ResourceRepositoryImpl implements ModelRepository {
 	private final PersistableCorrespondenceModel correspondenceModel;
 	private UuidResolver uuidResolver = UuidResolver.create(modelsResourceSet);
 	private final ChangeRecorder changeRecorder = new ChangeRecorder(modelsResourceSet);
-	private final VitruviusChangeResolver<Uuid> changeResolver = VitruviusChangeResolver.forUuids(uuidResolver);
+	private final VitruviusChangeResolver<Uuid> changeResolver = VitruviusChangeResolverFactory.forUuids(uuidResolver);
 
 	private final VsumFileSystemLayout fileSystemLayout;
 

--- a/vsum/src/test/xtend/tools/vitruv/framework/vsum/VirtualModelTest.xtend
+++ b/vsum/src/test/xtend/tools/vitruv/framework/vsum/VirtualModelTest.xtend
@@ -14,7 +14,7 @@ import tools.vitruv.change.atomic.feature.attribute.ReplaceSingleValuedEAttribut
 import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReference
 import tools.vitruv.change.atomic.root.InsertRootEObject
 import tools.vitruv.change.atomic.uuid.UuidResolver
-import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.composite.recording.ChangeRecorder
 import tools.vitruv.framework.views.View
 import tools.vitruv.framework.views.ViewTypeFactory
@@ -372,7 +372,7 @@ class VirtualModelTest {
 	
 	private def endRecording(ChangeRecorder changeRecorder, UuidResolver uuidResolver) {
 		val change = changeRecorder.endRecording
-		val changeResolver = VitruviusChangeResolver.forUuids(uuidResolver)
+		val changeResolver = VitruviusChangeResolverFactory.forUuids(uuidResolver)
 		return changeResolver.assignIds(change)
 	}
 

--- a/vsum/src/test/xtend/tools/vitruv/framework/vsum/VirtualModelTestUtil.xtend
+++ b/vsum/src/test/xtend/tools/vitruv/framework/vsum/VirtualModelTestUtil.xtend
@@ -13,7 +13,7 @@ import tools.vitruv.change.atomic.uuid.Uuid
 import tools.vitruv.change.atomic.uuid.UuidResolver
 import tools.vitruv.change.composite.MetamodelDescriptor
 import tools.vitruv.change.composite.description.VitruviusChange
-import tools.vitruv.change.composite.description.VitruviusChangeResolver
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.composite.recording.ChangeRecorder
 import tools.vitruv.change.correspondence.Correspondence
 import tools.vitruv.change.correspondence.view.EditableCorrespondenceModelView
@@ -35,7 +35,7 @@ class VirtualModelTestUtil {
      */
     def static VitruviusChange<Uuid> recordChanges(ResourceSet resourceSet, UuidResolver uuidResolver, Runnable changesToPerform) {
         val recorder = new ChangeRecorder(resourceSet)
-        val changeResolver = VitruviusChangeResolver.forUuids(uuidResolver)
+        val changeResolver = VitruviusChangeResolverFactory.forUuids(uuidResolver)
         recorder.addToRecording(resourceSet)
         recorder.beginRecording
         changesToPerform.run()


### PR DESCRIPTION
Allows us to verify in nightly builds that change in one module don't break internal dependencies. Release version is automatically set in the `prepare-release` script.