### PR TITLE
Issue730

### DIFF
--- a/views/src/main/java/tools/vitruv/framework/views/impl/IdentityMappingViewType.java
+++ b/views/src/main/java/tools/vitruv/framework/views/impl/IdentityMappingViewType.java
@@ -17,6 +17,7 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import tools.vitruv.change.atomic.hid.HierarchicalId;
 import tools.vitruv.change.atomic.uuid.Uuid;
 import tools.vitruv.change.atomic.uuid.UuidResolver;
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.description.VitruviusChangeResolver;
 import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory;
@@ -86,7 +87,7 @@ public class IdentityMappingViewType
     ResourceSet viewSourceCopyResourceSet = withGlobalFactories(new ResourceSetImpl());
     VitruviusChangeResolver<HierarchicalId> idChangeResolver =
         VitruviusChangeResolverFactory.forHierarchicalIds(viewSourceCopyResourceSet);
-    UuidResolver viewSourceCopyUuidResolver = UuidResolver.create(viewSourceCopyResourceSet);
+    UuidResolver viewSourceCopyUuidResolver = UuidResolverFactory.create(viewSourceCopyResourceSet);
     VitruviusChangeResolver<Uuid> uuidChangeResolver =
         VitruviusChangeResolverFactory.forUuids(viewSourceCopyUuidResolver);
     Map<Resource, Resource> mapping = createViewResources(view, viewSourceCopyResourceSet);

--- a/views/src/test/java/tools/vitruv/framework/views/impl/IdentityMappingViewTypeTest.java
+++ b/views/src/test/java/tools/vitruv/framework/views/impl/IdentityMappingViewTypeTest.java
@@ -42,6 +42,7 @@ import tools.vitruv.change.atomic.feature.attribute.ReplaceSingleValuedEAttribut
 import tools.vitruv.change.atomic.hid.HierarchicalId;
 import tools.vitruv.change.atomic.uuid.Uuid;
 import tools.vitruv.change.atomic.uuid.UuidResolver;
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.description.VitruviusChangeFactory;
 import tools.vitruv.change.composite.description.VitruviusChangeResolver;
