### PR TITLE
Implement changes of PR in vitruv-change

### DIFF
--- a/vsum/src/main/java/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
+++ b/vsum/src/main/java/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
@@ -28,9 +28,9 @@ import tools.vitruv.change.correspondence.Correspondence;
 import tools.vitruv.change.correspondence.model.PersistableCorrespondenceModel;
 import tools.vitruv.change.correspondence.view.CorrespondenceModelViewFactory;
 import tools.vitruv.change.correspondence.view.EditableCorrespondenceModelView;
-import tools.vitruv.change.propagation.ModelRepositorySnapshot;
+import tools.vitruv.change.propagation.ModelSnapshot;
 import tools.vitruv.change.propagation.TransactionalChangeWithPreviousState;
-import tools.vitruv.change.propagation.impl.DefaultModelRepositorySnapshot;
+import tools.vitruv.change.propagation.impl.DefaultModelSnapshot;
 import tools.vitruv.change.propagation.impl.ResourceRegistrationAdapter;
 import tools.vitruv.framework.vsum.helper.VsumFileSystemLayout;
 import tools.vitruv.framework.vsum.internal.messages.InfoMessages;
@@ -204,8 +204,8 @@ class ResourceRepositoryImpl implements ModelRepository {
   }
 
   @Override
-  public ModelRepositorySnapshot createSnapshot() {
-    return DefaultModelRepositorySnapshot.copyOf(modelsResourceSet, this::getMetadataModelURI);
+  public ModelSnapshot createSnapshot() {
+    return DefaultModelSnapshot.copyOf(modelsResourceSet, this::getMetadataModelURI);
   }
 
   @Override
@@ -213,7 +213,7 @@ class ResourceRepositoryImpl implements ModelRepository {
     List<TransactionalChangeWithPreviousState> result = new ArrayList<>();
 
     for (TransactionalChange<Uuid> transactionalChange : change.getTransactionalChangeSequence()) {
-      ModelRepositorySnapshot previousState = createSnapshot();
+      ModelSnapshot previousState = createSnapshot();
 
       try {
         var resolvedTransactionalChange = (TransactionalChange<EObject>) changeResolver.resolveAndApply(transactionalChange);

--- a/vsum/src/main/java/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
+++ b/vsum/src/main/java/tools/vitruv/framework/vsum/internal/ResourceRepositoryImpl.java
@@ -8,11 +8,7 @@ import static tools.vitruv.change.correspondence.model.CorrespondenceModelFactor
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,6 +28,9 @@ import tools.vitruv.change.correspondence.Correspondence;
 import tools.vitruv.change.correspondence.model.PersistableCorrespondenceModel;
 import tools.vitruv.change.correspondence.view.CorrespondenceModelViewFactory;
 import tools.vitruv.change.correspondence.view.EditableCorrespondenceModelView;
+import tools.vitruv.change.propagation.ModelRepositorySnapshot;
+import tools.vitruv.change.propagation.TransactionalChangeWithPreviousState;
+import tools.vitruv.change.propagation.impl.DefaultModelRepositorySnapshot;
 import tools.vitruv.change.propagation.impl.ResourceRegistrationAdapter;
 import tools.vitruv.framework.vsum.helper.VsumFileSystemLayout;
 import tools.vitruv.framework.vsum.internal.messages.InfoMessages;
@@ -202,6 +201,41 @@ class ResourceRepositoryImpl implements ModelRepository {
   @Override
   public VitruviusChange<EObject> applyChange(VitruviusChange<Uuid> change) {
     return changeResolver.resolveAndApply(change);
+  }
+
+  @Override
+  public ModelRepositorySnapshot createSnapshot() {
+    return DefaultModelRepositorySnapshot.copyOf(modelsResourceSet, this::getMetadataModelURI);
+  }
+
+  @Override
+  public List<TransactionalChangeWithPreviousState> applyChangeAndStorePreviousState(VitruviusChange<Uuid> change) {
+    List<TransactionalChangeWithPreviousState> result = new ArrayList<>();
+
+    for (TransactionalChange<Uuid> transactionalChange : change.getTransactionalChangeSequence()) {
+      ModelRepositorySnapshot previousState = createSnapshot();
+
+      try {
+        var resolvedTransactionalChange = (TransactionalChange<EObject>) changeResolver.resolveAndApply(transactionalChange);
+        result.add(new TransactionalChangeWithPreviousState(resolvedTransactionalChange, previousState));
+      } catch (Exception e) {
+        try {
+          previousState.close();
+          result.forEach(entry -> {
+            try {
+              entry.previousState().close();
+            } catch (Exception ex) {
+              throw new RuntimeException(ex);
+            }
+          });
+        } catch (Exception ex) {
+          throw new RuntimeException(ex);
+        }
+        throw e;
+      }
+    }
+
+    return result;
   }
 
   @Override


### PR DESCRIPTION
This implements the methods added to interfaces in PR https://github.com/vitruv-tools/Vitruv-Change/pull/560 . Additionally, the VirtualModelBuilder has received a few new methods that allow setting the level of change propagation specifications (see PR in vitruv change) and creating view types that require the ViewTypeProvider.