@@ -395,7 +396,7 @@ public class IdentityMappingViewTypeTest {
       this.view = mock(ModifiableView.class);
       this.viewSource = mock(ChangeableViewSource.class);
       this.viewSelection = mock(ViewSelection.class);
-      this.uuidResolver = UuidResolver.create(viewSourceResourceSet);
+      this.uuidResolver = UuidResolverFactory.create(viewSourceResourceSet);
       when(view.getViewSource()).thenReturn(viewSource);
       when(view.getSelection()).thenReturn(viewSelection);
       when(viewSource.getViewSourceModels()).thenReturn(viewSourceResourceSet.getResources());

--- a/vsum/src/main/java/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
+++ b/vsum/src/main/java/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import tools.vitruv.change.atomic.uuid.Uuid;
 import tools.vitruv.change.atomic.uuid.UuidResolver;
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory;
 import tools.vitruv.change.composite.description.TransactionalChange;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.description.VitruviusChangeResolver;
@@ -41,7 +42,7 @@ class ResourceRepositoryImpl implements ModelRepository {
   private final ResourceSet modelsResourceSet = withGlobalFactories(new ResourceSetImpl());
   private final Map<URI, ModelInstance> modelInstances = new HashMap<>();
   private final PersistableCorrespondenceModel correspondenceModel;
-  private UuidResolver uuidResolver = UuidResolver.create(modelsResourceSet);
+  private UuidResolver uuidResolver = UuidResolverFactory.create(modelsResourceSet);
   private final ChangeRecorder changeRecorder = new ChangeRecorder(modelsResourceSet);
   private final VitruviusChangeResolver<Uuid> changeResolver =
       VitruviusChangeResolverFactory.forUuids(uuidResolver);

--- a/vsum/src/test/xtend/tools/vitruv/framework/vsum/VirtualModelTest.xtend
+++ b/vsum/src/test/xtend/tools/vitruv/framework/vsum/VirtualModelTest.xtend
@@ -14,6 +14,7 @@ import tools.vitruv.change.atomic.feature.attribute.ReplaceSingleValuedEAttribut
 import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReference
 import tools.vitruv.change.atomic.root.InsertRootEObject
 import tools.vitruv.change.atomic.uuid.UuidResolver
+import tools.vitruv.change.atomic.uuid.UuidResolverFactory
 import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory
 import tools.vitruv.change.composite.recording.ChangeRecorder
 import tools.vitruv.framework.views.View
@@ -53,7 +54,7 @@ class VirtualModelTest {
 	def void propagateIntoVirtualModel() {
 		val virtualModel = createAndLoadTestVirtualModel(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		val changeRecorder = new ChangeRecorder(resourceSet)
 		changeRecorder.addToRecording(resourceSet)
 		changeRecorder.beginRecording
@@ -73,7 +74,7 @@ class VirtualModelTest {
 	def void propagateIntoVirtualModelWithConsistency() {
 		val virtualModel = createAndLoadTestVirtualModelWithConsistencyPreservation(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		val changeRecorder = new ChangeRecorder(resourceSet)
 		changeRecorder.addToRecording(resourceSet)
 		changeRecorder.beginRecording
@@ -97,7 +98,7 @@ class VirtualModelTest {
 	def void singleChangeForRootElementInMultipleResource() {
 		val virtualModel = createAndLoadTestVirtualModelWithConsistencyPreservation(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		val changeRecorder = new ChangeRecorder(resourceSet)
 		changeRecorder.addToRecording(resourceSet)
 		changeRecorder.beginRecording
@@ -128,7 +129,7 @@ class VirtualModelTest {
 	def void singleChangeForElementContainedInRootElementInMultipleResource() {
 		val virtualModel = createAndLoadTestVirtualModelWithConsistencyPreservation(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		val changeRecorder = new ChangeRecorder(resourceSet)
 		changeRecorder.addToRecording(resourceSet)
 		changeRecorder.beginRecording
@@ -166,7 +167,7 @@ class VirtualModelTest {
 	def void savedVirtualModel() {
 		val virtualModel = createAndLoadTestVirtualModel(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		val changeRecorder = new ChangeRecorder(resourceSet)
 		changeRecorder.addToRecording(resourceSet)
 		changeRecorder.beginRecording
@@ -187,7 +188,7 @@ class VirtualModelTest {
 	def void reloadVirtualModel() {
 		val virtualModel = createAndLoadTestVirtualModel(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		val changeRecorder = new ChangeRecorder(resourceSet)
 		changeRecorder.addToRecording(resourceSet)
 		changeRecorder.beginRecording
@@ -217,7 +218,7 @@ class VirtualModelTest {
 	def void reloadVirtualModelWithConsistency() {
 		val virtualModel = createAndLoadTestVirtualModelWithConsistencyPreservation(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		val changeRecorder = new ChangeRecorder(resourceSet)
 		changeRecorder.addToRecording(resourceSet)
 		changeRecorder.beginRecording
@@ -247,7 +248,7 @@ class VirtualModelTest {
 	def void moveCorrespondingToOtherResourceAndBack() {
 		val virtualModel = createAndLoadTestVirtualModelWithConsistencyPreservation(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		val changeRecorder = new ChangeRecorder(resourceSet)
 		changeRecorder.addToRecording(resourceSet)
 		changeRecorder.beginRecording
@@ -285,7 +286,7 @@ class VirtualModelTest {
 	def void createView() {
 		val virtualModel = createAndLoadTestVirtualModel(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		virtualModel.createAndPropagateRoot(resourceSet, uuidResolver, ROOT_ID)
 		val testView = virtualModel.createTestView
 		// Check initial state:
@@ -301,7 +302,7 @@ class VirtualModelTest {
 	def void updateView() {
 		val virtualModel = createAndLoadTestVirtualModel(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		virtualModel.createAndPropagateRoot(resourceSet, uuidResolver, ROOT_ID)
 		val testView = virtualModel.createTestView
 
@@ -333,7 +334,7 @@ class VirtualModelTest {
 	def void commitView() {
 		val virtualModel = createAndLoadTestVirtualModel(pathToVirtualModelProjectFolder)
 		val resourceSet = new ResourceSetImpl().withGlobalFactories
-		val uuidResolver = UuidResolver.create(resourceSet)
+		val uuidResolver = UuidResolverFactory.create(resourceSet)
 		virtualModel.createAndPropagateRoot(resourceSet, uuidResolver, ROOT_ID)
 		val testView = virtualModel.createTestView.withChangeRecordingTrait
 


### PR DESCRIPTION
The new class "UuidResolverFactory" contains the "create"-method for the class "UuidResolverImpl", which was originally located in the interface "UuidResolver".
This breaks the cyclic dependency between "UuidResolver" and "UuidResolverImpl".
In this repository only the calls to the create-method of UuidResolver were changed to UuidResolverFactory.